### PR TITLE
cmd/sgai: make project-critic-council mandatory and add validation criteria

### DIFF
--- a/GOALS/2026_02_05_mandatory_project_critic_council_and_validation_criteria.md
+++ b/GOALS/2026_02_05_mandatory_project_critic_council_and_validation_criteria.md
@@ -1,0 +1,41 @@
+---
+flow: |
+  "backend-go-developer" -> "go-readability-reviewer"
+  "backend-go-developer" -> "stpa-analyst"
+  "go-readability-reviewer" -> "stpa-analyst"
+  "general-purpose" -> "stpa-analyst"
+  "htmx-picocss-frontend-developer" -> "htmx-picocss-frontend-reviewer"
+  "htmx-picocss-frontend-reviewer" -> "stpa-analyst"
+  "project-critic-council"
+  "skill-writer"
+models:
+  "coordinator": "anthropic/claude-opus-4-5 (max)"
+  "backend-go-developer": "anthropic/claude-opus-4-5"
+  "go-readability-reviewer": "anthropic/claude-opus-4-5"
+  "general-purpose": "anthropic/claude-opus-4-5"
+  "htmx-picocss-frontend-developer": "anthropic/claude-opus-4-5"
+  "htmx-picocss-frontend-reviewer": "anthropic/claude-opus-4-5"
+  "stpa-analyst": "anthropic/claude-opus-4-5"
+  "project-critic-council": ["anthropic/claude-opus-4-5", "openai/gpt-5.2", "openai/gpt-5.2-codex"]
+  "skill-writer": "anthropic/claude-opus-4-5 (max)"
+interactive: yes
+completionGateScript: make test
+---
+
+Question: "Hard-code project critic council? Be even more strict about goal?"
+
+I want to improve the sgai ability to see a feature done to the end. And to that effect we are going to make few changes.
+
+# Change 1: Make project-critic-council mandatory
+In the sgai internal clockwork, there is a logic that forces/prepends the coordinator to all left-most nodes.
+We are going to add one mandatory relationship
+- [x] add `"coordinator" -> "project-critic-council"`
+- [x] update `coordinator.md` model to default to "anthropic/claude-opus-4-5 (max)" (refer to https://opencode.ai/docs/agents#markdown)
+  - [x] update `coordinator.md` to include a step in its master plan to ask `project-critic-council` agent whether the project is complete
+- [x] update `project-critic-council.md` model to default to "anthropic/claude-opus-4-5 (max)" (refer to https://opencode.ai/docs/agents#markdown)
+  - [x] update `project-critic-council.md` to include forceful instructions to always read PROJECT_MANAGEMENT.md and GOAL.md to make proper evaluations and decisions
+  - [x] update `project-critic-council.md` to include forceful instructions to always communicate back with the coordinator
+
+# Change 2: Ask Human Partner about validation criteria
+- [x] update the `cmd/sgai/skel/.sgai/skills/product-design/brainstorming/SKILL.md` skill to interview the human partner with validation questions that are supposed to be used by the project-critic-council; make sure that inside the brainstorming skill there are instructions to update PROJECT_MANAGEMENT.md with the human partner answers as it evolves.
+

--- a/cmd/sgai/dag.go
+++ b/cmd/sgai/dag.go
@@ -225,6 +225,7 @@ func parseFlow(flowSpec string, dir string) (*dag, error) {
 	}
 
 	d.injectCoordinatorEdges()
+	d.injectProjectCriticCouncilEdge()
 
 	if err := d.detectCycles(); err != nil {
 		return nil, err
@@ -257,6 +258,19 @@ func (d *dag) injectCoordinatorEdges() {
 	slices.Sort(coordNode.Successors)
 
 	d.EntryNodes = []string{"coordinator"}
+}
+
+func (d *dag) injectProjectCriticCouncilEdge() {
+	coordNode := d.ensureNode("coordinator")
+	pccNode := d.ensureNode("project-critic-council")
+
+	if !slices.Contains(coordNode.Successors, "project-critic-council") {
+		coordNode.Successors = append(coordNode.Successors, "project-critic-council")
+	}
+	if !slices.Contains(pccNode.Predecessors, "coordinator") {
+		pccNode.Predecessors = append(pccNode.Predecessors, "coordinator")
+	}
+	slices.Sort(coordNode.Successors)
 }
 
 func (d *dag) detectCycles() error {

--- a/cmd/sgai/skel/.sgai/agent/coordinator.md
+++ b/cmd/sgai/skel/.sgai/agent/coordinator.md
@@ -1,4 +1,5 @@
 ---
+model: "anthropic/claude-opus-4-5 (max)"
 description: Coordinates the work flow.
 mode: primary
 permission:
@@ -272,6 +273,19 @@ The master plan has these steps (if any of these files don't exist, YOU MUST CAL
 
 - Step Name: CODE-CLEANUP
   A step that looks at the generated code and cleans it up by asking why certain things are there, cross-referencing with GOAL.md, and cleaning up based on good taste. Create the corresponding SKILL.md.
+
+- Step Name: ASK-PROJECT-CRITIC-COUNCIL
+  BEFORE you can mark the workflow as complete, you SHOULD send a message to project-critic-council asking them to verify all GOAL.md checkboxes are genuinely complete. This is VERY STRONGLY ENCOURAGED.
+  
+  ```
+  sgai_send_message({
+    toAgent: "project-critic-council",
+    body: "Please verify all checked items in GOAL.md are genuinely complete before I mark the workflow as finished."
+  })
+  ```
+  
+  Then set status to "agent-done" to let project-critic-council evaluate.
+  When project-critic-council responds, review their verdict before proceeding to MARK-COMPLETE.
 
 - Step Name: MARK-COMPLETE
   After the CODE-CLEANUP mark the entire workflow as complete:

--- a/cmd/sgai/skel/.sgai/agent/project-critic-council.md
+++ b/cmd/sgai/skel/.sgai/agent/project-critic-council.md
@@ -1,4 +1,5 @@
 ---
+model: "anthropic/claude-opus-4-5 (max)"
 description: Multi-model council that strictly evaluates whether GOAL.md items are truly complete. Requests changes through coordinator.
 mode: primary
 permission:
@@ -12,6 +13,30 @@ permission:
 ---
 
 # Project Critic Council
+
+## CRITICAL: First Actions
+
+BEFORE doing ANYTHING else, you MUST:
+1. Read `@GOAL.md` to understand what was supposed to be accomplished
+2. Read `@.sgai/PROJECT_MANAGEMENT.md` to understand:
+   - Human partner's validation criteria (from brainstorming)
+   - Decisions made during the project
+   - Any edge cases or acceptance criteria defined
+3. Check your inbox for messages from coordinator
+
+DO NOT proceed with evaluation until you have read BOTH files.
+
+## CRITICAL: Always Report Back
+
+After completing your evaluation, you MUST send your verdict to the coordinator:
+```
+sgai_send_message({
+  toAgent: "coordinator",
+  body: "COUNCIL VERDICT: [summary of findings]"
+})
+```
+
+---
 
 You are a member of the Project Critic Council - a multi-model agent where multiple models collaborate to strictly evaluate whether goals declared in GOAL.md have actually been accomplished.
 

--- a/cmd/sgai/skel/.sgai/skills/product-design/brainstorming/SKILL.md
+++ b/cmd/sgai/skel/.sgai/skills/product-design/brainstorming/SKILL.md
@@ -37,6 +37,37 @@ IMPORTANT: Hand the control back to the human partner so they can feed you with 
 
 IMPORTANT: Hand the control back to the human partner so they can feed you with information.
 
+### Phase 4: Validation Criteria
+
+After design is agreed upon, gather validation criteria for project-critic-council.
+
+Ask these questions (each with escape hatch option):
+1. **Acceptance Criteria:** "How will you know this feature is done?"
+2. **Test Requirements:** "What tests should pass before completion?"
+3. **Evidence Requirements:** "What proof do you need to see?"
+4. **Edge Cases:** "What scenarios must work?"
+
+Example:
+```
+sgai_ask_user_question({
+  questions: [{
+    question: "**Phase 4: Validation Criteria**\n\nHow will you know this feature is complete? What's the acceptance criteria?",
+    choices: [
+      "Tests pass and feature works as described",
+      "I'll define specific criteria (describe in Other)",
+      "Skip detailed validation - proceed with current understanding"
+    ],
+    multiSelect: false
+  }]
+})
+```
+
+**IMPORTANT:** Always include "Skip detailed validation" option to let users shorten the interview.
+
+Log all validation criteria in `@.sgai/PROJECT_MANAGEMENT.md` under a `## Validation Criteria` section.
+
+IMPORTANT: Hand the control back to the human partner so they can feed you with information.
+
 ## When to Revisit Earlier Phases
 
 **You can and should go backward when:**


### PR DESCRIPTION
## Summary

- Make `project-critic-council` agent mandatory by injecting `coordinator -> project-critic-council` edge in the DAG
- Update coordinator to ask project-critic-council for verification before marking workflow complete
- Update project-critic-council with forceful instructions to read GOAL.md and PROJECT_MANAGEMENT.md before evaluation
- Add validation criteria phase to brainstorming skill to gather acceptance criteria from human partner
- Add comprehensive tests for the new project-critic-council edge injection