### PR TITLE
all: upgrade default model from claude-opus-4-5 to claude-opus-4-6

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ flow: |
   "backend-go-developer" -> "go-readability-reviewer"
   "go-readability-reviewer" -> "stpa-analyst"
 models:
-  "coordinator": "anthropic/claude-opus-4-5"
+  "coordinator": "anthropic/claude-opus-4-6"
   "backend-go-developer": "anthropic/claude-sonnet-4-5"
 interactive: yes
 ---

--- a/cmd/sgai/GOAL.example.md
+++ b/cmd/sgai/GOAL.example.md
@@ -7,13 +7,13 @@ flow: |
   "htmx-picocss-frontend-developer" -> "htmx-picocss-frontend-reviewer"
   "htmx-picocss-frontend-reviewer" -> "stpa-analyst"
 models:
-  "coordinator": "anthropic/claude-opus-4-5 (max)"
-  "backend-go-developer": "anthropic/claude-opus-4-5"
-  "go-readability-reviewer": "anthropic/claude-opus-4-5"
-  "general-purpose": "anthropic/claude-opus-4-5"
+  "coordinator": "anthropic/claude-opus-4-6 (max)"
+  "backend-go-developer": "anthropic/claude-opus-4-6"
+  "go-readability-reviewer": "anthropic/claude-opus-4-6"
+  "general-purpose": "anthropic/claude-opus-4-6"
   "htmx-picocss-frontend-developer": "anthropic/claude-sonnet-4-5"
-  "htmx-picocss-frontend-reviewer": "anthropic/claude-opus-4-5"
-  "stpa-analyst": "anthropic/claude-opus-4-5"
+  "htmx-picocss-frontend-reviewer": "anthropic/claude-opus-4-6"
+  "stpa-analyst": "anthropic/claude-opus-4-6"
 interactive: yes
 ---
 

--- a/cmd/sgai/compose_wizard.go
+++ b/cmd/sgai/compose_wizard.go
@@ -19,7 +19,7 @@ type workflowTemplate struct {
 	Interactive string
 }
 
-const defaultAgentModel = "anthropic/claude-opus-4-5"
+const defaultAgentModel = "anthropic/claude-opus-4-6"
 
 var workflowTemplates = []workflowTemplate{
 	{

--- a/cmd/sgai/config_test.go
+++ b/cmd/sgai/config_test.go
@@ -24,7 +24,7 @@ func TestLoadProjectConfigValidJSON(t *testing.T) {
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, configFileName)
 
-	content := `{"defaultModel": "anthropic/claude-opus-4-5"}`
+	content := `{"defaultModel": "anthropic/claude-opus-4-6"}`
 	if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
 		t.Fatal(err)
 	}
@@ -35,8 +35,8 @@ func TestLoadProjectConfigValidJSON(t *testing.T) {
 		t.Fatalf("loadProjectConfig() error = %v; want nil", err)
 	case config == nil:
 		t.Fatal("loadProjectConfig() = nil; want non-nil config")
-	case config.DefaultModel != "anthropic/claude-opus-4-5":
-		t.Errorf("config.DefaultModel = %q; want %q", config.DefaultModel, "anthropic/claude-opus-4-5")
+	case config.DefaultModel != "anthropic/claude-opus-4-6":
+		t.Errorf("config.DefaultModel = %q; want %q", config.DefaultModel, "anthropic/claude-opus-4-6")
 	}
 }
 
