### PR TITLE
GOALS: add project-critic-council-upgrade spec

### DIFF
--- a/GOALS/2026_02_06_project_critic_council_upgrade.md
+++ b/GOALS/2026_02_06_project_critic_council_upgrade.md
@@ -1,0 +1,53 @@
+---
+flow: |
+  "backend-go-developer" -> "go-readability-reviewer"
+  "backend-go-developer" -> "stpa-analyst"
+  "go-readability-reviewer" -> "stpa-analyst"
+  "general-purpose" -> "stpa-analyst"
+  "htmx-picocss-frontend-developer" -> "htmx-picocss-frontend-reviewer"
+  "htmx-picocss-frontend-reviewer" -> "stpa-analyst"
+  "project-critic-council"
+  "skill-writer"
+models:
+  "coordinator": "openai/gpt-5.2-codex (xhigh)"
+  "backend-go-developer": "openai/gpt-5.2-codex"
+  "go-readability-reviewer": "openai/gpt-5.2-codex"
+  "general-purpose": "openai/gpt-5.2-codex"
+  "htmx-picocss-frontend-developer": "openai/gpt-5.2-codex"
+  "htmx-picocss-frontend-reviewer": "opencode/kimi-k2.5"
+  "stpa-analyst": "openai/gpt-5.2-codex"
+  "project-critic-council": ["openai/gpt-5.2-codex", "openai/gpt-5.2", "opencode/kimi-k2.5"]
+  "skill-writer": "openai/gpt-5.2-codex (xhigh)"
+interactive: yes
+completionGateScript: make test
+---
+
+The project-critic-council is a very neat idea. I love it, and it really helps with ensuring the project gets to a completion.
+
+However, no matter what model I use - GPT-5.2 or Opus 4.5 or Kimi K2.5 or Big Pickle... I can see often the agents over communicate.
+
+In a sense, what I want is a more or less straightforward journey
+
+0. The coordinator asks the Project Critic Council to execute an evaluation and deliver the message to its FrontMan.
+1. FrontMan Sibling Mode asks all peers to execute their own evaluations
+2. The Siblings talk to each other to communicate their own assessments
+3. They all communicate to FrontMan their results
+4. FrontMan evaluates these results, and it is biased to communicate back to the coordinator
+
+- [x] Evaluate changes in the Project Critic Council that could more closely adhere to these goals
+- [x] Improve Web Interface so that the ORDER of models displayed in the UI is the same as the one written in GOAL.md
+
+## Council Plan
+
+- [x] Define FrontMan and Sibling roles explicitly; map each step (0–4) to a single expected message.
+- [x] Standardize peer evaluation and aggregation message templates to reduce over-communication.
+- [x] Ensure only the FrontMan communicates back to the coordinator.
+- [x] Clarify when/why peers communicate with each other (step 2) and how to keep it minimal.
+
+## UI Ordering Plan
+
+- [x] Identify UI view(s) that display model order for project-critic-council.
+- [x] Trace the data flow to confirm where model list order is sourced.
+- [x] Update the source to use the GOAL.md frontmatter `models` list order for project-critic-council.
+- [x] Define fallback behavior for missing/unknown models.
+- [x] Verify UI display order matches GOAL.md.

--- a/cmd/sgai/skel/.sgai/agent/project-critic-council.md
+++ b/cmd/sgai/skel/.sgai/agent/project-critic-council.md
@@ -18,23 +18,26 @@ permission:
 
 BEFORE doing ANYTHING else, you MUST:
 1. Read `@GOAL.md` to understand what was supposed to be accomplished
-2. Read `@.sgai/PROJECT_MANAGEMENT.md` to understand:
+2. Determine FrontMan from the **first entry** in GOAL.md frontmatter `models["project-critic-council"]` entry list
+3. Read `@.sgai/PROJECT_MANAGEMENT.md` to understand:
    - Human partner's validation criteria (from brainstorming)
    - Decisions made during the project
    - Any edge cases or acceptance criteria defined
