### PR TITLE
cmd/sgai: add macOS menu bar status item for factory monitoring

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ webapp-check-deps:
 	cd cmd/sgai/webapp && bun outdated
 
 lint:
-	go run -mod=readonly github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.8.0 run ./...
+	GOOS= GOARCH= go run -mod=readonly github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.8.0 run ./...
 
 install: build
 	cp sgai $(HOME)/bin/sgai

--- a/cmd/sgai/menubar.go
+++ b/cmd/sgai/menubar.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"net/url"
+	"sync"
+)
+
+type menuBarItem struct {
+	name       string
+	needsInput bool
+	running    bool
+	stopped    bool
+}
+
+type menuBarState struct {
+	mu      sync.Mutex
+	tags    map[int]menuBarAction
+	nextTag int
+}
+
+type menuBarAction struct {
+	actionURL string
+}
+
+var globalMenuBar = &menuBarState{
+	tags: make(map[int]menuBarAction),
+}
+
+func toMenuBarItem(w workspaceInfo) menuBarItem {
+	return menuBarItem{
+		name:       w.DirName,
+		needsInput: w.NeedsInput,
+		running:    w.Running,
+		stopped:    !w.Running && w.InProgress,
+	}
+}
+
+func countAttention(items []menuBarItem) int {
+	count := 0
+	for _, item := range items {
+		if item.needsInput || item.stopped {
+			count++
+		}
+	}
+	return count
+}
+
+func countRunning(items []menuBarItem) int {
+	count := 0
+	for _, item := range items {
+		if item.running {
+			count++
+		}
+	}
+	return count
+}
+
+func filterAttentionItems(items []menuBarItem) []menuBarItem {
+	var result []menuBarItem
+	for _, item := range items {
+		if item.needsInput || item.stopped {
+			result = append(result, item)
+		}
+	}
+	return result
+}
+
+func formatMenuItemLabel(item menuBarItem) string {
+	if item.needsInput {
+		return "\u26A0 " + item.name + " (Needs Input)"
+	}
+	return "\u25A0 " + item.name + " (Stopped)"
+}
+
+func workspaceItemSubpath(item menuBarItem) string {
+	if item.needsInput {
+		return "respond"
+	}
+	return "progress"
+}
+
+func workspaceURL(baseURL, name, subpath string) string {
+	u, errParse := url.Parse(baseURL)
+	if errParse != nil {
+		return baseURL + "/workspaces/" + name + "/" + subpath
+	}
+	u.Path = "/workspaces/" + name + "/" + subpath
+	return u.String()
+}
+
+func allocTag(action menuBarAction) int {
+	globalMenuBar.mu.Lock()
+	defer globalMenuBar.mu.Unlock()
+	globalMenuBar.nextTag++
+	tag := globalMenuBar.nextTag
+	globalMenuBar.tags[tag] = action
+	return tag
+}

