### PR TITLE
Feature/user configurable editor

### DIFF
--- a/cmd/sgai/config.go
+++ b/cmd/sgai/config.go
@@ -17,6 +17,7 @@ type projectConfig struct {
 	DisableRetrospective bool                       `json:"disable_retrospective,omitempty"`
 	EnableAdhocPrompt    bool                       `json:"enable-adhoc-prompt,omitempty"`
 	MCP                  map[string]json.RawMessage `json:"mcp,omitempty"`
+	Editor               string                     `json:"editor,omitempty"`
 }
 
 func loadProjectConfig(dir string) (*projectConfig, error) {

--- a/cmd/sgai/serve_test.go
+++ b/cmd/sgai/serve_test.go
@@ -344,7 +344,7 @@ func TestHandleWorkspaceOpenVSCodeForbiddenForRemote(t *testing.T) {
 	createsgaiDir(t, validProject)
 
 	srv := NewServer(rootDir)
-	srv.codeAvailable = true
+	srv.editorAvailable = true
 
 	req := httptest.NewRequest(http.MethodPost, "/workspaces/test-project/open-vscode", nil)
 	req.RemoteAddr = "192.168.1.100:54321"
@@ -366,7 +366,7 @@ func TestHandleWorkspaceOpenVSCodeUnavailable(t *testing.T) {
 	createsgaiDir(t, validProject)
 
 	srv := NewServer(rootDir)
-	srv.codeAvailable = false
+	srv.editorAvailable = false
 
 	req := httptest.NewRequest(http.MethodPost, "/workspaces/test-project/open-vscode", nil)
 	req.RemoteAddr = "127.0.0.1:54321"
@@ -388,7 +388,7 @@ func TestHandleWorkspaceOpenVSCodeInvalidFile(t *testing.T) {
 	createsgaiDir(t, validProject)
 
 	srv := NewServer(rootDir)
-	srv.codeAvailable = true
+	srv.editorAvailable = true
 
 	req := httptest.NewRequest(http.MethodPost, "/workspaces/test-project/open-vscode?file=../../../etc/passwd", nil)
 	req.RemoteAddr = "127.0.0.1:54321"
@@ -411,7 +411,7 @@ func TestHandleWorkspaceOpenVSCodeAllowedFiles(t *testing.T) {
 
 	mock := &mockEditorOpener{}
 	srv := NewServer(rootDir)
-	srv.codeAvailable = true
+	srv.editorAvailable = true
 	srv.editor = mock
 
 	allowedFiles := []string{"GOAL.md", "PROJECT_MANAGEMENT.md"}
@@ -464,7 +464,7 @@ func TestHandleWorkspaceOpenVSCodeEditorError(t *testing.T) {
 
 	mock := &mockEditorOpener{err: os.ErrPermission}
 	srv := NewServer(rootDir)
-	srv.codeAvailable = true
+	srv.editorAvailable = true
 	srv.editor = mock
 
 	req := httptest.NewRequest(http.MethodPost, "/workspaces/test-project/open-vscode", nil)

--- a/cmd/sgai/templates/trees.html
+++ b/cmd/sgai/templates/trees.html
@@ -970,6 +970,67 @@
 			z-index: 1000;
 		}
 
+		/* Terminal editor path display */
+		.terminal-editor-path {
+			display: inline-flex;
+			flex-direction: column;
+			gap: 0.25rem;
+			margin: 0;
+			padding: 0.25rem 0.5rem;
+			flex-shrink: 0;
+		}
+		.terminal-editor-path small {
+			font-size: 0.65rem;
+			color: var(--pico-muted-color);
+			margin: 0;
+		}
+		.terminal-editor-path .path-input {
+			cursor: text;
+			user-select: all;
+			font-family: monospace;
+			font-size: 0.75rem;
+			padding: 0.25rem 0.5rem;
+			margin: 0;
+			width: 100%;
+			min-width: 300px;
+			background: var(--pico-form-element-background-color);
+			border: 1px solid var(--pico-form-element-border-color);
+			border-radius: 0.25rem;
+		}
+		.terminal-editor-path .path-input:focus {
+			outline: 2px solid var(--pico-primary);
+			outline-offset: 0;
+		}
+
+		/* Terminal editor workspace path in header actions */
+		.terminal-editor-workspace-path {
+			display: inline-flex;
+			flex-direction: column;
+			gap: 0.25rem;
+			padding: 0.25rem 0.5rem;
+		}
+		.terminal-editor-workspace-path small {
+			font-size: 0.65rem;
+			color: var(--pico-muted-color);
+			margin: 0;
+		}
+		.terminal-editor-workspace-path .path-input {
+			cursor: text;
+			user-select: all;
+			font-family: monospace;
+			font-size: 0.75rem;
+			padding: 0.25rem 0.5rem;
+			margin: 0;
+			min-width: 300px;
+			background: var(--pico-form-element-background-color);
+			border: 1px solid var(--pico-form-element-border-color);
+			border-radius: 0.25rem;
+		}
+		.terminal-editor-workspace-path .path-input:focus {
+			outline: 2px solid var(--pico-primary);
+			outline-offset: 0;
+		}
+
 		/* Workflow container styles - mirrors session.html */
 		.tab-content #workflow-container ul {
 			list-style: none !important;

--- a/cmd/sgai/templates/trees_actions.html
+++ b/cmd/sgai/templates/trees_actions.html
@@ -20,11 +20,18 @@
 	<a href="/workspaces/{{.DirName}}/goal" role="button" class="action-btn outline">Edit GOAL</a>
 	{{end}}
 	{{if .CodeAvailable}}
-	<form action="/workspaces/{{.DirName}}/open-vscode" method="post" style="display:inline">
-		<button type="submit" class="action-btn outline">Open in VSCode</button>
-	</form>
+		{{if .IsTerminalEditor}}
+		<div class="terminal-editor-workspace-path">
+			<small>Workspace Path:</small>
+			<input type="text" readonly value="{{.Directory}}" class="path-input">
+		</div>
+		{{else}}
+		<form action="/workspaces/{{.DirName}}/open-vscode" method="post" style="display:inline">
+			<button type="submit" class="action-btn outline">Open in Editor</button>
+		</form>
+		{{end}}
 	{{else}}
-	<button type="button" class="action-btn outline" disabled data-tooltip="VSCode CLI not available or remote connection">Open in VSCode</button>
+	<button type="button" class="action-btn outline" disabled data-tooltip="Editor not available or remote connection">Open in Editor</button>
 	{{end}}
 	{{end}}
 	<a href="/workspaces/{{.DirName}}/skills" role="button" class="action-btn outline">Skills</a>

--- a/cmd/sgai/templates/trees_events_content.html
+++ b/cmd/sgai/templates/trees_events_content.html
@@ -3,11 +3,18 @@
 	<summary>
 		<strong>GOAL.md</strong>
 		{{if .CodeAvailable}}
-		<form action="/workspaces/{{.DirName}}/open-vscode?file=GOAL.md" method="post" class="spec-vscode-form">
-			<button type="submit" class="vscode-file-btn" title="Open in VSCode">&#128221;</button>
-		</form>
+			{{if .IsTerminalEditor}}
+			<div class="terminal-editor-path">
+				<small>Path (select to copy):</small>
+				<input type="text" readonly value="{{.Directory}}/GOAL.md" class="path-input">
+			</div>
+			{{else}}
+			<form action="/workspaces/{{.DirName}}/open-vscode?file=GOAL.md" method="post" class="spec-vscode-form">
+				<button type="submit" class="vscode-file-btn" title="Open in Editor">&#128221;</button>
+			</form>
+			{{end}}
 		{{else}}
-		<span class="vscode-file-btn disabled" title="VSCode CLI not available">&#128221;</span>
+		<span class="vscode-file-btn disabled" title="Editor not available">&#128221;</span>
 		{{end}}
 	</summary>
 	<div class="spec-content">{{.GoalContent}}</div>

--- a/cmd/sgai/templates/trees_session_content.html
+++ b/cmd/sgai/templates/trees_session_content.html
@@ -46,11 +46,18 @@
 	<summary>
 		<strong>PROJECT_MANAGEMENT.md</strong>
 		{{if .CodeAvailable}}
-		<form action="/workspaces/{{.DirName}}/open-vscode?file=PROJECT_MANAGEMENT.md" method="post" class="spec-vscode-form">
-			<button type="submit" class="vscode-file-btn" title="Open in VSCode">&#128221;</button>
-		</form>
+			{{if .IsTerminalEditor}}
+			<div class="terminal-editor-path">
+				<small>Path (select to copy):</small>
+				<input type="text" readonly value="{{.Directory}}/.sgai/PROJECT_MANAGEMENT.md" class="path-input">
+			</div>
+			{{else}}
+			<form action="/workspaces/{{.DirName}}/open-vscode?file=PROJECT_MANAGEMENT.md" method="post" class="spec-vscode-form">
+				<button type="submit" class="vscode-file-btn" title="Open in Editor">&#128221;</button>
+			</form>
+			{{end}}
 		{{else}}
-		<span class="vscode-file-btn disabled" title="VSCode CLI not available">&#128221;</span>
+		<span class="vscode-file-btn disabled" title="Editor not available">&#128221;</span>
 		{{end}}
 	</summary>
 	<div class="spec-content">{{.ProjectMgmtContent}}</div>

--- a/cmd/sgai/templates/trees_specification_content.html
+++ b/cmd/sgai/templates/trees_specification_content.html
@@ -4,11 +4,18 @@
 	<summary>
 		<strong>GOAL.md</strong>
 		{{if .CodeAvailable}}
-		<form action="/workspaces/{{.DirName}}/open-vscode?file=GOAL.md" method="post" class="spec-vscode-form">
-			<button type="submit" class="vscode-file-btn" title="Open in VSCode">&#128221;</button>
-		</form>
+			{{if .IsTerminalEditor}}
+			<div class="terminal-editor-path">
+				<small>Path (select to copy):</small>
+				<input type="text" readonly value="{{.Directory}}/GOAL.md" class="path-input">
+			</div>
+			{{else}}
+			<form action="/workspaces/{{.DirName}}/open-vscode?file=GOAL.md" method="post" class="spec-vscode-form">
+				<button type="submit" class="vscode-file-btn" title="Open in Editor">&#128221;</button>
+			</form>
+			{{end}}
 		{{else}}
-		<span class="vscode-file-btn disabled" title="VSCode CLI not available">&#128221;</span>
+		<span class="vscode-file-btn disabled" title="Editor not available">&#128221;</span>
 		{{end}}
 	</summary>
 	<div class="spec-content">{{.GoalContent}}</div>
@@ -24,11 +31,18 @@
 	<summary>
 		<strong>PROJECT_MANAGEMENT.md</strong>
 		{{if .CodeAvailable}}
-		<form action="/workspaces/{{.DirName}}/open-vscode?file=PROJECT_MANAGEMENT.md" method="post" class="spec-vscode-form">
-			<button type="submit" class="vscode-file-btn" title="Open in VSCode">&#128221;</button>
-		</form>
+			{{if .IsTerminalEditor}}
+			<div class="terminal-editor-path">
+				<small>Path (select to copy):</small>
+				<input type="text" readonly value="{{.Directory}}/.sgai/PROJECT_MANAGEMENT.md" class="path-input">
+			</div>
+			{{else}}
+			<form action="/workspaces/{{.DirName}}/open-vscode?file=PROJECT_MANAGEMENT.md" method="post" class="spec-vscode-form">
+				<button type="submit" class="vscode-file-btn" title="Open in Editor">&#128221;</button>
+			</form>
+			{{end}}
 		{{else}}
-		<span class="vscode-file-btn disabled" title="VSCode CLI not available">&#128221;</span>
+		<span class="vscode-file-btn disabled" title="Editor not available">&#128221;</span>
 		{{end}}
 	</summary>
 	<div class="spec-content">{{.ProjectMgmtContent}}</div>

--- a/docs/reference/project-configuration.md
+++ b/docs/reference/project-configuration.md
@@ -33,38 +33,54 @@ Type: boolean
 
 If `true`, `sgai` does not create or resume a retrospective directory for the workflow run.
 
-### `mcp`
-
-Type: object (`map[string]json.RawMessage`)
-
-`mcp` allows defining additional MCP entries that are merged into `.sgai/opencode.jsonc`.
-
-Merge rules:
-
-- `sgai` only adds an MCP entry when the entry name does not already exist in `.sgai/opencode.jsonc`.
-- If `sgai.json` contains MCP entries but all of them already exist in `.sgai/opencode.jsonc`, `sgai` does not rewrite `.sgai/opencode.jsonc`.
-
-## Notes
-
-- If `sgai.json` does not exist, `sgai` proceeds without configuration.
-- If `sgai.json` exists but cannot be read due to permissions, `sgai` reports a "permission denied reading config file" error.
-- If `sgai.json` contains invalid JSON syntax or type mismatches, `sgai` reports an error that includes the file path and the failing offset or field.
-
-### `defaultModel`
+### `editor`
 
 Type: string
 
-If set, `defaultModel` becomes the default model for any agent in `GOAL.md` that does not already have a model configured.
+Configures the editor used for the "Open in Editor" button in the web interface.
 
-Notes:
+**Preset names:**
 
-- `defaultModel` is validated using the base model name. If the value includes a variant in parentheses (for example, `provider/model (variant)`), only the base model is validated.
+| Preset | Command | Terminal? |
+|--------|---------|-----------|
+| `code` | `code {path}` | No |
+| `cursor` | `cursor {path}` | No |
+| `zed` | `zed {path}` | No |
+| `subl` | `subl {path}` | No |
+| `idea` | `idea {path}` | No |
+| `emacs` | `emacsclient -n {path}` | No |
+| `nvim` | `nvim {path}` | Yes |
+| `vim` | `vim {path}` | Yes |
+| `atom` | `atom {path}` | No |
 
-### `disable_retrospective`
+**Examples:**
 
-Type: boolean
+```json
+{"editor": "cursor"}
+```
 
-If `true`, `sgai` does not create or resume a retrospective directory for the workflow run.
+```json
+{"editor": "myeditor --open {path}"}
+```
+
+**Fallback chain:**
+
+When not set, `sgai` uses the following fallback chain:
+
+1. `$VISUAL` environment variable
+2. `$EDITOR` environment variable
+3. `code` (VS Code)
+
+**Custom commands:**
+
+- If your custom command contains `{path}`, it will be replaced with the file path.
+- If your custom command does not contain `{path}`, the path is appended to the end.
+- Environment variable values are treated as custom commands.
+- Custom commands are assumed to be GUI editors (not terminal editors).
+
+**Terminal editors:**
+
+Terminal-based editors (`vim`, `nvim`) cannot be opened from the web interface. When a terminal editor is configured, the "Open in Editor" button is hidden.
 
 ### `mcp`
 


### PR DESCRIPTION
Currently, sgai hardcodes VS Code as the only supported editor via the vscodeOpener struct in serve.go. Users who prefer other editors (Neovim, Zed, Cursor, Sublime Text, IntelliJ, Emacs, etc.) cannot use the "Open in Editor" feature.

Acceptance Criteria

-     editor field in sgai.json is respected
-     Common editor presets work out of the box (code, cursor, zed, subl, idea, emacs)
-     Custom editor commands with {path} placeholder work
-     Falls back to $VISUAL → $EDITOR → code when not configured
-     Terminal-based editors are detected and handled gracefully (button hidden or path copied)
-     UI labels say "Open in Editor" not "Open in VS Code"
-     Documentation updated (docs/reference/project-configuration.md)
-     Button only shows when editor is available AND request is from localhost (existing security)
