### PR TITLE
cmd/sgai: improve nudge to make agent yield on messaging

### DIFF
--- a/GOALS/2026_02_08_better_continuation_messages.md
+++ b/GOALS/2026_02_08_better_continuation_messages.md
@@ -1,0 +1,35 @@
+---
+flow: |
+  "backend-go-developer" -> "go-readability-reviewer"
+  "backend-go-developer" -> "stpa-analyst"
+  "go-readability-reviewer" -> "stpa-analyst"
+  "general-purpose" -> "stpa-analyst"
+  "htmx-picocss-frontend-developer" -> "htmx-picocss-frontend-reviewer"
+  "htmx-picocss-frontend-reviewer" -> "stpa-analyst"
+  "react-developer" -> "react-reviewer"
+  "react-reviewer" -> "stpa-analyst"
+  "project-critic-council"
+  "skill-writer"
+  "stpa-analyst"
+models:
+  "coordinator": "anthropic/claude-opus-4-6 (max)"
+  "backend-go-developer": "anthropic/claude-opus-4-6"
+  "go-readability-reviewer": "anthropic/claude-opus-4-6"
+  "general-purpose": "anthropic/claude-opus-4-6"
+  "htmx-picocss-frontend-developer": "anthropic/claude-opus-4-6"
+  "htmx-picocss-frontend-reviewer": "anthropic/claude-opus-4-6"
+  "react-developer": "openai/gpt-5.2-codex (xhigh)"
+  "react-reviewer": "openai/gpt-5.2-codex (xhigh)"
+  "stpa-analyst": "anthropic/claude-opus-4-6"
+  "project-critic-council": ["anthropic/claude-opus-4-6", "openai/gpt-5.2", "openai/gpt-5.2-codex"]
+  "skill-writer": "anthropic/claude-opus-4-6 (max)"
+interactive: yes
+completionGateScript: make test
+---
+
+There is a continuation message that's fed back into the agent.
+
+We need to make two changes.
+
+- [x] when the agent sends a message with `sgai_send_message`, we instruct the agent that to be able to see a response it MUST yield the control back (as part of the response to `sgai_send_message)
+- [x] in the continuation message, if the agent has an outbox with pending messages to be delivered, we must add a instruction in the continuation message that says something like "Listen, you sent a message; for the other agent get back to you, have to yield control by marking state:agent-done`

--- a/cmd/sgai/main.go
+++ b/cmd/sgai/main.go
@@ -765,6 +765,18 @@ func runFlowAgentWithModel(ctx context.Context, cfg multiModelConfig, wfState st
 				todoNudge := fmt.Sprintf("\nYou have %d pending TODO items. Please complete them before marking agent-done.\n", pendingTodosCount)
 				msg += todoNudge
 			}
+
+			if cfg.agent != "coordinator" {
+				outboxPending := 0
+				for _, m := range wfState.Messages {
+					if m.FromAgent == cfg.agent && !m.Read {
+						outboxPending++
+					}
+				}
+				if outboxPending > 0 {
+					msg += "\nYou have sent messages that haven't been read yet. For the recipient agents to process them, you MUST yield control by calling sgai_update_workflow_state({status: 'agent-done'}). They cannot run while you hold control.\n"
+				}
+			}
 		}
 
 		cmd := exec.CommandContext(ctx, "opencode", args...)

--- a/cmd/sgai/mcp.go
+++ b/cmd/sgai/mcp.go
@@ -977,7 +977,7 @@ func sendMessage(workingDir, toAgent, body string) (string, error) {
 
 	result := fmt.Sprintf("Message sent successfully to %s.\nFrom: %s\nTo: %s\nBody: %s", toAgent, fromAgent, toAgent, body)
 	if currentAgent != "coordinator" {
-		result += "\n\nIMPORTANT: Since you are not the coordinator, consider yielding control back to the main loop using sgai_update_workflow_state({status: 'agent-done'}) after completing your message-related tasks."
+		result += "\n\nIMPORTANT: To receive a response from the target agent, you MUST yield control by calling sgai_update_workflow_state({status: 'agent-done'}). The target agent cannot run until you yield."
 	}
 	return result, nil
 }


### PR DESCRIPTION
## Summary

- Adds outbox-pending detection in the continuation message: when a non-coordinator agent has sent messages that haven't been read yet, the continuation message now nudges them to yield control via `sgai_update_workflow_state({status: 'agent-done'})`.
- Updates the `sgai_send_message` response to use stronger, clearer language telling the agent it **must** yield for the target agent to run.
- Adds a GOAL file documenting the two changes for this feature.