### PR TITLE
cmd/sgai: update mac menu bar and notification

### DIFF
--- a/GOALS/2026_02_15_improved_mac_menu_bar.md
+++ b/GOALS/2026_02_15_improved_mac_menu_bar.md
@@ -1,0 +1,76 @@
+---
+flow: |
+  "backend-go-developer" -> "go-readability-reviewer"
+  "backend-go-developer" -> "stpa-analyst"
+  "go-readability-reviewer" -> "stpa-analyst"
+  "general-purpose" -> "stpa-analyst"
+  "react-developer" -> "react-reviewer"
+  "react-reviewer" -> "stpa-analyst"
+  "project-critic-council"
+  "skill-writer"
+  "stpa-analyst"
+models:
+  "coordinator": "anthropic/claude-opus-4-6 (max)"
+  "backend-go-developer": "anthropic/claude-opus-4-6"
+  "go-readability-reviewer": "anthropic/claude-opus-4-6 (max)"
+  "general-purpose": "anthropic/claude-opus-4-6"
+  "react-developer": "anthropic/claude-opus-4-6"
+  "react-reviewer": "anthropic/claude-opus-4-6 (max)"
+  "stpa-analyst": "anthropic/claude-opus-4-6 (max)"
+  "project-critic-council": ["anthropic/claude-opus-4-6", "anthropic/claude-opus-4-6", "anthropic/claude-opus-4-6"]
+  "skill-writer": "anthropic/claude-opus-4-6"
+completionGateScript: make test
+---
+
+- [x] update the Mac menu bar so that anything that's pinned shows up there, even if it wasn't started yet.
+  - [x] the counter seems to be counting correctly, but the list doesn't seem to be showing the pinned projects
+  - [x] the menu bar is not loading
+- [x] replace the osascript notification with a proper Mac native notification
+
+- [x] another panic to be fixed:
+```
+*** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'bundleProxyForCurrentProcess is nil: mainBundle.bundleURL file:///Users/ucirello/go/src/github.com/sandgardenhq/sgai/bin/'
+*** First throw call stack:
+(
+	0   CoreFoundation                      0x000000018908d8ec __exceptionPreprocess + 176
+	1   libobjc.A.dylib                     0x0000000188b66418 objc_exception_throw + 88
+	2   Foundation                          0x000000018b1d9284 _userInfoForFileAndLine + 0
+	3   UserNotifications                   0x000000019879a2bc __53+[UNUserNotificationCenter currentNotificationCenter]_block_invoke.cold.2 + 116
+	4   UserNotifications                   0x00000001987664d8 __53+[UNUserNotificationCenter currentNotificationCenter]_block_invoke + 472
+	5   libdispatch.dylib                   0x0000000188dfead4 _dispatch_client_callout + 16
+	6   libdispatch.dylib                   0x0000000188de7a60 _dispatch_once_callout + 32
+	7   UserNotifications                   0x00000001987662fc +[UNUserNotificationCenter currentNotificationCenter] + 156
+	8   sgai-base                           0x0000000100e060ec SendNativeNotification + 96
+	9   sgai-base                           0x00000001009abdfc runtime.asmcgocall.abi0 + 124
+)
+libc++abi: terminating due to uncaught exception of type NSException
+SIGABRT: abort
+PC=0x188f675b0 m=17 sigcode=0
+signal arrived during cgo execution
+
+goroutine 749 gp=0x438eb1e98960 m=17 mp=0x438eb1e53008 [syscall]:
+runtime.cgocall(0x100e06078, 0x438eb1ed12c8)
+	/usr/local/go/src/runtime/cgocall.go:167 +0x44 fp=0x438eb1ed1290 sp=0x438eb1ed1250 pc=0x1009a1734
+github.com/sandgardenhq/sgai/pkg/notify._Cfunc_SendNativeNotification(0x9df269030, 0x9df3fcd20)
+	_cgo_gotypes.go:83 +0x2c fp=0x438eb1ed12c0 sp=0x438eb1ed1290 pc=0x100c839dc
+github.com/sandgardenhq/sgai/pkg/notify.sendLocal({0x100e07b02?, 0x101f69800?}, {0x438eb1e7eec0, 0x20})
+	/Users/ucirello/go/src/github.com/sandgardenhq/improved-mac-menu-bar/pkg/notify/notify_darwin.go:22 +0x90 fp=0x438eb1ed1330 sp=0x438eb1ed12c0 pc=0x100c83b70
+github.com/sandgardenhq/sgai/pkg/notify.Send({0x100e07b02, 0x4}, {0x438eb1e7eec0, 0x20})
+	/Users/ucirello/go/src/github.com/sandgardenhq/improved-mac-menu-bar/pkg/notify/send.go:14 +0x7c fp=0x438eb1ed13c0 sp=0x438eb1ed1330 pc=0x100c837fc
+main.runFlowAgentWithModel({_, _}, {{0x438eb1bbf860, 0x44}, {0x438eb1ae6140, 0x4c}, {0x100e0f44e, 0xb}, 0x438eb1da4560, {0x438eb1bc7560, ...}, ...}, ...)
+	/Users/ucirello/go/src/github.com/sandgardenhq/improved-mac-menu-bar/cmd/sgai/main.go:875 +0x1c14 fp=0x438eb1ed2040 sp=0x438eb1ed13c0 pc=0x100d616a4
+main.runSingleModelIteration({_, _}, {{0x438eb1bbf860, 0x44}, {0x438eb1ae6140, 0x4c}, {0x100e0f44e, 0xb}, 0x438eb1da4560, {0x438eb1bc7560, ...}, ...}, ...)
+	/Users/ucirello/go/src/github.com/sandgardenhq/improved-mac-menu-bar/cmd/sgai/main.go:635 +0xf4 fp=0x438eb1ed2520 sp=0x438eb1ed2040 pc=0x100d5f9c4
+main.runMultiModelAgent({_, _}, {{0x438eb1bbf860, 0x44}, {0x438eb1ae6140, 0x4c}, {0x100e0f44e, 0xb}, 0x438eb1da4560, {0x438eb1bc7560, ...}, ...}, ...)
+	/Users/ucirello/go/src/github.com/sandgardenhq/improved-mac-menu-bar/cmd/sgai/main.go:543 +0x2ac fp=0x438eb1ed2e00 sp=0x438eb1ed2520 pc=0x100d5e7ec
+main.runFlowAgent({_, _}, {_, _}, {_, _}, {_, _}, _, {{0x100e0ab40, ...}, ...}, ...)
+	/Users/ucirello/go/src/github.com/sandgardenhq/improved-mac-menu-bar/cmd/sgai/main.go:948 +0x154 fp=0x438eb1ed32d0 sp=0x438eb1ed2e00 pc=0x100d63114
+main.runWorkflow({0x101f90738, 0x438eb1f3e370}, {0x438eb1d66430, 0x1, 0x1}, {0x438eb2102100, 0x1a}, {0x101f89cf8, 0x438eb1f3e3c0})
+	/Users/ucirello/go/src/github.com/sandgardenhq/improved-mac-menu-bar/cmd/sgai/main.go:299 +0x14c4 fp=0x438eb1ed3f00 sp=0x438eb1ed32d0 pc=0x100d5cdd4
+main.(*Server).startSession.func1()
+	/Users/ucirello/go/src/github.com/sandgardenhq/improved-mac-menu-bar/cmd/sgai/serve.go:425 +0xdc fp=0x438eb1ed3fd0 sp=0x438eb1ed3f00 pc=0x100d78aac
+runtime.goexit({})
+	/usr/local/go/src/runtime/asm_arm64.s:1447 +0x4 fp=0x438eb1ed3fd0 sp=0x438eb1ed3fd0 pc=0x1009ac004
+created by main.(*Server).startSession in goroutine 639
+	/Users/ucirello/go/src/github.com/sandgardenhq/improved-mac-menu-bar/cmd/sgai/serve.go:416 +0x6d4
+```