--- a/cmd/sgai/menubar_darwin.go
+++ b/cmd/sgai/menubar_darwin.go
@@ -1,0 +1,141 @@
+//go:build darwin
+
+package main
+
+/*
+#cgo CFLAGS: -x objective-c
+#cgo LDFLAGS: -framework Cocoa
+
+#include <stdlib.h>
+
+extern void MenuBarInit(void);
+extern void MenuBarSetTitle(const char *title);
+extern void MenuBarClear(void);
+extern void MenuBarAddItem(const char *title, int tag, int enabled);
+extern void MenuBarAddSeparator(void);
+extern void MenuBarOpenURL(const char *urlStr);
+extern void MenuBarRunLoop(void);
+*/
+import "C"
+
+import (
+	"fmt"
+	"runtime"
+	"unsafe"
+)
+
+var menuBarBaseURL string
+
+//export goMenuItemClicked
+func goMenuItemClicked(tag C.int) {
+	globalMenuBar.mu.Lock()
+	action, ok := globalMenuBar.tags[int(tag)]
+	globalMenuBar.mu.Unlock()
+	if !ok || action.actionURL == "" {
+		return
+	}
+	cURL := C.CString(action.actionURL)
+	defer C.free(unsafe.Pointer(cURL))
+	C.MenuBarOpenURL(cURL)
+}
+
+func startMenuBar(baseURL string, srv *Server) {
+	menuBarBaseURL = baseURL
+
+	runtime.LockOSThread()
+	C.MenuBarInit()
+
+	go menuBarUpdateLoop(srv)
+
+	C.MenuBarRunLoop()
+}
+
+func menuBarUpdateLoop(srv *Server) {
+	ch := srv.sseBroker.subscribe()
+	defer srv.sseBroker.unsubscribe(ch)
+
+	rebuildMenuFromServer(srv)
+
+	for {
+		select {
+		case <-ch.done:
+			return
+		case <-ch.events:
+			rebuildMenuFromServer(srv)
+		}
+	}
+}
+
+func rebuildMenuFromServer(srv *Server) {
+	groups, errScan := srv.scanWorkspaceGroups()
+	if errScan != nil {
+		return
+	}
+
+	var items []menuBarItem
+	for _, grp := range groups {
+		items = append(items, toMenuBarItem(grp.Root))
+		for _, fork := range grp.Forks {
+			items = append(items, toMenuBarItem(fork))
+		}
+	}
+
+	globalMenuBar.mu.Lock()
+	globalMenuBar.nextTag = 0
+	globalMenuBar.tags = make(map[int]menuBarAction)
+	baseURL := menuBarBaseURL
+	globalMenuBar.mu.Unlock()
+
+	attentionCount := countAttention(items)
+	setMenuTitle(attentionCount)
+
+	C.MenuBarClear()
+
+	dashTag := allocTag(menuBarAction{actionURL: baseURL})
+	addMenuEntry("Open Dashboard", dashTag, true)
+
+	C.MenuBarAddSeparator()
+
+	needsAttention := filterAttentionItems(items)
+	if len(needsAttention) == 0 {
+		addMenuEntry("No factories need attention", 0, false)
+	} else {
+		summary := fmt.Sprintf("%d factory(ies) need attention", len(needsAttention))
+		addMenuEntry(summary, 0, false)
+		C.MenuBarAddSeparator()
+		for _, item := range needsAttention {
+			label := formatMenuItemLabel(item)
+			itemURL := workspaceURL(baseURL, item.name, workspaceItemSubpath(item))
+			tag := allocTag(menuBarAction{actionURL: itemURL})
+			addMenuEntry(label, tag, true)
+		}
+	}
+
+	C.MenuBarAddSeparator()
+
+	runningCount := countRunning(items)
+	statusLine := fmt.Sprintf("%d running, %d need attention", runningCount, attentionCount)
+	addMenuEntry(statusLine, 0, false)
+}
+
+func setMenuTitle(attentionCount int) {
+	var title string
+	if attentionCount > 0 {
+		title = fmt.Sprintf("\u25CF %d", attentionCount)
+	} else {
+		title = "\u25CB sgai"
+	}
+	cTitle := C.CString(title)
+	defer C.free(unsafe.Pointer(cTitle))
+	C.MenuBarSetTitle(cTitle)
+}
+
+func addMenuEntry(label string, tag int, enabled bool) {
+	cLabel := C.CString(label)
+	defer C.free(unsafe.Pointer(cLabel))
+	e := 0
+	if enabled {
+		e = 1
+	}
+	C.MenuBarAddItem(cLabel, C.int(tag), C.int(e))
+}

