### PR TITLE
cmd/sgai: add mode alternation between auto and interactive

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,6 +19,22 @@ jobs:
       with:
         go-version-file: 'go.mod'
 
+    - name: Install jj (macOS)
+      if: runner.os == 'macOS'
+      run: brew install jj
+
+    - name: Install jj (Linux)
+      if: runner.os == 'Linux'
+      run: |
+        JJ_VERSION=$(gh api repos/jj-vcs/jj/releases/latest --jq '.tag_name')
+        curl -fsSL "https://github.com/jj-vcs/jj/releases/download/${JJ_VERSION}/jj-${JJ_VERSION}-x86_64-unknown-linux-musl.tar.gz" -o /tmp/jj.tar.gz
+        mkdir -p /tmp/jj-extract
+        tar -xzf /tmp/jj.tar.gz -C /tmp/jj-extract
+        sudo install /tmp/jj-extract/jj /usr/local/bin/jj
+        jj --version
+      env:
+        GH_TOKEN: ${{ github.token }}
+
     - name: Build
       run: make build
 

--- a/GOALS/2026_02_03_fix_regressions_and_auto_yes_toggle.md
+++ b/GOALS/2026_02_03_fix_regressions_and_auto_yes_toggle.md
@@ -1,0 +1,32 @@
+---
+flow: |
+  "backend-go-developer" -> "go-readability-reviewer"
+  "backend-go-developer" -> "stpa-analyst"
+  "go-readability-reviewer" -> "stpa-analyst"
+  "general-purpose" -> "stpa-analyst"
+  "htmx-picocss-frontend-developer" -> "htmx-picocss-frontend-reviewer"
+  "htmx-picocss-frontend-reviewer" -> "stpa-analyst"
+  "project-critic-council"
+models:
+  "coordinator": "anthropic/claude-opus-4-5 (max)"
+  "backend-go-developer": "anthropic/claude-opus-4-5"
+  "go-readability-reviewer": "anthropic/claude-opus-4-5"
+  "general-purpose": "anthropic/claude-opus-4-5"
+  "htmx-picocss-frontend-developer": "anthropic/claude-opus-4-5"
+  "htmx-picocss-frontend-reviewer": "anthropic/claude-opus-4-5"
+  "stpa-analyst": "anthropic/claude-opus-4-5"
+  "project-critic-council": ["opencode/kimi-k2.5-free", "opencode/minimax-m2.1-free", "opencode/glm-4.7-free"]
+interactive: yes
+completionGateScript: make test
+mode: graph
+---
+
+- [x] Once the session is started, add a button to allow me to alternate between auto and yes.
+
+Using gh look at https://github.com/sandgardenhq/sgai/actions/runs/21652033466/job/62418618478?pr=96
+note how the tests are not passing:
+- [x] fix regressions
+
+Using gh look at https://github.com/sandgardenhq/sgai/actions/runs/21657705908/job/62435865772?pr=96
+note how the tests are not passing:
+- [x] fix regressions

--- a/cmd/sgai/gitexclude_test.go
+++ b/cmd/sgai/gitexclude_test.go
@@ -16,7 +16,7 @@ func TestEnsureGitExclude(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		ensureGitExclude(dir, "sgai")
+		ensureGitExclude(dir)
 
 		excludePath := filepath.Join(gitInfoDir, "exclude")
 		content, err := os.ReadFile(excludePath)
@@ -41,7 +41,7 @@ func TestEnsureGitExclude(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		ensureGitExclude(dir, "sgai")
+		ensureGitExclude(dir)
 
 		content, err := os.ReadFile(excludePath)
 		if err != nil {
@@ -68,7 +68,7 @@ func TestEnsureGitExclude(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		ensureGitExclude(dir, "sgai")
+		ensureGitExclude(dir)
 
 		content, err := os.ReadFile(excludePath)
 		if err != nil {
@@ -82,7 +82,7 @@ func TestEnsureGitExclude(t *testing.T) {
 	t.Run("skipsNonGitRepository", func(t *testing.T) {
 		dir := t.TempDir()
 
-		ensureGitExclude(dir, "sgai")
+		ensureGitExclude(dir)
 
 		excludePath := filepath.Join(dir, ".git", "info", "exclude")
 		if _, err := os.Stat(excludePath); !os.IsNotExist(err) {
@@ -97,7 +97,7 @@ func TestEnsureGitExclude(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		ensureGitExclude(dir, "sgai")
+		ensureGitExclude(dir)
 
 		excludePath := filepath.Join(gitDir, "info", "exclude")
 		content, err := os.ReadFile(excludePath)

--- a/cmd/sgai/templates/trees_actions.html
+++ b/cmd/sgai/templates/trees_actions.html
@@ -38,6 +38,14 @@
 	<a href="/workspaces/{{.DirName}}/snippets" role="button" class="action-btn outline">Snippets</a>
 	<a href="/workspaces/{{.DirName}}/agents" role="button" class="action-btn outline">Agents</a>
 	{{if .Running}}
+	<form action="/workspaces/{{.DirName}}/toggle-mode" method="post">
+		<input type="hidden" name="mode" value="auto">
+		<button type="submit" class="action-btn{{if not .InteractiveAuto}} outline{{end}}">Auto</button>
+	</form>
+	<form action="/workspaces/{{.DirName}}/toggle-mode" method="post">
+		<input type="hidden" name="mode" value="yes">
+		<button type="submit" class="action-btn{{if .InteractiveAuto}} outline{{end}}">Interactive</button>
+	</form>
 	<form action="/workspaces/{{.DirName}}/stop" method="post">
 		<input type="hidden" name="directory" value="{{.Directory}}">
 		<button type="submit" class="action-btn outline">Stop</button>

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -136,7 +136,8 @@ type Workflow struct {
 
 	Cost SessionCost `json:"cost"`
 
-	WorkGateApproved bool `json:"workGateApproved,omitempty"`
+	WorkGateApproved    bool   `json:"workGateApproved,omitempty"`
+	InteractiveOverride string `json:"interactiveOverride,omitempty"`
 
 	// ModelStatuses tracks per-model status in multi-model agents.
 	// Key is model ID (agent:modelSpec), value is "model-working", "model-done", or "model-error".


### PR DESCRIPTION
## Summary
- Add toggle buttons (Auto/Interactive) to the workspace action bar, allowing users to switch between auto and interactive modes while a session is running
- Refactor workspace initialization into a single `initializeWorkspaceDir` function that handles skeleton unpacking, layer overlay, jj init, and git exclude setup
- Add `InteractiveOverride` field to workflow state and `handleToggleMode` endpoint to persist and apply mode changes