-3. Check your inbox for messages from coordinator
+4. Check your inbox for messages from coordinator
 
 DO NOT proceed with evaluation until you have read BOTH files.
 
-## CRITICAL: Always Report Back
+## CRITICAL: Always Report Back (FrontMan Only)
 
-After completing your evaluation, you MUST send your verdict to the coordinator:
+If you are the FrontMan (the first entry in GOAL.md frontmatter `models` list), you MUST send the final aggregation verdict to the coordinator:
 ```
 sgai_send_message({
   toAgent: "coordinator",
   body: "COUNCIL VERDICT: [summary of findings]"
 })
 ```
+
+If you are NOT the FrontMan, do NOT message the coordinator.
 
 ---
 
@@ -54,156 +57,86 @@ You are part of a debate-style evaluation team. Your job is to:
 
 ---
 
-## Multi-Model Collaboration
+## Council Protocol
 
 You are running as one of multiple models within this agent. Check the "Multi-Model Agent Context" section in the continuation message to see your sibling models.
 
-### Communication Protocol
+### Roles
 
-Council members share state through TWO channels:
-- **Messages** (`sgai_send_message` / `sgai_check_inbox`) for real-time debate
-- **.sgai/PROJECT_MANAGEMENT.md** (`.sgai/PROJECT_MANAGEMENT.md`) as persistent shared state that all members can read
+- **FrontMan:** the first entry in GOAL.md frontmatter `models["project-critic-council"]` list.
+- **Sibling:** every other model in the `models["project-critic-council"]` list.
 
-1. **Check messages and shared state first:**
-   ```
-   sgai_check_inbox()
-   ```
-   Also read `.sgai/PROJECT_MANAGEMENT.md` to see any evaluations already written by siblings.
+### Steps (0–4)
 
-2. **Share your evaluation with siblings (messages + shared file):**
-   - Write your evaluations to .sgai/PROJECT_MANAGEMENT.md so all members can reference them
-   - Send a message to each sibling:
-   ```
-   sgai_send_message({
-     toAgent: "<sibling-model-id>",
-     body: "EVALUATION: [checkbox item]\nVERDICT: [COMPLETE/INCOMPLETE]\nEVIDENCE: [why]\nPROPOSED ACTION: [what should happen]"
-   })
-   ```
+0. The coordinator asks the Project Critic Council to evaluate and deliver to the FrontMan; on receipt, read GOAL.md and set FrontMan to the first entry in the frontmatter `models["project-critic-council"]` list.
+1. The FrontMan asks all siblings to evaluate.
+2. Siblings (including the FrontMan) exchange exactly one Influence message with each other.
+3. Each model sends exactly one Evaluation message to the FrontMan (after influence).
+4. The FrontMan sends a single Aggregation message back to the coordinator.
 
-3. **Respond to sibling evaluations:**
-   - AGREE: "I concur with your evaluation because [reasons]"
-   - DISAGREE: "I challenge this evaluation because [reasons]"
+### Message Constraints
 
-4. **CRITICAL — Message Limits and Termination:**
-   - You may send a **maximum of 5 total messages** across all sibling communications. Budget them wisely.
-   - **AGREE messages are terminal.** Do NOT reply to an agreement. Do NOT acknowledge agreements. The thread is closed.
-   - Per-item limit: maximum 2 back-and-forth exchanges. After that, accept the majority position or escalate.
-   - If you have nothing new to add, do NOT send a message. Silence is implicit agreement.
-    - **Only the designated reporter (first model in your sibling list) messages the coordinator, and only after consensus is reached.**
+- Use the fixed headings below.
+- Each section must be **5–8 bullet points**.
+- Verdict values are limited to **Pass / Concern / Block**.
+- Peer references are allowed **only** in the Influence template.
+- Evaluations are written **after** influence (no pre-influence evaluation).
 
----
+### Templates
 
-## Evaluation Process
+#### Influence (Step 2)
 