--- a/cmd/sgai/menubar_darwin.m
+++ b/cmd/sgai/menubar_darwin.m
@@ -1,0 +1,92 @@
+#import <Cocoa/Cocoa.h>
+
+extern void goMenuItemClicked(int tag);
+
+static NSStatusItem *statusItem = nil;
+static NSMenu *statusMenu = nil;
+
+@interface MenuBarDelegate : NSObject
+- (void)menuItemClicked:(NSMenuItem *)sender;
+@end
+
+@implementation MenuBarDelegate
+- (void)menuItemClicked:(NSMenuItem *)sender {
+	int tag = (int)sender.tag;
+	dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+		goMenuItemClicked(tag);
+	});
+}
+@end
+
+static MenuBarDelegate *menuDelegate = nil;
+
+void MenuBarInit(void) {
+	[NSApplication sharedApplication];
+	[NSApp setActivationPolicy:NSApplicationActivationPolicyAccessory];
+
+	menuDelegate = [[MenuBarDelegate alloc] init];
+
+	statusItem = [[NSStatusBar systemStatusBar]
+		statusItemWithLength:NSVariableStatusItemLength];
+	statusItem.button.title = @"\u25CB sgai";
+	statusItem.button.toolTip = @"SGAI Factory Monitor";
+
+	statusMenu = [[NSMenu alloc] init];
+	statusItem.menu = statusMenu;
+}
+
+void MenuBarSetTitle(const char *title) {
+	NSString *nsTitle = [NSString stringWithUTF8String:title];
+	dispatch_async(dispatch_get_main_queue(), ^{
+		if (statusItem != nil) {
+			statusItem.button.title = nsTitle;
+		}
+	});
+}
+
+void MenuBarClear(void) {
+	dispatch_async(dispatch_get_main_queue(), ^{
+		if (statusMenu != nil) {
+			[statusMenu removeAllItems];
+		}
+	});
+}
+
+void MenuBarAddItem(const char *title, int tag, int enabled) {
+	NSString *nsTitle = [NSString stringWithUTF8String:title];
+	int t = tag;
+	int e = enabled;
+	dispatch_async(dispatch_get_main_queue(), ^{
+		if (statusMenu == nil || menuDelegate == nil) return;
+		NSMenuItem *item = [[NSMenuItem alloc]
+			initWithTitle:nsTitle
+			action:@selector(menuItemClicked:)
+			keyEquivalent:@""];
+		item.target = menuDelegate;
+		item.tag = t;
+		item.enabled = e ? YES : NO;
+		[statusMenu addItem:item];
+	});
+}
+
+void MenuBarAddSeparator(void) {
+	dispatch_async(dispatch_get_main_queue(), ^{
+		if (statusMenu != nil) {
+			[statusMenu addItem:[NSMenuItem separatorItem]];
+		}
+	});
+}
+
+void MenuBarOpenURL(const char *urlStr) {
+	NSString *nsURL = [NSString stringWithUTF8String:urlStr];
+	dispatch_async(dispatch_get_main_queue(), ^{
+		NSURL *url = [NSURL URLWithString:nsURL];
+		if (url != nil) {
+			[[NSWorkspace sharedWorkspace] openURL:url];
+		}
+	});
+}
+
+void MenuBarRunLoop(void) {
+	[NSApp run];
+}

--- a/cmd/sgai/menubar_other.go
+++ b/cmd/sgai/menubar_other.go
@@ -1,0 +1,7 @@
+//go:build !darwin
+
+package main
+
+func startMenuBar(_ string, _ *Server) {
+	select {}
+}

