### PR TITLE
cmd/sgai: publish SSE event on log append for live reload

### DIFF
--- a/GOALS/2026_02_13_log_tab_not_live_reloading.md
+++ b/GOALS/2026_02_13_log_tab_not_live_reloading.md
@@ -1,0 +1,26 @@
+---
+flow: |
+  "backend-go-developer" -> "go-readability-reviewer"
+  "backend-go-developer" -> "stpa-analyst"
+  "go-readability-reviewer" -> "stpa-analyst"
+  "general-purpose" -> "stpa-analyst"
+  "react-developer" -> "react-reviewer"
+  "react-reviewer" -> "stpa-analyst"
+  "project-critic-council"
+  "skill-writer"
+  "stpa-analyst"
+models:
+  "coordinator": "anthropic/claude-opus-4-6 (max)"
+  "backend-go-developer": "anthropic/claude-opus-4-6"
+  "go-readability-reviewer": "anthropic/claude-opus-4-6 (max)"
+  "general-purpose": "anthropic/claude-opus-4-6"
+  "react-developer": "anthropic/claude-opus-4-6"
+  "react-reviewer": "anthropic/claude-opus-4-6 (max)"
+  "stpa-analyst": "anthropic/claude-opus-4-6 (max)"
+  "project-critic-council": ["anthropic/claude-opus-4-6", "anthropic/claude-opus-4-6", "anthropic/claude-opus-4-6"]
+  "skill-writer": "anthropic/claude-opus-4-6"
+interactive: yes
+completionGateScript: make test
+---
+
+- [x] the Log tab doesn't live reload

--- a/cmd/sgai/outputlog.go
+++ b/cmd/sgai/outputlog.go
@@ -182,6 +182,9 @@ func (s *Server) captureOutput(stdout, stderr io.ReadCloser, sessionKey, prefix 
 				sess.outputLog.add(logLine{prefix: prefix, text: line})
 			}
 			s.mu.Unlock()
+			if sess != nil {
+				s.sseBroker.publish(sseEvent{Type: "log:append", Data: map[string]string{"workspace": sessionKey}})
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Publish an SSE `log:append` event after new log lines are added, so the Log tab live-reloads in the browser without requiring a manual refresh.