### PR TITLE
cmd/sgai: simplify forked repository logic

### DIFF
--- a/GOALS/2026_02_07_fix_forked_mode.md
+++ b/GOALS/2026_02_07_fix_forked_mode.md
@@ -1,0 +1,42 @@
+---
+flow: |
+  "backend-go-developer" -> "go-readability-reviewer"
+  "backend-go-developer" -> "stpa-analyst"
+  "go-readability-reviewer" -> "stpa-analyst"
+  "general-purpose" -> "stpa-analyst"
+  "htmx-picocss-frontend-developer" -> "htmx-picocss-frontend-reviewer"
+  "htmx-picocss-frontend-reviewer" -> "stpa-analyst"
+  "project-critic-council"
+  "skill-writer"
+models:
+  "coordinator": "anthropic/claude-opus-4-6 (max)"
+  "backend-go-developer": "anthropic/claude-opus-4-6"
+  "go-readability-reviewer": "anthropic/claude-opus-4-6"
+  "general-purpose": "anthropic/claude-opus-4-6"
+  "htmx-picocss-frontend-developer": "anthropic/claude-opus-4-6"
+  "htmx-picocss-frontend-reviewer": "anthropic/claude-opus-4-6"
+  "stpa-analyst": "anthropic/claude-opus-4-6"
+  "project-critic-council": ["anthropic/claude-opus-4-6", "openai/gpt-5.2", "openai/gpt-5.2-codex"]
+  "skill-writer": "anthropic/claude-opus-4-6 (max)"
+interactive: yes
+completionGateScript: make test
+---
+
+Terminology:
+- Standalone Repository: a repository that has only _one_ `jj workspace` -- itself.
+- Root Repository: a repository that has more than one `jj workspace`, and it is the root (it is the one in which `.jj/repo` is a directory and not a file)
+- Forked Repository: a repository that is part of a `jj workspace, and it is not the root (it is the one in which `.jj/repo` is a text file, whose content points to the parent).
+
+- Repository Mode: is when a repository is served by SGAI in a way that it can actually run software.
+- Forked Mode: is when a root repository has at least one child, it displays the fork (dashboard-style) mode.
+**CRITICAL** when a Root Repository run out of children, it must revert back from Forked Mode to Repository Mode.
+
+Expected Behaviors:
+- [x] Standalone Repositories
+    - [x] Must always display the Fork Button
+    - [x] Must always use the Repository Mode
+- [x] Root Repositories
+    - [x] Must always display the Fork Button
+    - [x] Must always use the Forked Mode
+    - [x] Forked Repositories of a Root Repository must NEVER show the Fork Button
+    - [x] Forked Repositories of a Root Repository must ALWAYS be displayed in Repository Mode

--- a/cmd/sgai/main.go
+++ b/cmd/sgai/main.go
@@ -1407,7 +1407,7 @@ func dotSGAILinePresent(content []byte) bool {
 }
 
 func ensureJJ(dir string) {
-	if isForkWorkspace(dir) {
+	if classifyWorkspace(dir) == workspaceFork {
 		return
 	}
 	cmd := exec.Command("jj", "status")
@@ -1469,7 +1469,7 @@ func initializeWorkspaceDir(dir string) error {
 }
 
 func initializeJJ(dir string) error {
-	if isForkWorkspace(dir) {
+	if classifyWorkspace(dir) == workspaceFork {
 		return nil
 	}
 	cmd := exec.Command("jj", "status")

--- a/cmd/sgai/serve_test.go
+++ b/cmd/sgai/serve_test.go
@@ -1852,11 +1852,11 @@ func TestBuildWorkspacePageData(t *testing.T) {
 	})
 }
 
-func TestIsRootWorkspace(t *testing.T) {
+func TestClassifyWorkspace(t *testing.T) {
 	t.Run("noJJRepo", func(t *testing.T) {
 		dir := t.TempDir()
-		if isRootWorkspace(dir) {
-			t.Error("isRootWorkspace() = true; want false for directory without .jj/repo")
+		if got := classifyWorkspace(dir); got != workspaceStandalone {
+			t.Errorf("classifyWorkspace() = %q; want %q for directory without .jj/repo", got, workspaceStandalone)
 		}
 	})
 
@@ -1868,8 +1868,8 @@ func TestIsRootWorkspace(t *testing.T) {
 		if err := os.WriteFile(filepath.Join(dir, ".jj", "repo"), []byte("/some/path"), 0644); err != nil {
 			t.Fatalf("failed to create repo file: %v", err)
 		}
-		if isRootWorkspace(dir) {
-			t.Error("isRootWorkspace() = true; want false for .jj/repo as file")
+		if got := classifyWorkspace(dir); got != workspaceFork {
+			t.Errorf("classifyWorkspace() = %q; want %q for .jj/repo as file", got, workspaceFork)
 		}
 	})
 
@@ -1880,8 +1880,8 @@ func TestIsRootWorkspace(t *testing.T) {
 		if err := os.MkdirAll(filepath.Join(dir, ".jj", "repo"), 0755); err != nil {
 			t.Fatalf("failed to create jj repo: %v", err)
 		}
-		if isRootWorkspace(dir) {
-			t.Error("isRootWorkspace() = true; want false for single workspace")
+		if got := classifyWorkspace(dir); got != workspaceStandalone {
+			t.Errorf("classifyWorkspace() = %q; want %q for single workspace", got, workspaceStandalone)
 		}
 	})
 
@@ -1892,8 +1892,8 @@ func TestIsRootWorkspace(t *testing.T) {
 		if err := os.MkdirAll(filepath.Join(dir, ".jj", "repo"), 0755); err != nil {
 			t.Fatalf("failed to create jj repo: %v", err)
 		}
-		if !isRootWorkspace(dir) {
-			t.Error("isRootWorkspace() = false; want true for multiple workspaces")
+		if got := classifyWorkspace(dir); got != workspaceRoot {
+			t.Errorf("classifyWorkspace() = %q; want %q for multiple workspaces", got, workspaceRoot)
 		}
 	})
 
@@ -1909,40 +1909,8 @@ func TestIsRootWorkspace(t *testing.T) {
 		if err := os.MkdirAll(filepath.Join(dir, ".jj", "repo"), 0755); err != nil {
 			t.Fatalf("failed to create jj repo: %v", err)
 		}
-		if isRootWorkspace(dir) {
-			t.Error("isRootWorkspace() = true; want false when jj command fails")
-		}
-	})
-}
-
-func TestIsJJRepoRoot(t *testing.T) {
-	t.Run("noJJRepo", func(t *testing.T) {
-		dir := t.TempDir()
-		if isJJRepoRoot(dir) {
-			t.Error("isJJRepoRoot() = true; want false for directory without .jj/repo")
-		}
-	})
-
-	t.Run("repoIsFile", func(t *testing.T) {
-		dir := t.TempDir()
-		if err := os.MkdirAll(filepath.Join(dir, ".jj"), 0755); err != nil {
-			t.Fatalf("failed to create .jj dir: %v", err)
-		}
-		if err := os.WriteFile(filepath.Join(dir, ".jj", "repo"), []byte("/some/path"), 0644); err != nil {
-			t.Fatalf("failed to create repo file: %v", err)
-		}
-		if isJJRepoRoot(dir) {
-			t.Error("isJJRepoRoot() = true; want false for .jj/repo as file")
-		}
-	})
-
-	t.Run("repoIsDirectory", func(t *testing.T) {
-		dir := t.TempDir()
-		if err := os.MkdirAll(filepath.Join(dir, ".jj", "repo"), 0755); err != nil {
-			t.Fatalf("failed to create jj repo: %v", err)
-		}
-		if !isJJRepoRoot(dir) {
-			t.Error("isJJRepoRoot() = false; want true for .jj/repo as directory")
+		if got := classifyWorkspace(dir); got != workspaceStandalone {
+			t.Errorf("classifyWorkspace() = %q; want %q when jj command fails", got, workspaceStandalone)
 		}
 	})
 }


### PR DESCRIPTION
## Summary

- Replaces multiple boolean helper functions (`hasJJDirectory`, `isJJRepoRoot`, `isRootWorkspace`, `hasMultipleWorkspaces`, `isForkWorkspace`) with a single `classifyWorkspace` function that returns a `workspaceKind` enum (`standalone`, `root`, `fork`)
- Simplifies the workspace classification logic throughout the codebase using a switch statement pattern instead of chained if-else conditions
- Updates all call sites and tests to use the new unified classification approach