### PR TITLE
cmd/sgai: add button to delete the fork

### DIFF
--- a/GOALS/2026_02_07_delete_fork.md
+++ b/GOALS/2026_02_07_delete_fork.md
@@ -1,0 +1,38 @@
+---
+flow: |
+  "backend-go-developer" -> "go-readability-reviewer"
+  "backend-go-developer" -> "stpa-analyst"
+  "go-readability-reviewer" -> "stpa-analyst"
+  "general-purpose" -> "stpa-analyst"
+  "htmx-picocss-frontend-developer" -> "htmx-picocss-frontend-reviewer"
+  "htmx-picocss-frontend-reviewer" -> "stpa-analyst"
+  "project-critic-council"
+  "skill-writer"
+models:
+  "coordinator": "anthropic/claude-opus-4-6 (max)"
+  "backend-go-developer": "anthropic/claude-opus-4-6"
+  "go-readability-reviewer": "anthropic/claude-opus-4-6"
+  "general-purpose": "anthropic/claude-opus-4-6"
+  "htmx-picocss-frontend-developer": "anthropic/claude-opus-4-6"
+  "htmx-picocss-frontend-reviewer": "anthropic/claude-opus-4-6"
+  "stpa-analyst": "anthropic/claude-opus-4-6"
+  "project-critic-council": ["anthropic/claude-opus-4-6", "openai/gpt-5.2", "openai/gpt-5.2-codex"]
+  "skill-writer": "anthropic/claude-opus-4-6 (max)"
+interactive: yes
+completionGateScript: make test
+---
+
+Terminology:
+- Standalone Repository: a repository that has only _one_ `jj workspace` -- itself.
+- Root Repository: a repository that has more than one `jj workspace`, and it is the root (it is the one in which `.jj/repo` is a directory and not a file)
+- Forked Repository: a repository that is part of a `jj workspace, and it is not the root (it is the one in which `.jj/repo` is a text file, whose content points to the parent).
+
+- Repository Mode: is when a repository is served by SGAI in a way that it can actually run software.
+- Forked Mode: is when a root repository has at least one child, it displays the fork (dashboard-style) mode.
+**CRITICAL** when a Root Repository run out of children, it must revert back from Forked Mode to Repository Mode.
+
+Expected Behaviors:
+- [x] Root Repositories
+    - [x] Must always display the "Delete" Button for each Fork
+      - [x] delete must forget the workspace (`jj workspace forget <workspace-name>`) 
+      - [x] delete must remove the workspace directory (`rm -rf <workspace-dir>`)

--- a/cmd/sgai/templates/trees_forks_content.html
+++ b/cmd/sgai/templates/trees_forks_content.html
@@ -36,20 +36,14 @@
 						<button type="button" class="action-btn outline" disabled data-tooltip="Editor not available or remote connection">Open in Editor</button>
 						{{end}}
 						<a href="/trees?workspace={{.DirName}}" role="button" class="action-btn outline">Open in sgai</a>
-						<details class="merge-confirmation">
-							<summary><span class="action-btn outline">Merge</span></summary>
-							<div class="merge-confirmation-panel">
-								<p>This will rebase and squash the fork, create the PR, then delete the fork workspace.</p>
-								<form action="/workspaces/{{$.RootDirName}}/merge" method="post">
-									<input type="hidden" name="fork_dir" value="{{.Directory}}">
-									<label class="merge-confirmation-check">
-									<input type="checkbox" name="confirm_delete" value="true" required>
-										I understand this deletes the fork workspace after merge.
-									</label>
-									<button type="submit" class="action-btn attention">Confirm merge</button>
-								</form>
-							</div>
-						</details>
+						<button hx-post="/workspaces/{{$.RootDirName}}/merge"
+							hx-vals='{"fork_dir": "{{.Directory}}"}'
+							hx-confirm="This will rebase, squash, create a PR, then delete the fork workspace. Are you sure?"
+							class="action-btn outline">Merge</button>
+						<button hx-post="/workspaces/{{$.RootDirName}}/delete-fork"
+							hx-vals='{"fork_dir": "{{.Directory}}"}'
+							hx-confirm="This will permanently delete the fork '{{.DirName}}' and all its changes. Are you sure?"
+							class="action-btn attention">Delete</button>
 					</div>
 				</td>
 			</tr>


### PR DESCRIPTION
## Summary

- Adds a "Delete" button for each fork in the forks dashboard view
- Implements `handleForkDelete` endpoint that forgets the jj workspace and removes the fork directory
- Adds `htmxRedirect` helper for proper HTMX vs standard redirect handling
- Simplifies the merge confirmation flow to use `hx-confirm` instead of a details/checkbox panel
- Removes the `confirm_delete` / `confirm` checkbox requirement from the merge handler
- Includes comprehensive tests for delete-fork endpoint (POST requirement, non-root rejection, non-fork rejection, wrong-root rejection, success, and HTMX redirect)