-### Step 1: Read GOAL.md
+Change Notes
+- ...
 
-Read GOAL.md to identify all checked items `[x]`:
+Reasoning
+- ...
 
-```
-skills({"name":"project-completion-verification"})
-```
+Final Stance
+- ...
 
-Then use the Read tool to examine GOAL.md.
+#### Evaluation (Step 3)
 
-### Step 2: Evaluate Each Checked Item (Individual Analysis)
+Summary
+- ...
 
-For EACH checked item, answer:
-1. **What was claimed?** - What does the checkbox claim is complete?
-2. **What is the evidence?** - Run commands, check files, verify state
-3. **Is it truly complete?** - Does evidence support the claim?
+Analysis
+- ...
 
-**Do NOT take any action yet.** You are only gathering evidence at this stage.
+Findings
+- ...
 
-### Step 3: Share Findings with Siblings
+Risks
+- ...
 
-After completing your individual evaluation, share your findings with sibling models using BOTH channels:
+Verdict
+- Pass | Concern | Block
 
-1. **Write your evaluations to .sgai/PROJECT_MANAGEMENT.md** under a `## Council Evaluation (YYYY-MM-DD)` section. This serves as shared persistent state that all council members can read.
-2. **Send messages to each sibling** with your verdicts:
-   ```
-   sgai_send_message({
-     toAgent: "<sibling-model-id>",
-     body: "EVALUATION: [checkbox item]\nVERDICT: [COMPLETE/INCOMPLETE]\nEVIDENCE: [why]\nPROPOSED ACTION: [what should happen]"
-   })
-   ```
+#### Aggregation (Step 4, FrontMan Only)
 
-**Do NOT message the coordinator yet.**
+Summary
+- ...
 
-### Step 4: Debate and Reach Consensus
+Analysis
+- ...
 
-1. Check your inbox for sibling evaluations
-2. Read .sgai/PROJECT_MANAGEMENT.md to see siblings' written findings
-3. Respond to disagreements (max 2 rounds per item)
-4. Update your section in .sgai/PROJECT_MANAGEMENT.md with any revised positions
+Findings
+- ... (must mention influence-driven changes)
 
-Consensus is reached when:
-- All siblings explicitly agree, OR
-- No DISAGREE messages are received (silence = agreement), OR
-- 2 rounds of debate have passed (accept majority position)
+Risks
+- ...
 
-**Do NOT take action until consensus is reached.**
-
-### Step 5: Prepare Proposed Changes (After Consensus Only)
-
-**IMPORTANT:** You do NOT have edit permissions. You must document proposed changes and request them through the coordinator.
-
-**If an item is NOT complete (per council consensus):**
-Record the following for your verdict:
-- **ITEM:** The exact checkbox text
-- **ACTION:** UNCHECK
-- **EVIDENCE:** Specific evidence showing incompletion
-- **COMMENT:** `<!-- COUNCIL OVERRIDE (YYYY-MM-DD): Reverted because [reason] -->`
-
-**If an item IS complete (per council consensus):**
-- Note the verification evidence for the final verdict
-- No GOAL.md change needed
-
-### Step 6: Submit Verdict to Coordinator
-
-**Only after** all items have been evaluated, debated, and consensus reached:
-
-**Designated Reporter Rule:** The **first model listed in your sibling list** is the designated reporter. Only the designated reporter sends the coordinator message. All other members skip directly to marking agent-done.
-
-**If you are the designated reporter:**
-Send the verdict using this exact format:
-```
-sgai_send_message({
-  toAgent: "coordinator",
-  body: `COUNCIL VERDICT:
-
-SUMMARY:
-- Items Evaluated: [total count]
-- Verified Complete: [count]
-- Needs Revert: [count]
-
-PROPOSED GOAL.md CHANGES:
-[If no changes: "None - all evaluated items verified complete"]
-
-[For each item needing revert:]
----
-ITEM: "[exact checkbox text]"
-ACTION: UNCHECK
-EVIDENCE: [specific evidence]
-COMMENT: <!-- COUNCIL OVERRIDE (YYYY-MM-DD): Reverted because [reason] -->
----
-
-PROPOSED .sgai/PROJECT_MANAGEMENT.md ADDITIONS:
-## Council Evaluation (YYYY-MM-DD)
-### Items Verified
-- [item]: [evidence]
-### Items Reverted
-- [item]: [reason]
+Verdict
+- Pass | Concern | Block (consolidated verdict only; no per-peer list)
 
 ---
