### PR TITLE
cmd/sgai: simplify Messages and Run tabs by removing redundant headers

### DIFF
--- a/GOALS/2026_02_05_simplify_messages_and_run_tabs.md
+++ b/GOALS/2026_02_05_simplify_messages_and_run_tabs.md
@@ -1,0 +1,28 @@
+---
+flow: |
+  "backend-go-developer" -> "go-readability-reviewer"
+  "backend-go-developer" -> "stpa-analyst"
+  "go-readability-reviewer" -> "stpa-analyst"
+  "general-purpose" -> "stpa-analyst"
+  "htmx-picocss-frontend-developer" -> "htmx-picocss-frontend-reviewer"
+  "htmx-picocss-frontend-reviewer" -> "stpa-analyst"
+  "project-critic-council"
+  "skill-writer"
+models:
+  "coordinator": "anthropic/claude-opus-4-5 (max)"
+  "backend-go-developer": "anthropic/claude-opus-4-5"
+  "go-readability-reviewer": "anthropic/claude-opus-4-5"
+  "general-purpose": "anthropic/claude-opus-4-5"
+  "htmx-picocss-frontend-developer": "anthropic/claude-opus-4-5"
+  "htmx-picocss-frontend-reviewer": "anthropic/claude-opus-4-5"
+  "stpa-analyst": "anthropic/claude-opus-4-5"
+  "project-critic-council": ["anthropic/claude-opus-4-5", "openai/gpt-5.2", "openai/gpt-5.2-codex"]
+  "skill-writer": "anthropic/claude-opus-4-5 (max)"
+interactive: yes
+completionGateScript: make test
+---
+
+- [x] In Messages tab, the messages box doesn't need a title
+  - [x] does it even need a box? why not inline?
+- [x] In Run, the Run box doesn't need a title
+  - [x] does it even need a box? why not inline?

--- a/cmd/sgai/templates/trees_messages_content.html
+++ b/cmd/sgai/templates/trees_messages_content.html
@@ -1,5 +1,4 @@
-<article id="messages-content">
-	<header>Messages</header>
+<div id="messages-content">
 	{{if .Messages}}
 	<div>
 		{{range $m := .Messages}}
@@ -26,4 +25,4 @@
 	{{else}}
 	<p><em>No messages</em></p>
 	{{end}}
-</article>
+</div>

--- a/cmd/sgai/templates/trees_run_content.html
+++ b/cmd/sgai/templates/trees_run_content.html
@@ -1,5 +1,4 @@
-<article id="adhoc-prompt-container">
-	<header>Run</header>
+<div id="adhoc-prompt-container">
 	<form hx-post="/workspaces/{{.DirName}}/adhoc/submit" hx-target="#adhoc-output" hx-swap="outerHTML">
 		<div class="grid">
 			<select name="model" id="adhoc-model" aria-label="Model" required{{if .AdhocRunning}} disabled{{end}} hx-post="/workspaces/{{.DirName}}/adhoc/save-state" hx-trigger="change" hx-swap="none" hx-include="[name='prompt']">
@@ -18,4 +17,4 @@
 			{{end}}
 		</div>
 	</form>
-</article>
+</div>


### PR DESCRIPTION
## Summary
- Remove redundant "Messages" header from the Messages tab since it's already contextually clear from the tab name
- Remove redundant "Run" header from the Run tab for the same reason
- Archive completed GOAL.md to GOALS/ directory

This simplifies the UI by removing unnecessary visual noise.