### PR TITLE
cmd/sgai: fix Open In OpenCode by removing unsupported --variant flag

### DIFF
--- a/GOALS/2026_02_11_open_in_opencode_redo.md
+++ b/GOALS/2026_02_11_open_in_opencode_redo.md
@@ -1,0 +1,86 @@
+---
+flow: |
+  "backend-go-developer" -> "go-readability-reviewer"
+  "backend-go-developer" -> "stpa-analyst"
+  "go-readability-reviewer" -> "stpa-analyst"
+  "general-purpose" -> "stpa-analyst"
+  "htmx-picocss-frontend-developer" -> "htmx-picocss-frontend-reviewer"
+  "htmx-picocss-frontend-reviewer" -> "stpa-analyst"
+  "project-critic-council"
+  "skill-writer"
+models:
+  "coordinator": "anthropic/claude-opus-4-6 (max)"
+  "backend-go-developer": "anthropic/claude-opus-4-6"
+  "go-readability-reviewer": "anthropic/claude-opus-4-6"
+  "general-purpose": "anthropic/claude-opus-4-6"
+  "htmx-picocss-frontend-developer": "anthropic/claude-opus-4-6"
+  "htmx-picocss-frontend-reviewer": "anthropic/claude-opus-4-6"
+  "stpa-analyst": "anthropic/claude-opus-4-6"
+  "project-critic-council": ["anthropic/claude-opus-4-6", "openai/gpt-5.2", "openai/gpt-5.2-codex"]
+  "skill-writer": "anthropic/claude-opus-4-6 (max)"
+interactive: yes
+completionGateScript: make test
+---
+
+- [x] `Open In OpenCode` doesn't work. I get this log, that indicates you got something very very wrong (refer to ./GOALS/2026_02_10_open_in_opencode.md)
+```
+/var/folders/9_/xr1r7kx92z1_bp3z7r6n6qjw0000gn/T/sgai-opencode-1533742199.sh ; exit;
+Mac:~ ucirello$ /var/folders/9_/xr1r7kx92z1_bp3z7r6n6qjw0000gn/T/sgai-opencode-1533742199.sh ; exit;
+
+▄
+█▀▀█ █▀▀█ █▀▀█ █▀▀▄ █▀▀▀ █▀▀█ █▀▀█ █▀▀█
+█  █ █  █ █▀▀▀ █  █ █    █  █ █  █ █▀▀▀
+▀▀▀▀ █▀▀▀ ▀▀▀▀ ▀▀▀▀ ▀▀▀▀ ▀▀▀▀ ▀▀▀▀ ▀▀▀▀
+
+Commands:
+  opencode completion          generate shell completion script
+  opencode acp                 start ACP (Agent Client Protocol) server
+  opencode mcp                 manage MCP (Model Context Protocol) servers
+  opencode [project]           start opencode tui                                          [default]
+  opencode attach <url>        attach to a running opencode server
+  opencode run [message..]     run opencode with a message
+  opencode debug               debugging and troubleshooting tools
+  opencode auth                manage credentials
+  opencode agent               manage agents
+  opencode upgrade [target]    upgrade opencode to the latest or a specific version
+  opencode uninstall           uninstall opencode and remove all related files
+  opencode serve               starts a headless opencode server
+  opencode web                 start opencode server and open web interface
+  opencode models [provider]   list all available models
+  opencode stats               show token usage and cost statistics
+  opencode export [sessionID]  export session data as JSON
+  opencode import <file>       import session data from JSON file or URL
+  opencode github              manage GitHub agent
+  opencode pr <number>         fetch and checkout a GitHub PR branch, then run opencode
+  opencode session             manage sessions
+
+Positionals:
+  project  path to start opencode in                                                        [string]
+
+Options:
+  -h, --help         show help                                                             [boolean]
+  -v, --version      show version number                                                   [boolean]
+      --print-logs   print logs to stderr                                                  [boolean]
+      --log-level    log level                  [string] [choices: "DEBUG", "INFO", "WARN", "ERROR"]
+      --port         port to listen on                                         [number] [default: 0]
+      --hostname     hostname to listen on                           [string] [default: "127.0.0.1"]
+      --mdns         enable mDNS service discovery (defaults hostname to 0.0.0.0)
+                                                                          [boolean] [default: false]
+      --mdns-domain  custom domain name for mDNS service (default: opencode.local)
+                                                                [string] [default: "opencode.local"]
+      --cors         additional domains to allow for CORS                      [array] [default: []]
+  -m, --model        model to use in the format of provider/model                           [string]
+  -c, --continue     continue the last session                                             [boolean]
+  -s, --session      session id to continue                                                 [string]
+      --fork         fork the session when continuing (use with --continue or --session)   [boolean]
+      --prompt       prompt to use                                                          [string]
+      --agent        agent to use                                                           [string]
+logout
+
+Saving session...
+...copying shared history...
+...saving history...truncating history files...
+...completed.
+
+[Process completed]
+```

--- a/cmd/sgai/serve.go
+++ b/cmd/sgai/serve.go
@@ -3919,7 +3919,7 @@ func (s *Server) handleWorkspaceOpenInOpenCode(w http.ResponseWriter, r *http.Re
 	sessionID := wfState.SessionID
 
 	modelSpec := lookupModelForAgent(workspacePath, currentAgent)
-	model, variant := parseModelAndVariant(modelSpec)
+	model, _ := parseModelAndVariant(modelSpec)
 
 	interactive := "yes"
 	if data, errRead := os.ReadFile(filepath.Join(workspacePath, "GOAL.md")); errRead == nil {
@@ -3939,10 +3939,6 @@ func (s *Server) handleWorkspaceOpenInOpenCode(w http.ResponseWriter, r *http.Re
 	if model != "" {
 		opencodeCmd += fmt.Sprintf(" --model %q", model)
 	}
-	if variant != "" {
-		opencodeCmd += fmt.Sprintf(" --variant %q", variant)
-	}
-
 	scriptContent := fmt.Sprintf("#!/bin/bash\ntrap 'rm -f \"$0\"' EXIT\ncd %q\nexport OPENCODE_CONFIG_DIR=.sgai\nexport SGAI_MCP_EXECUTABLE=%q\nexport SGAI_MCP_INTERACTIVE=%q\n%s\n",
 		workspacePath, execPath, interactive, opencodeCmd)
 


### PR DESCRIPTION
## Summary

- Removes the `--variant` flag from the OpenCode command construction in `serve.go`, which was causing OpenCode to fail because it doesn't support that flag
- The `--variant` flag was being passed to `opencode run` but OpenCode CLI doesn't recognize it, resulting in a help screen being printed instead of actually running