### PR TITLE
cmd/sgai: remove GOAL buttons from root repositories

### DIFF
--- a/GOALS/2026_02_07_remove_compose_edit_goal_root_repo.md
+++ b/GOALS/2026_02_07_remove_compose_edit_goal_root_repo.md
@@ -1,0 +1,37 @@
+---
+flow: |
+  "backend-go-developer" -> "go-readability-reviewer"
+  "backend-go-developer" -> "stpa-analyst"
+  "go-readability-reviewer" -> "stpa-analyst"
+  "general-purpose" -> "stpa-analyst"
+  "htmx-picocss-frontend-developer" -> "htmx-picocss-frontend-reviewer"
+  "htmx-picocss-frontend-reviewer" -> "stpa-analyst"
+  "project-critic-council"
+  "skill-writer"
+models:
+  "coordinator": "anthropic/claude-opus-4-6 (max)"
+  "backend-go-developer": "anthropic/claude-opus-4-6"
+  "go-readability-reviewer": "anthropic/claude-opus-4-6"
+  "general-purpose": "anthropic/claude-opus-4-6"
+  "htmx-picocss-frontend-developer": "anthropic/claude-opus-4-6"
+  "htmx-picocss-frontend-reviewer": "anthropic/claude-opus-4-6"
+  "stpa-analyst": "anthropic/claude-opus-4-6"
+  "project-critic-council": ["anthropic/claude-opus-4-6", "openai/gpt-5.2", "openai/gpt-5.2-codex"]
+  "skill-writer": "anthropic/claude-opus-4-6 (max)"
+interactive: yes
+completionGateScript: make test
+---
+
+Terminology:
+- Standalone Repository: a repository that has only _one_ `jj workspace` -- itself.
+- Root Repository: a repository that has more than one `jj workspace`, and it is the root (it is the one in which `.jj/repo` is a directory and not a file)
+- Forked Repository: a repository that is part of a `jj workspace, and it is not the root (it is the one in which `.jj/repo` is a text file, whose content points to the parent).
+
+- Repository Mode: is when a repository is served by SGAI in a way that it can actually run software.
+- Forked Mode: is when a root repository has at least one child, it displays the fork (dashboard-style) mode.
+**CRITICAL** when a Root Repository run out of children, it must revert back from Forked Mode to Repository Mode.
+
+Expected Behaviors:
+- [x] Root Repositories
+    - [x] Remove Compose Goal Button
+    - [x] Remove Edit Goal Button

--- a/cmd/sgai/serve.go
+++ b/cmd/sgai/serve.go
@@ -2818,18 +2818,11 @@ func (s *Server) renderRootWorkspaceContent(dir, sessionParam string, r *http.Re
 		}
 	}
 
-	hasEditedGoal := false
-	if data, err := os.ReadFile(filepath.Join(dir, "GOAL.md")); err == nil {
-		body := extractBody(data)
-		hasEditedGoal = len(strings.TrimSpace(string(body))) > 0
-	}
-
 	workspaceData := struct {
 		Directory        string
 		DirName          string
 		TabContent       template.HTML
 		ErrorMessage     string
-		HasEditedGoal    bool
 		CodeAvailable    bool
 		EditorAvailable  bool
 		IsTerminalEditor bool
@@ -2841,7 +2834,6 @@ func (s *Server) renderRootWorkspaceContent(dir, sessionParam string, r *http.Re
 		DirName:          rootName,
 		TabContent:       template.HTML(tabBuf.String()),
 		ErrorMessage:     errMsg,
-		HasEditedGoal:    hasEditedGoal,
 		CodeAvailable:    editorAvailable,
 		EditorAvailable:  editorAvailable,
 		IsTerminalEditor: s.isTerminalEditor,

--- a/cmd/sgai/templates/trees_root_actions.html
+++ b/cmd/sgai/templates/trees_root_actions.html
@@ -1,9 +1,5 @@
 <div class="header-actions-container">
 	<a href="/workspaces/{{.DirName}}/fork/new" role="button" class="action-btn outline">Fork</a>
-	<a href="/compose?workspace={{.DirName}}" role="button" class="action-btn outline">Compose GOAL</a>
-	{{if .HasEditedGoal}}
-	<a href="/workspaces/{{.DirName}}/goal" role="button" class="action-btn outline">Edit GOAL</a>
-	{{end}}
 	{{if .CodeAvailable}}
 		{{if .IsTerminalEditor}}
 		<div class="terminal-editor-workspace-path">


### PR DESCRIPTION
## Summary

- Remove the "Compose GOAL" and "Edit GOAL" buttons from root repository views
- Clean up related `HasEditedGoal` field and logic from `serve.go` and `trees_root_actions.html`
- Root repositories should only show the Fork button (and editor buttons if available), since GOAL operations are meant for forked workspaces

## Terminology

- **Root Repository**: a repository that has more than one `jj workspace`, and it is the root (`.jj/repo` is a directory)
- **Forked Repository**: a workspace where `.jj/repo` is a text file pointing to the parent
- **Forked Mode**: when a root repository has at least one child, it displays the fork (dashboard-style) mode

## Changes

- `cmd/sgai/serve.go`: Remove `hasEditedGoal` variable and `HasEditedGoal` struct field from workspace data
- `cmd/sgai/templates/trees_root_actions.html`: Remove "Compose GOAL" link and conditional "Edit GOAL" link
- `GOALS/2026_02_07_remove_compose_edit_goal_root_repo.md`: Add GOAL spec for the change