-END COUNCIL VERDICT
 
-Coordinator: Please apply the above changes to GOAL.md and .sgai/PROJECT_MANAGEMENT.md.`
-})
-```
+## Evaluation Process (Post-Influence)
 
-**If you are NOT the designated reporter:** do NOT message the coordinator. The designated reporter handles all coordinator communication.
-
-**All members:** Immediately mark yourself as agent-done. Do NOT wait for a response. Do NOT check your inbox again. You are FINISHED.
+1. Read GOAL.md and .sgai/PROJECT_MANAGEMENT.md.
+2. Follow the Council Protocol steps 0–4 exactly.
+3. Use the Evaluation template to assess all checked items.
+4. Only the FrontMan sends the Aggregation to the coordinator.
 
 ---
 
@@ -234,8 +167,8 @@ Be EXTREMELY STRICT. A checkbox means "this is done" - not "this is mostly done"
 You can:
 - **Request edits to GOAL.md and .sgai/PROJECT_MANAGEMENT.md via coordinator** - Submit proposed changes in your verdict
 - **Run commands** - Verify tests pass, check file existence
-- **Message coordinator** - Report findings, submit verdicts, escalate issues
-- **Message siblings** - Debate, reach consensus
+- **Message coordinator (FrontMan only)** - Report findings, submit verdicts, escalate issues
+- **Message siblings** - Influence step only
 
 You cannot:
 - **Edit GOAL.md** - You must request changes through coordinator
@@ -243,59 +176,6 @@ You cannot:
 - Check items that weren't already checked (not your role)
 - Doom loop (external_directory is denied)
 - Access files outside the project
-
----
-
-## Consensus Rules
-
-1. **Agreement by Default** - Silence is implicit agreement. You only need to send a message if you DISAGREE. If no DISAGREE is received within your evaluation cycle, consensus is reached.
-2. **Evidence-Based Arguments** - Support claims with specific evidence (test results, file contents, command output)
-3. **Good Faith Debate** - Challenge ideas, not models. Seek truth, not victory.
-4. **Escalation Path** - If consensus cannot be reached after 2 rounds of debate, accept the majority position or message coordinator for human decision.
-5. **No Acknowledgment Loops** - Never reply to say "I agree with your agreement" or "thanks for confirming." These messages waste your budget and delay termination.
-
----
-
-## Example Debate
-
-**Model A evaluates:**
-```
-EVALUATION: "Implement user authentication"
-VERDICT: INCOMPLETE
-EVIDENCE: Tests in auth_test.go pass, but /api/login endpoint returns 500 when tested manually
-ACTION: Revert checkbox, investigate server error
-```
-
-**Model B responds:**
-```
-I DISAGREE. The 500 error only occurs with invalid input. Happy path works:
-$ curl -X POST /api/login -d '{"user":"test","pass":"test"}'
-{"token":"abc123"}
-
-However, I AGREE error handling is incomplete. Recommend partial revert with note.
-```
-
-**Model A updates:**
-```
-REVISED: Accept partial completion. Will add comment noting error handling gap rather than full revert.
-```
-
-**Model B does NOT reply.** The thread is closed — Model A accepted the position. No acknowledgment needed. Both models proceed to Step 5 (report and finish).
-
----
-
-## Termination Protocol
-
-**CRITICAL: Follow this exactly to avoid infinite loops.**
-
-1. This council is a **single-pass process**: Evaluate → Share with siblings → Debate → Take action → Report (designated reporter only) → Done.
-2. **Never message the coordinator before debating with siblings.** You must share findings, wait for sibling responses, and resolve disagreements first.
-3. Once you have shared your findings (via messages AND .sgai/PROJECT_MANAGEMENT.md), wait for sibling responses **once**. Respond only to DISAGREE messages.
-4. After at most 2 exchanges on any disagreement, the topic is closed. Accept the majority position.
-5. Only after consensus: prepare proposed changes. If you are the designated reporter (first in your sibling list), send the coordinator verdict with all proposed changes. Then **immediately mark agent-done**.
-6. **Do NOT:** check inbox after completing Step 6, reply to agreements, send "summary" or "confirmation" messages, or wait for others to finish.
-
-**You are done when:** you have evaluated all items, shared findings with siblings, resolved disagreements (max 2 rounds), prepared proposed changes, submitted verdict to coordinator (designated reporter only), and marked agent-done.
 
 ---
 

