### PR TITLE
cmd/sgai: fix Open In Editor button disabled when EDITOR env points to unavailable binary

### DIFF
--- a/GOALS/2026_02_03_fix_open_in_editor.md
+++ b/GOALS/2026_02_03_fix_open_in_editor.md
@@ -1,0 +1,21 @@
+---
+flow: |
+  "backend-go-developer" -> "go-readability-reviewer"
+  "backend-go-developer" -> "stpa-analyst"
+  "go-readability-reviewer" -> "stpa-analyst"
+  "general-purpose" -> "stpa-analyst"
+  "htmx-picocss-frontend-developer" -> "htmx-picocss-frontend-reviewer"
+  "htmx-picocss-frontend-reviewer" -> "stpa-analyst"
+models:
+  "coordinator": "anthropic/claude-opus-4-5 (max)"
+  "backend-go-developer": "anthropic/claude-opus-4-5"
+  "go-readability-reviewer": "anthropic/claude-opus-4-5"
+  "general-purpose": "anthropic/claude-opus-4-5"
+  "htmx-picocss-frontend-developer": "anthropic/claude-sonnet-4-5"
+  "htmx-picocss-frontend-reviewer": "anthropic/claude-opus-4-5"
+  "stpa-analyst": "anthropic/claude-opus-4-5"
+interactive: yes
+completionGateScript: make test
+---
+
+- [x] The `Open In Editor` is not working anymore. I used to be able to open my VSCode, I can't it anymore.


### PR DESCRIPTION
## Summary

- Fixes the "Open In Editor" button that was disabled when the EDITOR environment variable points to an unavailable binary by falling back to the default editor preset
- Adds tests covering the editor fallback behavior, explicit env editor usage, and config editor override
- Includes spec file GOALS/2026_02_03_fix_open_in_editor.md