@@ -119,7 +119,7 @@ func TestApplyConfigDefaultsWithEmptyDefaultModel(t *testing.T) {
 }
 
 func TestApplyConfigDefaultsAppliesDefault(t *testing.T) {
-	config := &projectConfig{DefaultModel: "anthropic/claude-opus-4-5"}
+	config := &projectConfig{DefaultModel: "anthropic/claude-opus-4-6"}
 	metadata := GoalMetadata{
 		Models: map[string]any{
 			"agent1": "",
@@ -129,8 +129,8 @@ func TestApplyConfigDefaultsAppliesDefault(t *testing.T) {
 	applyConfigDefaults(config, &metadata)
 
 	models1 := getModelsForAgent(metadata.Models, "agent1")
-	if len(models1) != 1 || models1[0] != "anthropic/claude-opus-4-5" {
-		t.Errorf("agent1 models = %v; want [anthropic/claude-opus-4-5]", models1)
+	if len(models1) != 1 || models1[0] != "anthropic/claude-opus-4-6" {
+		t.Errorf("agent1 models = %v; want [anthropic/claude-opus-4-6]", models1)
 	}
 	models2 := getModelsForAgent(metadata.Models, "agent2")
 	if len(models2) != 1 || models2[0] != "openai/gpt-4" {
@@ -139,7 +139,7 @@ func TestApplyConfigDefaultsAppliesDefault(t *testing.T) {
 }
 
 func TestApplyConfigDefaultsNilModelsMap(t *testing.T) {
-	config := &projectConfig{DefaultModel: "anthropic/claude-opus-4-5"}
+	config := &projectConfig{DefaultModel: "anthropic/claude-opus-4-6"}
 	metadata := GoalMetadata{}
 
 	applyConfigDefaults(config, &metadata)

--- a/cmd/sgai/main_test.go
+++ b/cmd/sgai/main_test.go
@@ -17,20 +17,20 @@ func TestParseModelAndVariant(t *testing.T) {
 	}{
 		{
 			name:        "noVariant",
-			modelSpec:   "anthropic/claude-opus-4-5",
-			wantModel:   "anthropic/claude-opus-4-5",
+			modelSpec:   "anthropic/claude-opus-4-6",
+			wantModel:   "anthropic/claude-opus-4-6",
 			wantVariant: "",
 		},
 		{
 			name:        "withSpaceBeforeParenthesis",
-			modelSpec:   "anthropic/claude-opus-4-5 (high)",
-			wantModel:   "anthropic/claude-opus-4-5",
+			modelSpec:   "anthropic/claude-opus-4-6 (high)",
+			wantModel:   "anthropic/claude-opus-4-6",
 			wantVariant: "high",
 		},
 		{
 			name:        "noSpaceBeforeParenthesis",
-			modelSpec:   "anthropic/claude-opus-4-5(banana)",
-			wantModel:   "anthropic/claude-opus-4-5",
+			modelSpec:   "anthropic/claude-opus-4-6(banana)",
+			wantModel:   "anthropic/claude-opus-4-6",
 			wantVariant: "banana",
 		},
 		{
@@ -47,14 +47,14 @@ func TestParseModelAndVariant(t *testing.T) {
 		},
 		{
 			name:        "multipleSpacesBeforeParenthesis",
-			modelSpec:   "anthropic/claude-opus-4-5  (high)",
-			wantModel:   "anthropic/claude-opus-4-5",
+			modelSpec:   "anthropic/claude-opus-4-6  (high)",
+			wantModel:   "anthropic/claude-opus-4-6",
 			wantVariant: "high",
 		},
 		{
 			name:        "variantWithSpaces",
-			modelSpec:   "anthropic/claude-opus-4-5 (high quality)",
-			wantModel:   "anthropic/claude-opus-4-5",
+			modelSpec:   "anthropic/claude-opus-4-6 (high quality)",
+			wantModel:   "anthropic/claude-opus-4-6",
 			wantVariant: "high quality",
 		},
 	}
@@ -80,7 +80,7 @@ func TestTryReloadGoalMetadata(t *testing.T) {
 		newContent := `---
 interactive: "auto"
 models:
-  coordinator: anthropic/claude-opus-4-5
+  coordinator: anthropic/claude-opus-4-6
 completionGateScript: make test
 ---
 # New Goal
@@ -101,8 +101,8 @@ completionGateScript: make test
 			t.Errorf("tryReloadGoalMetadata() Interactive = %q; want %q", got.Interactive, "auto")
 		}
 		models := getModelsForAgent(got.Models, "coordinator")
-		if len(models) != 1 || models[0] != "anthropic/claude-opus-4-5" {
-			t.Errorf("tryReloadGoalMetadata() Models[coordinator] = %v; want [anthropic/claude-opus-4-5]", models)
+		if len(models) != 1 || models[0] != "anthropic/claude-opus-4-6" {
+			t.Errorf("tryReloadGoalMetadata() Models[coordinator] = %v; want [anthropic/claude-opus-4-6]", models)
 		}
 		if got.CompletionGateScript != "make test" {
 			t.Errorf("tryReloadGoalMetadata() CompletionGateScript = %q; want %q", got.CompletionGateScript, "make test")

--- a/cmd/sgai/multimodel_test.go
+++ b/cmd/sgai/multimodel_test.go
@@ -85,14 +85,14 @@ func TestFormatModelID(t *testing.T) {
 		{
 			name:      "simpleModel",
 			agent:     "backend-go-developer",
-			modelSpec: "anthropic/claude-opus-4-5",
-			want:      "backend-go-developer:anthropic/claude-opus-4-5",
+			modelSpec: "anthropic/claude-opus-4-6",
+			want:      "backend-go-developer:anthropic/claude-opus-4-6",
 		},
 		{
 			name:      "modelWithVariant",
 			agent:     "backend-go-developer",
-			modelSpec: "anthropic/claude-opus-4-5 (max)",
-			want:      "backend-go-developer:anthropic/claude-opus-4-5 (max)",
+			modelSpec: "anthropic/claude-opus-4-6 (max)",
+			want:      "backend-go-developer:anthropic/claude-opus-4-6 (max)",
 		},
 		{
 			name:      "coordinator",
@@ -120,12 +120,12 @@ func TestExtractAgentFromModelID(t *testing.T) {
 	}{
 		{
 			name:    "standardModelID",
-			modelID: "backend-go-developer:anthropic/claude-opus-4-5",
+			modelID: "backend-go-developer:anthropic/claude-opus-4-6",
 			want:    "backend-go-developer",
 		},
 		{
 			name:    "modelIDWithVariant",
-			modelID: "backend-go-developer:anthropic/claude-opus-4-5 (max)",
+			modelID: "backend-go-developer:anthropic/claude-opus-4-6 (max)",
 			want:    "backend-go-developer",
 		},
 		{
@@ -503,12 +503,12 @@ func TestExtractAgentNameFromTarget(t *testing.T) {
 		},
 		{
 			name:   "modelID",
-			target: "backend-go-developer:anthropic/claude-opus-4-5",
+			target: "backend-go-developer:anthropic/claude-opus-4-6",
 			want:   "backend-go-developer",
 		},
 		{
 			name:   "modelIDWithVariant",
-			target: "backend-go-developer:anthropic/claude-opus-4-5 (max)",
+			target: "backend-go-developer:anthropic/claude-opus-4-6 (max)",
 			want:   "backend-go-developer",
 		},
 		{
@@ -550,16 +550,16 @@ func TestMessageMatchesRecipient(t *testing.T) {
 		},
 		{
 			name:         "matchesModelID",
-			msg:          state.Message{ToAgent: "backend-go-developer:anthropic/claude-opus-4-5"},
+			msg:          state.Message{ToAgent: "backend-go-developer:anthropic/claude-opus-4-6"},
 			currentAgent: "backend-go-developer",
-			currentModel: "backend-go-developer:anthropic/claude-opus-4-5",
+			currentModel: "backend-go-developer:anthropic/claude-opus-4-6",
 			want:         true,
 		},
 		{
 			name:         "matchesAgentWhenModelSet",
 			msg:          state.Message{ToAgent: "backend-go-developer"},
 			currentAgent: "backend-go-developer",
-			currentModel: "backend-go-developer:anthropic/claude-opus-4-5",
+			currentModel: "backend-go-developer:anthropic/claude-opus-4-6",
 			want:         true,
 		},
 		{
@@ -573,12 +573,12 @@ func TestMessageMatchesRecipient(t *testing.T) {
 			name:         "noMatchDifferentModel",
 			msg:          state.Message{ToAgent: "backend-go-developer:anthropic/claude-sonnet-4-5"},
 			currentAgent: "backend-go-developer",
-			currentModel: "backend-go-developer:anthropic/claude-opus-4-5",
+			currentModel: "backend-go-developer:anthropic/claude-opus-4-6",
 			want:         false,
 		},
 		{
 			name:         "modelMessageWithoutCurrentModel",
-			msg:          state.Message{ToAgent: "backend-go-developer:anthropic/claude-opus-4-5"},
+			msg:          state.Message{ToAgent: "backend-go-developer:anthropic/claude-opus-4-6"},
 			currentAgent: "backend-go-developer",
 			currentModel: "",
 			want:         false,
@@ -612,16 +612,16 @@ func TestMessageMatchesSender(t *testing.T) {
 		},
 		{
 			name:         "matchesModelID",
-			msg:          state.Message{FromAgent: "backend-go-developer:anthropic/claude-opus-4-5"},
+			msg:          state.Message{FromAgent: "backend-go-developer:anthropic/claude-opus-4-6"},
 			currentAgent: "backend-go-developer",
-			currentModel: "backend-go-developer:anthropic/claude-opus-4-5",
+			currentModel: "backend-go-developer:anthropic/claude-opus-4-6",
 			want:         true,
 		},
 		{
 			name:         "matchesAgentWhenModelSet",
 			msg:          state.Message{FromAgent: "backend-go-developer"},
 			currentAgent: "backend-go-developer",
-			currentModel: "backend-go-developer:anthropic/claude-opus-4-5",
+			currentModel: "backend-go-developer:anthropic/claude-opus-4-6",
 			want:         true,
 		},
 		{
@@ -635,7 +635,7 @@ func TestMessageMatchesSender(t *testing.T) {
 			name:         "noMatchDifferentModel",
 			msg:          state.Message{FromAgent: "backend-go-developer:anthropic/claude-sonnet-4-5"},
 			currentAgent: "backend-go-developer",
-			currentModel: "backend-go-developer:anthropic/claude-opus-4-5",
+			currentModel: "backend-go-developer:anthropic/claude-opus-4-6",
 			want:         false,
 		},
 	}
@@ -701,13 +701,13 @@ func TestExtractModelShortName(t *testing.T) {
 	}{
 		{
 			name:    "standardModelID",
-			modelID: "backend-go-developer:anthropic/claude-opus-4-5",
-			want:    "anthropic/claude-opus-4-5",
+			modelID: "backend-go-developer:anthropic/claude-opus-4-6",
+			want:    "anthropic/claude-opus-4-6",
 		},
 		{
 			name:    "modelIDWithVariant",
-			modelID: "backend-go-developer:anthropic/claude-opus-4-5 (max)",
-			want:    "anthropic/claude-opus-4-5 (max)",
+			modelID: "backend-go-developer:anthropic/claude-opus-4-6 (max)",
+			want:    "anthropic/claude-opus-4-6 (max)",
 		},
 		{
 			name:    "noColon",

--- a/cmd/sgai/skel/.sgai/agent/coordinator.md
+++ b/cmd/sgai/skel/.sgai/agent/coordinator.md
@@ -1,5 +1,5 @@
 ---
-model: "anthropic/claude-opus-4-5 (max)"
+model: "anthropic/claude-opus-4-6 (max)"
 description: Coordinates the work flow.
 mode: primary
 permission:

--- a/cmd/sgai/skel/.sgai/agent/project-critic-council.md
+++ b/cmd/sgai/skel/.sgai/agent/project-critic-council.md
@@ -1,5 +1,5 @@
 ---
-model: "anthropic/claude-opus-4-5 (max)"
+model: "anthropic/claude-opus-4-6 (max)"
 description: Multi-model council that strictly evaluates whether GOAL.md items are truly complete. Requests changes through coordinator.
 mode: primary
 permission:

--- a/cmd/sgai/skel/.sgai/opencode.jsonc
+++ b/cmd/sgai/skel/.sgai/opencode.jsonc
@@ -1,5 +1,6 @@
 {
         "$schema": "https://opencode.ai/config.json",
+        "model": "anthropic/claude-opus-4-6",
         "mcp": {
                 "playwright": {
                         "type": "local",

--- a/cmd/sgai/skel/.sgai/skills/product-design/goal-md-composer/REFERENCE.md
+++ b/cmd/sgai/skel/.sgai/skills/product-design/goal-md-composer/REFERENCE.md
@@ -73,10 +73,10 @@ Per-agent model assignments. Supports variant syntax in parentheses.
 **Example:**
 ```yaml
 models:
-  "coordinator": "anthropic/claude-opus-4-5 (max)"
-  "backend-go-developer": "anthropic/claude-opus-4-5"
-  "go-readability-reviewer": "anthropic/claude-opus-4-5"
-  "general-purpose": "anthropic/claude-opus-4-5"
+  "coordinator": "anthropic/claude-opus-4-6 (max)"
+  "backend-go-developer": "anthropic/claude-opus-4-6"
+  "go-readability-reviewer": "anthropic/claude-opus-4-6"
+  "general-purpose": "anthropic/claude-opus-4-6"
   "htmx-picocss-frontend-developer": "anthropic/claude-sonnet-4-5"
 ```
 
@@ -261,8 +261,8 @@ The `general-purpose` agent does not have a dedicated reviewer since it handles 
 
 | Model | Variant | Cost | Description |
 |-------|---------|------|-------------|
-| `anthropic/claude-opus-4-5` | - | $$$$ | Most capable, best reasoning |
-| `anthropic/claude-opus-4-5` | `(max)` | $$$$ | Extended thinking for complex tasks |
+| `anthropic/claude-opus-4-6` | - | $$$$ | Most capable, best reasoning |
+| `anthropic/claude-opus-4-6` | `(max)` | $$$$ | Extended thinking for complex tasks |
 | `anthropic/claude-sonnet-4-5` | - | $$$ | Balanced capability and cost |
 | `anthropic/claude-sonnet-4-5` | `(max)` | $$$ | Extended thinking variant |
 
@@ -285,13 +285,13 @@ The `general-purpose` agent does not have a dedicated reviewer since it handles 
 
 | Agent Type | Recommended Model | Reason |
 |------------|-------------------|--------|
-| Coordinator | `anthropic/claude-opus-4-5 (max)` | Needs best reasoning for orchestration |
-| Go Developer | `anthropic/claude-opus-4-5` | Complex code generation |
-| Go Reviewer | `anthropic/claude-opus-4-5` | Thorough code analysis |
+| Coordinator | `anthropic/claude-opus-4-6 (max)` | Needs best reasoning for orchestration |
+| Go Developer | `anthropic/claude-opus-4-6` | Complex code generation |
+| Go Reviewer | `anthropic/claude-opus-4-6` | Thorough code analysis |
 | Frontend Dev | `anthropic/claude-sonnet-4-5` | Good balance for UI work |
-| Frontend Reviewer | `anthropic/claude-opus-4-5` | Detailed visual analysis |
-| General Purpose | `anthropic/claude-opus-4-5` | Varied complex tasks |
-| STPA Analyst | `anthropic/claude-opus-4-5` | Safety-critical analysis |
+| Frontend Reviewer | `anthropic/claude-opus-4-6` | Detailed visual analysis |
+| General Purpose | `anthropic/claude-opus-4-6` | Varied complex tasks |
+| STPA Analyst | `anthropic/claude-opus-4-6` | Safety-critical analysis |
 | Utility Agents | `anthropic/claude-sonnet-4-5` | Cost-effective for simple tasks |
 
 ---
@@ -305,9 +305,9 @@ The `general-purpose` agent does not have a dedicated reviewer since it handles 
 flow: |
   "backend-go-developer" -> "go-readability-reviewer"
 models:
-  "coordinator": "anthropic/claude-opus-4-5 (max)"
-  "backend-go-developer": "anthropic/claude-opus-4-5"
-  "go-readability-reviewer": "anthropic/claude-opus-4-5"
+  "coordinator": "anthropic/claude-opus-4-6 (max)"
+  "backend-go-developer": "anthropic/claude-opus-4-6"
+  "go-readability-reviewer": "anthropic/claude-opus-4-6"
 interactive: yes
 completionGateScript: go test ./...
 ---
@@ -345,13 +345,13 @@ flow: |
   "htmx-picocss-frontend-reviewer" -> "stpa-analyst"
   "general-purpose" -> "stpa-analyst"
 models:
-  "coordinator": "anthropic/claude-opus-4-5 (max)"
-  "backend-go-developer": "anthropic/claude-opus-4-5"
-  "go-readability-reviewer": "anthropic/claude-opus-4-5"
+  "coordinator": "anthropic/claude-opus-4-6 (max)"
+  "backend-go-developer": "anthropic/claude-opus-4-6"
+  "go-readability-reviewer": "anthropic/claude-opus-4-6"
   "htmx-picocss-frontend-developer": "anthropic/claude-sonnet-4-5"
-  "htmx-picocss-frontend-reviewer": "anthropic/claude-opus-4-5"
-  "general-purpose": "anthropic/claude-opus-4-5"
-  "stpa-analyst": "anthropic/claude-opus-4-5"
+  "htmx-picocss-frontend-reviewer": "anthropic/claude-opus-4-6"
+  "general-purpose": "anthropic/claude-opus-4-6"
+  "stpa-analyst": "anthropic/claude-opus-4-6"
 interactive: yes
 ---
 
@@ -392,8 +392,8 @@ Build a web-based task management application for small teams.
 flow: |
   "general-purpose"
 models:
-  "coordinator": "anthropic/claude-opus-4-5 (max)"
-  "general-purpose": "anthropic/claude-opus-4-5"
+  "coordinator": "anthropic/claude-opus-4-6 (max)"
+  "general-purpose": "anthropic/claude-opus-4-6"
 interactive: yes
 ---
 
@@ -424,9 +424,9 @@ Research and document best practices for REST API versioning.
 flow: |
   "shell-script-coder" -> "shell-script-reviewer"
 models:
-  "coordinator": "anthropic/claude-opus-4-5 (max)"
-  "shell-script-coder": "anthropic/claude-opus-4-5"
-  "shell-script-reviewer": "anthropic/claude-opus-4-5"
+  "coordinator": "anthropic/claude-opus-4-6 (max)"
+  "shell-script-coder": "anthropic/claude-opus-4-6"
+  "shell-script-reviewer": "anthropic/claude-opus-4-6"
 interactive: yes
 completionGateScript: shellcheck scripts/*.sh
 ---

--- a/cmd/sgai/skel/.sgai/skills/product-design/goal-md-composer/SKILL.md
+++ b/cmd/sgai/skel/.sgai/skills/product-design/goal-md-composer/SKILL.md
@@ -118,27 +118,27 @@ flow: |
 Configure per-agent model assignments.
 
 **Available models (see REFERENCE.md for full list):**
-- `anthropic/claude-opus-4-5` - Most capable, highest cost ($$$$)
-- `anthropic/claude-opus-4-5 (max)` - Extended thinking variant
+- `anthropic/claude-opus-4-6` - Most capable, highest cost ($$$$)
+- `anthropic/claude-opus-4-6 (max)` - Extended thinking variant
 - `anthropic/claude-sonnet-4-5` - Balanced capability/cost ($$$)
 - `anthropic/claude-sonnet-4-5 (max)` - Extended thinking variant
 - `google/gemini-2.0-flash-001` - Fast, lower cost ($$)
 - `openai/gpt-4.1` - Alternative high-capability model ($$$)
 
 **Default recommendations:**
-- `coordinator`: `anthropic/claude-opus-4-5 (max)` (always use strongest for coordination)
-- Development agents: `anthropic/claude-opus-4-5` (complex reasoning)
-- Review agents: `anthropic/claude-opus-4-5` (thorough analysis)
+- `coordinator`: `anthropic/claude-opus-4-6 (max)` (always use strongest for coordination)
+- Development agents: `anthropic/claude-opus-4-6` (complex reasoning)
+- Review agents: `anthropic/claude-opus-4-6` (thorough analysis)
 - Frontend agents: `anthropic/claude-sonnet-4-5` (good balance)
 - Utility agents: `anthropic/claude-sonnet-4-5` (cost-effective)
 
 **Present configuration:**
 ```yaml
 models:
-  "coordinator": "anthropic/claude-opus-4-5 (max)"
-  "backend-go-developer": "anthropic/claude-opus-4-5"
-  "go-readability-reviewer": "anthropic/claude-opus-4-5"
-  "general-purpose": "anthropic/claude-opus-4-5"
+  "coordinator": "anthropic/claude-opus-4-6 (max)"
+  "backend-go-developer": "anthropic/claude-opus-4-6"
+  "go-readability-reviewer": "anthropic/claude-opus-4-6"
+  "general-purpose": "anthropic/claude-opus-4-6"
 ```
 
 **Ask:** "Do you want to adjust any model assignments? (e.g., use a faster/cheaper model for certain agents)"
@@ -285,11 +285,11 @@ flow: |
   "go-readability-reviewer" -> "stpa-analyst"
   "general-purpose" -> "stpa-analyst"
 models:
-  "coordinator": "anthropic/claude-opus-4-5 (max)"
-  "backend-go-developer": "anthropic/claude-opus-4-5"
-  "go-readability-reviewer": "anthropic/claude-opus-4-5"
-  "general-purpose": "anthropic/claude-opus-4-5"
-  "stpa-analyst": "anthropic/claude-opus-4-5"
+  "coordinator": "anthropic/claude-opus-4-6 (max)"
+  "backend-go-developer": "anthropic/claude-opus-4-6"
+  "go-readability-reviewer": "anthropic/claude-opus-4-6"
+  "general-purpose": "anthropic/claude-opus-4-6"
+  "stpa-analyst": "anthropic/claude-opus-4-6"
 interactive: yes
 ---
 

--- a/opencode.json
+++ b/opencode.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://opencode.ai/config.json",
-  "model": "anthropic/claude-opus-4-5",
+  "model": "anthropic/claude-opus-4-6",
   "mcp": {
     "playwright": {
       "type": "local",


### PR DESCRIPTION
## Summary

- Upgrade all model references from `anthropic/claude-opus-4-5` to `anthropic/claude-opus-4-6` across the codebase
- Updates default model constant in `compose_wizard.go`, agent configs (coordinator, project-critic-council), GOAL example, REFERENCE/SKILL docs, opencode.json, and README
- Updates all corresponding test fixtures in `config_test.go`, `main_test.go`, and `multimodel_test.go`
