### PR TITLE
cmd/sgai: fix panic

### DIFF
--- a/GOALS/2026_02_09_fix_negative_repeat_panic.md
+++ b/GOALS/2026_02_09_fix_negative_repeat_panic.md
@@ -1,0 +1,44 @@
+---
+flow: |
+  "backend-go-developer" -> "go-readability-reviewer"
+  "backend-go-developer" -> "stpa-analyst"
+  "go-readability-reviewer" -> "stpa-analyst"
+  "general-purpose" -> "stpa-analyst"
+  "htmx-picocss-frontend-developer" -> "htmx-picocss-frontend-reviewer"
+  "htmx-picocss-frontend-reviewer" -> "stpa-analyst"
+  "project-critic-council"
+  "skill-writer"
+models:
+  "coordinator": "anthropic/claude-opus-4-6 (max)"
+  "backend-go-developer": "anthropic/claude-opus-4-6"
+  "go-readability-reviewer": "anthropic/claude-opus-4-6"
+  "general-purpose": "anthropic/claude-opus-4-6"
+  "htmx-picocss-frontend-developer": "anthropic/claude-opus-4-6"
+  "htmx-picocss-frontend-reviewer": "anthropic/claude-opus-4-6"
+  "stpa-analyst": "anthropic/claude-opus-4-6"
+  "project-critic-council": ["anthropic/claude-opus-4-6", "openai/gpt-5.2", "openai/gpt-5.2-codex"]
+  "skill-writer": "anthropic/claude-opus-4-6 (max)"
+interactive: yes
+completionGateScript: make test
+---
+
+- [x] fix this panic
+```
+[session-timeout] panic: strings: negative Repeat count
+[session-timeout]
+[session-timeout] goroutine 1 [running]:
+[session-timeout] strings.Repeat({0x102a720d8?, 0xf?}, 0x14000470000?)
+[session-timeout] 	/usr/local/go/src/strings/strings.go:628 +0x574
+[session-timeout] main.runFlowAgentWithModel({_, _}, {{0x16da4f564, 0x3e}, {0x14000422000, 0x46}, {0x140003052f0, 0x25}, 0x1400044e4e0, {0x14000422050, ...}, ...}, ...)
+[session-timeout] 	/Users/ucirello/go/src/github.com/sandgardenhq/sgai/cmd/sgai/main.go:699 +0x90
+[session-timeout] main.runSingleModelIteration({_, _}, {{0x16da4f564, 0x3e}, {0x14000422000, 0x46}, {0x140003052f0, 0x25}, 0x1400044e4e0, {0x14000422050, ...}, ...}, ...)
+[session-timeout] 	/Users/ucirello/go/src/github.com/sandgardenhq/sgai/cmd/sgai/main.go:695 +0xd4
+[session-timeout] main.runMultiModelAgent({_, _}, {{0x16da4f564, 0x3e}, {0x14000422000, 0x46}, {0x140003052f0, 0x25}, 0x1400044e4e0, {0x14000422050, ...}, ...}, ...)
+[session-timeout] 	/Users/ucirello/go/src/github.com/sandgardenhq/sgai/cmd/sgai/main.go:607 +0x2b4
+[session-timeout] main.runFlowAgent({_, _}, {_, _}, {_, _}, {_, _}, _, {{0x10289373f, ...}, ...}, ...)
+[session-timeout] 	/Users/ucirello/go/src/github.com/sandgardenhq/sgai/cmd/sgai/main.go:991 +0x10c
+[session-timeout] main.runWorkflow({0x102bc6400, 0x1400037fd40}, {0x14000020160, 0x2, 0x2})
+[session-timeout] 	/Users/ucirello/go/src/github.com/sandgardenhq/sgai/cmd/sgai/main.go:368 +0x17d0
+[session-timeout] main.main()
+[session-timeout] 	/Users/ucirello/go/src/github.com/sandgardenhq/sgai/cmd/sgai/main.go:87 +0x4c8
+```