--- a/cmd/sgai/menubar_darwin.go
+++ b/cmd/sgai/menubar_darwin.go
@@ -104,7 +104,7 @@ func rebuildMenuFromServer(srv *Server) {
 
 	C.MenuBarAddSeparator()
 
-	for _, item := range filterAttentionItems(items) {
+	for _, item := range filterVisibleItems(items) {
 		label := formatMenuItemLabel(item)
 		itemURL := workspaceURL(baseURL, item.name, workspaceItemSubpath(item))
 		tag := allocTag(menuBarAction{actionURL: itemURL})

--- a/cmd/sgai/serve.go
+++ b/cmd/sgai/serve.go
@@ -519,8 +519,7 @@ func cmdServe(args []string) {
 		}
 	}()
 
-	_ = startMenuBar
-	<-ctx.Done()
+	startMenuBar(ctx, baseURL, srv)
 	if errClose := httpServer.Close(); errClose != nil {
 		log.Println("http server close:", errClose)
 	}

--- a/pkg/notify/notify_darwin.go
+++ b/pkg/notify/notify_darwin.go
@@ -2,21 +2,23 @@
 
 package notify
 
-import (
-	"os/exec"
-	"strings"
-)
+/*
+#cgo CFLAGS: -x objective-c
+#cgo LDFLAGS: -framework Cocoa -framework UserNotifications
+
+#include <stdlib.h>
+
+extern void SendNativeNotification(const char *title, const char *message);
+*/
+import "C"
+
+import "unsafe"
 
 func sendLocal(title, message string) error {
-	title = escapeAppleScript(title)
-	message = escapeAppleScript(message)
-
-	script := `display notification "` + message + `" with title "` + title + `"`
-	return exec.Command("osascript", "-e", script).Run()
-}
-
-func escapeAppleScript(s string) string {
-	s = strings.ReplaceAll(s, `\`, `\\`)
-	s = strings.ReplaceAll(s, `"`, `\"`)
-	return s
+	cTitle := C.CString(title)
+	defer C.free(unsafe.Pointer(cTitle))
+	cMessage := C.CString(message)
+	defer C.free(unsafe.Pointer(cMessage))
+	C.SendNativeNotification(cTitle, cMessage)
+	return nil
 }

--- a/pkg/notify/notify_darwin.m
+++ b/pkg/notify/notify_darwin.m
@@ -1,0 +1,64 @@
+#import <Cocoa/Cocoa.h>
+#import <UserNotifications/UserNotifications.h>
+
+static BOOL authorizationRequested = NO;
+static BOOL authorizationGranted = NO;
+
+static void requestAuthorization(void) {
+	if (authorizationRequested) {
+		return;
+	}
+	authorizationRequested = YES;
+
+	if ([[NSBundle mainBundle] bundleIdentifier] == nil) {
+		return;
+	}
+
+	UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
+	dispatch_semaphore_t sem = dispatch_semaphore_create(0);
+	[center requestAuthorizationWithOptions:(UNAuthorizationOptionAlert | UNAuthorizationOptionSound)
+		completionHandler:^(BOOL granted, NSError *error) {
+			authorizationGranted = granted;
+			dispatch_semaphore_signal(sem);
+		}];
+	dispatch_semaphore_wait(sem, dispatch_time(DISPATCH_TIME_NOW, 5 * NSEC_PER_SEC));
+}
+
+static void sendWithUNNotification(NSString *title, NSString *message) {
+	UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
+	UNMutableNotificationContent *content = [[UNMutableNotificationContent alloc] init];
+	content.title = title;
+	content.body = message;
+	content.sound = [UNNotificationSound defaultSound];
+
+	NSString *identifier = [[NSUUID UUID] UUIDString];
+	UNNotificationRequest *request = [UNNotificationRequest
+		requestWithIdentifier:identifier
+		content:content
+		trigger:nil];
+	[center addNotificationRequest:request withCompletionHandler:nil];
+}
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+static void sendWithNSUserNotification(NSString *title, NSString *message) {
+	NSUserNotification *notification = [[NSUserNotification alloc] init];
+	notification.title = title;
+	notification.informativeText = message;
+	notification.soundName = NSUserNotificationDefaultSoundName;
+	[[NSUserNotificationCenter defaultUserNotificationCenter] deliverNotification:notification];
+}
+#pragma clang diagnostic pop
+
+void SendNativeNotification(const char *title, const char *message) {
+	NSString *nsTitle = [NSString stringWithUTF8String:title];
+	NSString *nsMessage = [NSString stringWithUTF8String:message];
+
+	requestAuthorization();
+
+	if (authorizationGranted) {
+		sendWithUNNotification(nsTitle, nsMessage);
+	} else {
+		sendWithNSUserNotification(nsTitle, nsMessage);
+	}
+}

--- a/pkg/notify/ntfy.go
+++ b/pkg/notify/ntfy.go
@@ -1,5 +1,5 @@
 // Package notify provides desktop notification support.
-// On macOS, notifications are displayed using osascript.
+// On macOS, notifications are displayed using native UserNotifications framework.
 // On other platforms, Send is a no-op.
 package notify
 


### PR DESCRIPTION
## Summary

- Update the Mac menu bar to show pinned projects even when not running, with distinct icons for running/idle/stopped/needs-input states
- Replace osascript-based notifications with native macOS UserNotifications framework (with NSUserNotification fallback for non-bundled binaries)
- Rename `filterAttentionItems` to `filterVisibleItems` to reflect the broader scope of visible menu items (pinned + attention)