### PR TITLE
cmd/sgai: add -n flag to VS Code editor preset

### DIFF
--- a/cmd/sgai/serve.go
+++ b/cmd/sgai/serve.go
@@ -182,7 +182,7 @@ type editorPreset struct {
 }
 
 var editorPresets = map[string]editorPreset{
-	"code":   {command: "code {path}", isTerminal: false},
+	"code":   {command: "code -n {path}", isTerminal: false},
 	"cursor": {command: "cursor {path}", isTerminal: false},
 	"zed":    {command: "zed {path}", isTerminal: false},
 	"subl":   {command: "subl {path}", isTerminal: false},


### PR DESCRIPTION
## Summary
- Adds `-n` flag to VS Code editor preset command to open files in a new window
- Changes `code {path}` to `code -n {path}` in the editor presets configuration