### PR TITLE
cmd/sgai: move Run from session content into its own tab

### DIFF
--- a/GOALS/2026-02-03-move-run-to-own-tab.md
+++ b/GOALS/2026-02-03-move-run-to-own-tab.md
@@ -1,0 +1,25 @@
+---
+flow: |
+  "backend-go-developer" -> "go-readability-reviewer"
+  "backend-go-developer" -> "stpa-analyst"
+  "go-readability-reviewer" -> "stpa-analyst"
+  "general-purpose" -> "stpa-analyst"
+  "htmx-picocss-frontend-developer" -> "htmx-picocss-frontend-reviewer"
+  "htmx-picocss-frontend-reviewer" -> "stpa-analyst"
+models:
+  "coordinator": "anthropic/claude-opus-4-5 (max)"
+  "backend-go-developer": "anthropic/claude-opus-4-5"
+  "go-readability-reviewer": "anthropic/claude-opus-4-5"
+  "general-purpose": "anthropic/claude-opus-4-5"
+  "htmx-picocss-frontend-developer": "anthropic/claude-sonnet-4-5"
+  "htmx-picocss-frontend-reviewer": "anthropic/claude-opus-4-5"
+  "stpa-analyst": "anthropic/claude-opus-4-5"
+interactive: yes
+completionGateScript: make test
+---
+
+- [x] Move the Run from inside Internal and make its own Tab
+- [x] The default model for the Run tab must be the same model of "coordinator"(it is safe to rely only on the model name and ignore the variant within parenthesis)
+- [x] As the Run box runs, the output scrolls up over and over, and I can't keep up with the output.
+- [x] Run should use stdin instead of parameter `echo $msg | opencode run` instead of `opencode run $msg`
+- [x] update opencode.json in sgai template to automatically deny doom_loop and external_directory permissions (refer to https://opencode.ai/docs/permissions/#granular-rules-object-syntax )

--- a/cmd/sgai/config.go
+++ b/cmd/sgai/config.go
@@ -15,7 +15,6 @@ const configFileName = "sgai.json"
 type projectConfig struct {
 	DefaultModel         string                     `json:"defaultModel,omitempty"`
 	DisableRetrospective bool                       `json:"disable_retrospective,omitempty"`
-	EnableAdhocPrompt    bool                       `json:"enable-adhoc-prompt,omitempty"`
 	MCP                  map[string]json.RawMessage `json:"mcp,omitempty"`
 	Editor               string                     `json:"editor,omitempty"`
 }

--- a/cmd/sgai/skel/.sgai/opencode.jsonc
+++ b/cmd/sgai/skel/.sgai/opencode.jsonc
@@ -20,5 +20,9 @@
                         ],
                         "enabled": true
                 }
+        },
+        "permission": {
+                "doom_loop": "deny",
+                "external_directory": "deny"
         }
 }

--- a/cmd/sgai/templates/adhoc_output.html
+++ b/cmd/sgai/templates/adhoc_output.html
@@ -1,4 +1,4 @@
-<div id="adhoc-output"{{if .Running}} hx-get="/workspaces/{{.DirName}}/adhoc/output" hx-trigger="every 1s" hx-swap="outerHTML"{{end}}>
+<div id="adhoc-output"{{if .Running}} hx-get="/workspaces/{{.DirName}}/adhoc/output" hx-trigger="every 1s" hx-swap="morph:outerHTML"{{end}}>
 	<pre class="adhoc-output">{{.Output}}</pre>
 	{{if .Running}}
 	<button type="submit" disabled aria-busy="true">Running...</button>

--- a/cmd/sgai/templates/trees.html
+++ b/cmd/sgai/templates/trees.html
@@ -1722,14 +1722,28 @@
 	/* Idiomorph integration: preserve scroll positions during morph swaps */
 	(function() {
 		var scrollState = {}, selectors = '.tree-panel, .log-panel, .retro-panel-embedded';
+		var adhocScrollState = {};
 		document.body.addEventListener('htmx:beforeSwap', function() {
 			scrollState = {};
 			document.querySelectorAll(selectors).forEach(function(el, i) { scrollState[i] = el.scrollTop; });
+			var adhocOutput = document.querySelector('.adhoc-output');
+			if (adhocOutput) {
+				var wasAtBottom = adhocOutput.scrollTop + adhocOutput.clientHeight >= adhocOutput.scrollHeight - 30;
+				adhocScrollState = { scrollTop: adhocOutput.scrollTop, wasAtBottom: wasAtBottom };
+			}
 		});
 		document.body.addEventListener('htmx:afterSwap', function() {
 			document.querySelectorAll(selectors).forEach(function(el, i) {
 				if (scrollState[i] !== undefined) el.scrollTop = scrollState[i];
 			});
+			var adhocOutput = document.querySelector('.adhoc-output');
+			if (adhocOutput && adhocScrollState.wasAtBottom !== undefined) {
+				if (adhocScrollState.wasAtBottom) {
+					adhocOutput.scrollTop = adhocOutput.scrollHeight;
+				} else {
+					adhocOutput.scrollTop = adhocScrollState.scrollTop;
+				}
+			}
 		});
 	})();
 	</script>

