### PR TITLE
cmd/sgai/webapp: render markdown in Messages tab body

### DIFF
--- a/GOALS/2026_02_15_messages_tab_not_rendering_markdown.md
+++ b/GOALS/2026_02_15_messages_tab_not_rendering_markdown.md
@@ -1,0 +1,24 @@
+---
+flow: |
+  "backend-go-developer" -> "go-readability-reviewer"
+  "backend-go-developer" -> "stpa-analyst"
+  "go-readability-reviewer" -> "stpa-analyst"
+  "general-purpose" -> "stpa-analyst"
+  "react-developer" -> "react-reviewer"
+  "react-reviewer" -> "stpa-analyst"
+  "project-critic-council"
+  "skill-writer"
+models:
+  "coordinator": "anthropic/claude-opus-4-6 (max)"
+  "backend-go-developer": "anthropic/claude-opus-4-6"
+  "go-readability-reviewer": "anthropic/claude-opus-4-6"
+  "general-purpose": "anthropic/claude-opus-4-6"
+  "react-developer": "anthropic/claude-opus-4-6"
+  "react-reviewer": "anthropic/claude-opus-4-6"
+  "stpa-analyst": "anthropic/claude-opus-4-6"
+  "project-critic-council": ["anthropic/claude-opus-4-6"]
+  "skill-writer": "anthropic/claude-opus-4-6 (max)"
+completionGateScript: make test
+---
+
+- [x] the Messages tab in the Workspace page, when I unfold the messages, the output is markdown but is not being rendered.

--- a/cmd/sgai/webapp/src/pages/tabs/MessagesTab.test.tsx
+++ b/cmd/sgai/webapp/src/pages/tabs/MessagesTab.test.tsx
@@ -40,6 +40,19 @@ const messagesResponse: ApiMessagesResponse = {
   ],
 };
 
+const markdownMessagesResponse: ApiMessagesResponse = {
+  messages: [
+    {
+      id: 3,
+      fromAgent: "coordinator",
+      toAgent: "backend-developer",
+      body: "## Task\n\nPlease implement the **API** with:\n\n- endpoint `/users`\n- endpoint `/posts`\n\n```go\nfunc main() {}\n```",
+      subject: "API Implementation",
+      read: true,
+    },
+  ],
+};
+
 function renderMessagesTab() {
   return render(
     <MemoryRouter>
@@ -106,5 +119,34 @@ describe("MessagesTab", () => {
 
     const calledUrl = (mockFetch.mock.calls[0] as unknown[])[0] as string;
     expect(calledUrl).toContain("/api/v1/workspaces/test-project/messages");
+  });
+
+  it("renders markdown content in message body", async () => {
+    mockFetch.mockResolvedValue(new Response(JSON.stringify(markdownMessagesResponse)));
+    renderMessagesTab();
+
+    await waitFor(() => {
+      expect(screen.getAllByText("coordinator").length).toBeGreaterThan(0);
+    });
+
+    const details = document.querySelector("details");
+    expect(details).not.toBeNull();
+    details!.setAttribute("open", "");
+
+    await waitFor(() => {
+      const heading = document.querySelector("h2");
+      expect(heading).not.toBeNull();
+      expect(heading!.textContent).toBe("Task");
+    });
+
+    const bold = document.querySelector("strong");
+    const strongTexts = Array.from(document.querySelectorAll("strong")).map((el) => el.textContent);
+    expect(strongTexts).toContain("API");
+
+    const listItems = document.querySelectorAll("li");
+    expect(listItems.length).toBe(2);
+
+    const codeBlock = document.querySelector("pre");
+    expect(codeBlock).not.toBeNull();
   });
 });

--- a/cmd/sgai/webapp/src/pages/tabs/MessagesTab.tsx
+++ b/cmd/sgai/webapp/src/pages/tabs/MessagesTab.tsx
@@ -3,6 +3,7 @@ import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { MarkdownContent } from "@/components/MarkdownContent";
 import { api } from "@/lib/api";
 import { useWorkspaceSSEEvent } from "@/hooks/useSSE";
 import type { ApiMessagesResponse, ApiMessageEntry } from "@/types";
@@ -46,9 +47,7 @@ function MessageItem({ message }: { message: ApiMessageEntry }) {
           <div className="text-xs text-muted-foreground">
             <strong>To:</strong> {message.toAgent}
           </div>
-          <div className="prose prose-sm max-w-none mt-2 whitespace-pre-wrap text-sm">
-            {message.body}
-          </div>
+          <MarkdownContent content={message.body} className="mt-2" />
         </div>
       )}
     </details>


### PR DESCRIPTION
## Summary

- Use the existing `MarkdownContent` component in the Messages tab to render message bodies as Markdown instead of plain text
- Add test coverage for Markdown rendering (headings, bold, lists, code blocks)