--- a/cmd/sgai/main.go
+++ b/cmd/sgai/main.go
@@ -241,7 +241,7 @@ func runWorkflow(ctx context.Context, args []string) {
 	for _, agent := range allAgents {
 		longestNameLen = max(longestNameLen, len(agent))
 	}
-	paddedsgai := "sgai" + strings.Repeat(" ", longestNameLen-len("sgai"))
+	paddedsgai := "sgai" + strings.Repeat(" ", max(0, longestNameLen-len("sgai")))
 
 	pmPath := filepath.Join(dir, ".sgai", "PROJECT_MANAGEMENT.md")
 	retrospectivesBaseDir := filepath.Join(dir, ".sgai", "retrospectives")
@@ -696,7 +696,7 @@ func runSingleModelIteration(ctx context.Context, cfg multiModelConfig, wfState 
 }
 
 func runFlowAgentWithModel(ctx context.Context, cfg multiModelConfig, wfState state.Workflow, metadata GoalMetadata, iterationCounter *int, modelSpec string) state.Workflow {
-	paddedAgentName := cfg.agent + strings.Repeat(" ", cfg.longestNameLen-len(cfg.agent))
+	paddedAgentName := cfg.agent + strings.Repeat(" ", max(0, cfg.longestNameLen-len(cfg.agent)))
 	var humanResponse string
 	var capturedSessionID string
 	outputCapture := newRingWriter()
@@ -1312,7 +1312,7 @@ func findFirstPendingMessageAgent(s state.Workflow) string {
 	}
 	for _, msg := range s.Messages {
 		if !msg.Read {
-			return msg.ToAgent
+			return extractAgentFromModelID(msg.ToAgent)
 		}
 	}
 	return ""

--- a/cmd/sgai/main_test.go
+++ b/cmd/sgai/main_test.go
@@ -197,6 +197,68 @@ No frontmatter here.
 	})
 }
 
+func TestFindFirstPendingMessageAgent(t *testing.T) {
+	t.Run("noMessages", func(t *testing.T) {
+		wf := state.Workflow{}
+		got := findFirstPendingMessageAgent(wf)
+		if got != "" {
+			t.Errorf("findFirstPendingMessageAgent() = %q; want empty string", got)
+		}
+	})
+
+	t.Run("allRead", func(t *testing.T) {
+		wf := state.Workflow{
+			Messages: []state.Message{
+				{ToAgent: "agent-a", Read: true},
+				{ToAgent: "agent-b", Read: true},
+			},
+		}
+		got := findFirstPendingMessageAgent(wf)
+		if got != "" {
+			t.Errorf("findFirstPendingMessageAgent() = %q; want empty string", got)
+		}
+	})
+
+	t.Run("plainAgentName", func(t *testing.T) {
+		wf := state.Workflow{
+			Messages: []state.Message{
+				{ToAgent: "agent-a", Read: true},
+				{ToAgent: "agent-b", Read: false},
+			},
+		}
+		got := findFirstPendingMessageAgent(wf)
+		if got != "agent-b" {
+			t.Errorf("findFirstPendingMessageAgent() = %q; want %q", got, "agent-b")
+		}
+	})
+
+	t.Run("modelQualifiedID", func(t *testing.T) {
+		wf := state.Workflow{
+			Messages: []state.Message{
+				{ToAgent: "project-critic-council:openai/gpt-5.2", Read: false},
+			},
+		}
+		got := findFirstPendingMessageAgent(wf)
+		if got != "project-critic-council" {
+			t.Errorf("findFirstPendingMessageAgent() = %q; want %q", got, "project-critic-council")
+		}
+	})
+
+	t.Run("firstUnreadWins", func(t *testing.T) {
+		wf := state.Workflow{
+			Messages: []state.Message{
+				{ToAgent: "agent-a", Read: true},
+				{ToAgent: "agent-b:openai/gpt-5.2", Read: false},
+				{ToAgent: "agent-c", Read: false},
+			},
+		}
+		got := findFirstPendingMessageAgent(wf)
+		if got != "agent-b" {
+			t.Errorf("findFirstPendingMessageAgent() = %q; want %q", got, "agent-b")
+		}
+	})
+}
+
 func TestCanResumeWorkflow(t *testing.T) {
 	checksum := "abc123"
 


### PR DESCRIPTION
## Summary

- Fix `strings: negative Repeat count` panic in `runFlowAgentWithModel` by guarding the `strings.Repeat` call with `max(0, ...)`
- Apply the same guard to the padded sgai name computation
- Add tests for `findFirstPendingMessageAgent` covering no messages, all-read, plain agent names, model-qualified IDs, and first-unread-wins scenarios