--- a/cmd/sgai/templates/trees_run_content.html
+++ b/cmd/sgai/templates/trees_run_content.html
@@ -1,0 +1,21 @@
+<article id="adhoc-prompt-container">
+	<header>Run</header>
+	<form hx-post="/workspaces/{{.DirName}}/adhoc/submit" hx-target="#adhoc-output" hx-swap="outerHTML">
+		<div class="grid">
+			<select name="model" id="adhoc-model" aria-label="Model" required{{if .AdhocRunning}} disabled{{end}} hx-post="/workspaces/{{.DirName}}/adhoc/save-state" hx-trigger="change" hx-swap="none" hx-include="[name='prompt']">
+				{{range .AdhocModels}}
+				<option value="{{.}}"{{if eq . $.AdhocSelectedModel}} selected{{end}}>{{.}}</option>
+				{{end}}
+			</select>
+			<input type="text" name="prompt" id="adhoc-prompt" aria-label="Prompt" placeholder="Enter prompt..." required{{if .AdhocRunning}} disabled{{end}} value="{{.AdhocPromptText}}" hx-post="/workspaces/{{.DirName}}/adhoc/save-state" hx-trigger="input changed delay:500ms, focusout changed" hx-swap="none" hx-include="[name='model']">
+		</div>
+		<div id="adhoc-output"{{if .AdhocRunning}} hx-get="/workspaces/{{.DirName}}/adhoc/output" hx-trigger="every 1s" hx-swap="morph:outerHTML"{{end}}>
+			<pre class="adhoc-output">{{.AdhocOutput}}</pre>
+			{{if .AdhocRunning}}
+			<button type="submit" disabled aria-busy="true">Running...</button>
+			{{else}}
+			<button type="submit">Submit</button>
+			{{end}}
+		</div>
+	</form>
+</article>

--- a/cmd/sgai/templates/trees_session_content.html
+++ b/cmd/sgai/templates/trees_session_content.html
@@ -120,26 +120,4 @@
 	</article>
 </div>
 
-{{if .AdhocPromptEnabled}}
-<article id="adhoc-prompt-container">
-	<header>Run</header>
-	<form hx-post="/workspaces/{{.DirName}}/adhoc/submit" hx-target="#adhoc-output" hx-swap="outerHTML">
-		<div class="grid">
-			<select name="model" id="adhoc-model" aria-label="Model" required{{if .AdhocRunning}} disabled{{end}} hx-post="/workspaces/{{.DirName}}/adhoc/save-state" hx-trigger="change" hx-swap="none" hx-include="[name='prompt']">
-				{{range .AdhocModels}}
-				<option value="{{.}}"{{if eq . $.AdhocSelectedModel}} selected{{end}}>{{.}}</option>
-				{{end}}
-			</select>
-			<input type="text" name="prompt" id="adhoc-prompt" aria-label="Prompt" placeholder="Enter prompt..." required{{if .AdhocRunning}} disabled{{end}} value="{{.AdhocPromptText}}" hx-post="/workspaces/{{.DirName}}/adhoc/save-state" hx-trigger="input changed delay:500ms, focusout changed" hx-swap="none" hx-include="[name='model']">
-		</div>
-		<div id="adhoc-output"{{if .AdhocRunning}} hx-get="/workspaces/{{.DirName}}/adhoc/output" hx-trigger="every 1s" hx-swap="outerHTML"{{end}}>
-			<pre class="adhoc-output">{{.AdhocOutput}}</pre>
-			{{if .AdhocRunning}}
-			<button type="submit" disabled aria-busy="true">Running...</button>
-			{{else}}
-			<button type="submit">Submit</button>
-			{{end}}
-		</div>
-	</form>
-</article>
-{{end}}
+

--- a/cmd/sgai/templates/trees_workspace.html
+++ b/cmd/sgai/templates/trees_workspace.html
@@ -18,6 +18,7 @@
 			<li><a href="/workspaces/{{.DirName}}/messages"{{if eq .ActiveTab "messages"}} class="active"{{end}}>Messages</a></li>
 			<li><a href="/workspaces/{{.DirName}}/internals"{{if eq .ActiveTab "internals"}} class="active"{{end}}>Internals</a></li>
 			{{if not .DisableRetrospective}}<li><a href="/workspaces/{{.DirName}}/retro"{{if eq .ActiveTab "retrospectives"}} class="active"{{end}}>Retrospectives</a></li>{{end}}
+			<li><a href="/workspaces/{{.DirName}}/run"{{if eq .ActiveTab "run"}} class="active"{{end}}>Run</a></li>
 		</ul>
 	</nav>
 </div>


### PR DESCRIPTION
## Summary

- Move the "Run" (ad-hoc prompt) feature from being embedded inside the session content tab into its own dedicated "Run" tab in the workspace navigation
- Remove the `EnableAdhocPrompt` config flag and `--enable-adhoc-prompt` CLI flag — Run is now always available as a tab
- Default the Run tab's model selection to the coordinator's model (parsed from GOAL.md), falling back to the first available model
- Add `GOALS/2026-02-03-move-run-to-own-tab.md` archiving the completed goal