--- a/cmd/sgai/menubar_test.go
+++ b/cmd/sgai/menubar_test.go
@@ -1,0 +1,311 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestCountAttention(t *testing.T) {
+	cases := []struct {
+		name  string
+		items []menuBarItem
+		want  int
+	}{
+		{
+			name:  "empty",
+			items: nil,
+			want:  0,
+		},
+		{
+			name: "noAttention",
+			items: []menuBarItem{
+				{name: "a", running: true},
+				{name: "b", running: true},
+			},
+			want: 0,
+		},
+		{
+			name: "needsInput",
+			items: []menuBarItem{
+				{name: "a", needsInput: true},
+				{name: "b", running: true},
+			},
+			want: 1,
+		},
+		{
+			name: "stopped",
+			items: []menuBarItem{
+				{name: "a", stopped: true},
+				{name: "b", running: true},
+			},
+			want: 1,
+		},
+		{
+			name: "multipleAttention",
+			items: []menuBarItem{
+				{name: "a", needsInput: true},
+				{name: "b", stopped: true},
+				{name: "c", running: true},
+			},
+			want: 2,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := countAttention(tc.items)
+			if got != tc.want {
+				t.Errorf("countAttention() = %d; want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCountRunning(t *testing.T) {
+	cases := []struct {
+		name  string
+		items []menuBarItem
+		want  int
+	}{
+		{
+			name:  "empty",
+			items: nil,
+			want:  0,
+		},
+		{
+			name: "twoRunning",
+			items: []menuBarItem{
+				{name: "a", running: true},
+				{name: "b", running: true},
+				{name: "c"},
+			},
+			want: 2,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := countRunning(tc.items)
+			if got != tc.want {
+				t.Errorf("countRunning() = %d; want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFilterAttentionItems(t *testing.T) {
+	items := []menuBarItem{
+		{name: "a", running: true},
+		{name: "b", needsInput: true},
+		{name: "c", stopped: true},
+		{name: "d", running: true},
+	}
+
+	got := filterAttentionItems(items)
+	if len(got) != 2 {
+		t.Fatalf("filterAttentionItems() returned %d items; want 2", len(got))
+	}
+	if got[0].name != "b" {
+		t.Errorf("filterAttentionItems()[0].name = %q; want %q", got[0].name, "b")
+	}
+	if got[1].name != "c" {
+		t.Errorf("filterAttentionItems()[1].name = %q; want %q", got[1].name, "c")
+	}
+}
+
+func TestFilterAttentionItemsEmpty(t *testing.T) {
+	items := []menuBarItem{
+		{name: "a", running: true},
+	}
+	got := filterAttentionItems(items)
+	if len(got) != 0 {
+		t.Errorf("filterAttentionItems() returned %d items; want 0", len(got))
+	}
+}
+
+func TestFormatMenuItemLabel(t *testing.T) {
+	cases := []struct {
+		name string
+		item menuBarItem
+		want string
+	}{
+		{
+			name: "needsInput",
+			item: menuBarItem{name: "my-workspace", needsInput: true},
+			want: "\u26A0 my-workspace (Needs Input)",
+		},
+		{
+			name: "stopped",
+			item: menuBarItem{name: "my-workspace", stopped: true},
+			want: "\u25A0 my-workspace (Stopped)",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := formatMenuItemLabel(tc.item)
+			if got != tc.want {
+				t.Errorf("formatMenuItemLabel() = %q; want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestWorkspaceURL(t *testing.T) {
+	cases := []struct {
+		name    string
+		baseURL string
+		wsName  string
+		subpath string
+		want    string
+	}{
+		{
+			name:    "respondRoute",
+			baseURL: "http://127.0.0.1:8080",
+			wsName:  "my-project",
+			subpath: "respond",
+			want:    "http://127.0.0.1:8080/workspaces/my-project/respond",
+		},
+		{
+			name:    "progressRoute",
+			baseURL: "http://127.0.0.1:8080",
+			wsName:  "my-project",
+			subpath: "progress",
+			want:    "http://127.0.0.1:8080/workspaces/my-project/progress",
+		},
+		{
+			name:    "customPort",
+			baseURL: "http://localhost:9090",
+			wsName:  "test-ws",
+			subpath: "progress",
+			want:    "http://localhost:9090/workspaces/test-ws/progress",
+		},
+		{
+			name:    "invalidURL",
+			baseURL: "://invalid",
+			wsName:  "test",
+			subpath: "respond",
+			want:    "://invalid/workspaces/test/respond",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := workspaceURL(tc.baseURL, tc.wsName, tc.subpath)
+			if got != tc.want {
+				t.Errorf("workspaceURL(%q, %q, %q) = %q; want %q", tc.baseURL, tc.wsName, tc.subpath, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestWorkspaceItemSubpath(t *testing.T) {
+	cases := []struct {
+		name string
+		item menuBarItem
+		want string
+	}{
+		{
+			name: "needsInput",
+			item: menuBarItem{name: "ws", needsInput: true},
+			want: "respond",
+		},
+		{
+			name: "stopped",
+			item: menuBarItem{name: "ws", stopped: true},
+			want: "progress",
+		},
+		{
+			name: "running",
+			item: menuBarItem{name: "ws", running: true},
+			want: "progress",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := workspaceItemSubpath(tc.item)
+			if got != tc.want {
+				t.Errorf("workspaceItemSubpath() = %q; want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAllocTag(t *testing.T) {
+	saved := globalMenuBar
+	defer func() { globalMenuBar = saved }()
+
+	globalMenuBar = &menuBarState{
+		tags: make(map[int]menuBarAction),
+	}
+
+	tag1 := allocTag(menuBarAction{actionURL: "http://example.com"})
+	tag2 := allocTag(menuBarAction{actionURL: "http://other.com"})
+
+	if tag1 == tag2 {
+		t.Errorf("allocTag returned duplicate tags: %d", tag1)
+	}
+	if tag1 < 1 {
+		t.Errorf("allocTag returned non-positive tag: %d", tag1)
+	}
+
+	globalMenuBar.mu.Lock()
+	action, ok := globalMenuBar.tags[tag1]
+	globalMenuBar.mu.Unlock()
+	if !ok {
+		t.Errorf("allocTag did not store action for tag %d", tag1)
+	}
+	if action.actionURL != "http://example.com" {
+		t.Errorf("stored action URL = %q; want %q", action.actionURL, "http://example.com")
+	}
+}
+
+func TestToMenuBarItem(t *testing.T) {
+	t.Run("running", func(t *testing.T) {
+		w := workspaceInfo{
+			DirName:    "test-workspace",
+			Running:    true,
+			NeedsInput: false,
+			InProgress: true,
+		}
+		got := toMenuBarItem(w)
+		if got.name != "test-workspace" {
+			t.Errorf("name = %q; want %q", got.name, "test-workspace")
+		}
+		if !got.running {
+			t.Error("expected running = true")
+		}
+		if got.needsInput {
+			t.Error("expected needsInput = false")
+		}
+		if got.stopped {
+			t.Error("expected stopped = false (running overrides)")
+		}
+	})
+
+	t.Run("stoppedAfterProgress", func(t *testing.T) {
+		w := workspaceInfo{
+			DirName:    "stopped-ws",
+			Running:    false,
+			NeedsInput: false,
+			InProgress: true,
+		}
+		got := toMenuBarItem(w)
+		if !got.stopped {
+			t.Error("expected stopped = true (not running but in progress)")
+		}
+	})
+
+	t.Run("idle", func(t *testing.T) {
+		w := workspaceInfo{
+			DirName:    "idle-ws",
+			Running:    false,
+			NeedsInput: false,
+			InProgress: false,
+		}
+		got := toMenuBarItem(w)
+		if got.stopped {
+			t.Error("expected stopped = false (never started)")
+		}
+	})
+}

--- a/cmd/sgai/serve.go
+++ b/cmd/sgai/serve.go
@@ -475,10 +475,16 @@ func cmdServe(args []string) {
 	srv.registerAPIRoutes(mux)
 	handler := srv.spaMiddleware(mux)
 
-	log.Println("sgai serve listening on http://" + *listenAddr)
-	if err := http.ListenAndServe(*listenAddr, handler); err != nil {
-		log.Fatalln("server error:", err)
-	}
+	baseURL := "http://" + *listenAddr
+	log.Println("sgai serve listening on", baseURL)
+
+	go func() {
+		if err := http.ListenAndServe(*listenAddr, handler); err != nil {
+			log.Fatalln("server error:", err)
+		}
+	}()
+
+	startMenuBar(baseURL, srv)
 }
 
 func renderDotToSVG(dotContent string) string {


### PR DESCRIPTION
## Summary

- Adds a macOS menu bar status item integrated into `sgai serve` that shows factory attention status (badge count, dropdown with needing-attention factories, quick actions)
- Event-driven updates via SSE broker subscription — no polling
- Includes Objective-C native Cocoa integration (`NSStatusBar`) with Go CGo bridge
- Non-darwin builds get a no-op stub
- Unit tests for menu bar item logic (attention counting, filtering, URL building, label formatting)