### PR TITLE
cmd/sgai: add support to pin workspaces

### DIFF
--- a/GOALS/2026_02_06_pin_projects.md
+++ b/GOALS/2026_02_06_pin_projects.md
@@ -1,0 +1,27 @@
+---
+flow: |
+  "backend-go-developer" -> "go-readability-reviewer"
+  "backend-go-developer" -> "stpa-analyst"
+  "go-readability-reviewer" -> "stpa-analyst"
+  "general-purpose" -> "stpa-analyst"
+  "htmx-picocss-frontend-developer" -> "htmx-picocss-frontend-reviewer"
+  "htmx-picocss-frontend-reviewer" -> "stpa-analyst"
+  "project-critic-council"
+  "skill-writer"
+models:
+  "coordinator": "anthropic/claude-opus-4-6 (max)"
+  "backend-go-developer": "anthropic/claude-opus-4-6"
+  "go-readability-reviewer": "anthropic/claude-opus-4-6"
+  "general-purpose": "anthropic/claude-opus-4-6"
+  "htmx-picocss-frontend-developer": "anthropic/claude-opus-4-6"
+  "htmx-picocss-frontend-reviewer": "anthropic/claude-opus-4-6"
+  "stpa-analyst": "anthropic/claude-opus-4-6"
+  "project-critic-council": ["anthropic/claude-opus-4-6", "openai/gpt-5.2", "openai/gpt-5.2-codex"]
+  "skill-writer": "anthropic/claude-opus-4-6 (max)"
+interactive: yes
+completionGateScript: make test
+---
+
+- [x] I want to be able to pin projects in the left tree
+  - [x] the ones I pin, should be permanent in the In Progress session
+  - [x] Pinning / Unpinning must be done from the button bar in the workspace page

--- a/cmd/sgai/templates/trees.html
+++ b/cmd/sgai/templates/trees.html
@@ -1241,6 +1241,12 @@
 			font-size: 0.6rem;
 			vertical-align: middle;
 		}
+		.workspace-pinned {
+			margin-left: 0.25rem;
+			font-size: 0.7rem;
+			vertical-align: middle;
+			opacity: 0.7;
+		}
 
 		/* Tree panel footer - fixed button at bottom */
 		.tree-panel-footer-spacer {

--- a/cmd/sgai/templates/trees_actions.html
+++ b/cmd/sgai/templates/trees_actions.html
@@ -52,6 +52,9 @@
 	<a href="/workspaces/{{.DirName}}/skills" role="button" class="action-btn outline">Skills</a>
 	<a href="/workspaces/{{.DirName}}/snippets" role="button" class="action-btn outline">Snippets</a>
 	<a href="/workspaces/{{.DirName}}/agents" role="button" class="action-btn outline">Agents</a>
+	<form action="/workspaces/{{.DirName}}/toggle-pin" method="post">
+		<button type="submit" class="action-btn outline">{{if .Pinned}}Unpin{{else}}Pin{{end}}</button>
+	</form>
 	{{if .NeedsInput}}
 	<a href="/respond?dir={{.Directory}}&returnTo={{.ReturnTo}}" role="button" class="action-btn attention">Respond to Agent</a>
 	{{end}}

--- a/cmd/sgai/templates/trees_content.html
+++ b/cmd/sgai/templates/trees_content.html
@@ -2,7 +2,7 @@
 
 {{define "attention-indicator"}}{{if .NeedsInput}}<span class="workspace-attention" title="Needs input">●</span>{{end}}{{end}}
 
-{{define "workspace-indicators"}}{{if .Running}}<span class="workspace-spinner" title="Running">⟳</span>{{end}}{{template "attention-indicator" .}}{{end}}
+{{define "workspace-indicators"}}{{if .Pinned}}<span class="workspace-pinned" data-tooltip="Pinned">📌</span>{{end}}{{if .Running}}<span class="workspace-spinner" title="Running">⟳</span>{{end}}{{template "attention-indicator" .}}{{end}}
 
 <div class="tree-panel" id="tree-panel-content">
 {{if .InProgressWorkspaces}}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/sandgardenhq/sgai
 go 1.25.7
 
 require (
+	github.com/adrg/xdg v0.5.3
 	github.com/google/jsonschema-go v0.4.2
 	github.com/mactaggart/gographviz v0.0.0-20250815040658-9ffd0326c418
 	github.com/modelcontextprotocol/go-sdk v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,7 @@
+github.com/adrg/xdg v0.5.3 h1:xRnxJXne7+oWDatRhR1JLnvuccuIeCoBu2rtuLqQB78=
+github.com/adrg/xdg v0.5.3/go.mod h1:nlTsY+NNiCBGCK2tpm09vRqfVzrc2fLmXGpBLF0zlTQ=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/golang-jwt/jwt/v5 v5.2.2 h1:Rl4B7itRWVtYIHFrSNd7vhTiz9UpLdi6gZhZ3wEeDy8=
 github.com/golang-jwt/jwt/v5 v5.2.2/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
@@ -8,6 +12,10 @@ github.com/mactaggart/gographviz v0.0.0-20250815040658-9ffd0326c418 h1:aUW3Z/6i8
 github.com/mactaggart/gographviz v0.0.0-20250815040658-9ffd0326c418/go.mod h1:hsTCrJORC++1ALA6HowECDkzofwRJF7nq7PDB9FfeXg=
 github.com/modelcontextprotocol/go-sdk v1.2.0 h1:Y23co09300CEk8iZ/tMxIX1dVmKZkzoSBZOpJwUnc/s=
 github.com/modelcontextprotocol/go-sdk v1.2.0/go.mod h1:6fM3LCm3yV7pAs8isnKLn07oKtB0MP9LHd3DfAcKw10=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
 github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 github.com/yuin/goldmark v1.7.16 h1:n+CJdUxaFMiDUNnWC3dMWCIQJSkxH4uz3ZwQBkAlVNE=
@@ -28,5 +36,7 @@ golang.org/x/tools v0.41.0 h1:a9b8iMweWG+S0OBnlU36rzLp20z1Rp10w+IY2czHTQc=
 golang.org/x/tools v0.41.0/go.mod h1:XSY6eDqxVNiYgezAVqqCeihT4j1U2CCsqvH3WhQpnlg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 sigs.k8s.io/yaml v1.6.0 h1:G8fkbMSAFqgEFgh4b1wmtzDnioxFCUgTZhlbj5P9QYs=
 sigs.k8s.io/yaml v1.6.0/go.mod h1:796bPqUfzR/0jLAl6XjHl3Ck7MiyVv8dbTdyT3/pMf4=


### PR DESCRIPTION
## Summary

- Add ability to pin/unpin projects in the workspace view
- Pinned projects persist across server restarts (stored in `~/.config/sgai/pinned.json`)
- Pinned projects always appear in the "In Progress" section regardless of running state
- Pin/Unpin toggle button added to the workspace action bar
- Visual indicator (📌) shown for pinned workspaces in the tree view