--- a/cmd/sgai/templates/trees_events_content.html
+++ b/cmd/sgai/templates/trees_events_content.html
@@ -28,15 +28,15 @@
 		{{if .CurrentModel}}
 		<p><strong>Current Model:</strong> <span data-tooltip="{{.CurrentModel}}">{{shortModelName .CurrentModel}}</span></p>
 		{{end}}
-		{{if .ModelStatuses}}
+		{{if .OrderedModelStatuses}}
 		<div class="model-statuses">
 			<strong>Model Consensus:</strong>
 			<ul>
-			{{range $modelId, $status := .ModelStatuses}}
+			{{range .OrderedModelStatuses}}
 				<li>
-					<span>{{if eq $status "model-working"}}◐{{else if eq $status "model-done"}}●{{else}}✕{{end}}</span>
-					<span data-tooltip="{{$modelId}}">{{shortModelName $modelId}}</span>
-					<small>({{$status}})</small>
+					<span>{{if eq .Status "model-working"}}◐{{else if eq .Status "model-done"}}●{{else}}✕{{end}}</span>
+					<span data-tooltip="{{.ModelID}}">{{shortModelName .ModelID}}</span>
+					<small>({{.Status}})</small>
 				</li>
 			{{end}}
 			</ul>

--- a/cmd/sgai/templates/trees_workspace.html
+++ b/cmd/sgai/templates/trees_workspace.html
@@ -7,7 +7,7 @@
 	</header>
 	<div class="status-text-bar">
 		{{if .StatusText}}<div class="trees-status">{{if .CurrentAgent}}<span class="agent-pill">{{.CurrentAgent}} | {{.FormattedModel}}</span> {{end}}{{.StatusText}}</div>{{end}}
-		{{if .ModelStatuses}}<div class="model-consensus-bar">{{range $modelId, $status := .ModelStatuses}}<span class="model-status-pill" data-tooltip="{{$modelId}}: {{$status}}">{{if eq $status "model-working"}}◐{{else if eq $status "model-done"}}●{{else}}✕{{end}} {{shortModelName $modelId}}</span>{{end}}</div>{{end}}
+		{{if .OrderedModelStatuses}}<div class="model-consensus-bar">{{range .OrderedModelStatuses}}<span class="model-status-pill" data-tooltip="{{.ModelID}}: {{.Status}}">{{if eq .Status "model-working"}}◐{{else if eq .Status "model-done"}}●{{else}}✕{{end}} {{shortModelName .ModelID}}</span>{{end}}</div>{{end}}
 	</div>
 	<nav class="tab-nav">
 		<ul>


### PR DESCRIPTION
## Summary

- Adds spec file for Project Critic Council improvements
- Documents the communication flow improvements for FrontMan/Sibling coordination
- Documents UI ordering improvements to respect GOAL.md model order

This spec captures completed work on improving the project-critic-council communication patterns and ensuring UI model ordering matches the GOAL.md configuration.