### PR TITLE
AGENTS.md: use dynamic port for test listen address

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ Always run the code reviewer when one is available.
 Always make sure you use tmux and playwright to test the changes.
 
 For tests:
-use listen address `-listen-addr 127.0.0.1:8181`
+use listen address `-listen-addr 127.0.0.1:0` (observe the port number and use that from this moment on)
 use directory ./verification
 use `make build` to generate the binary
 


### PR DESCRIPTION
## Summary
- Changes test listen address from fixed port `127.0.0.1:8181` to dynamic port `127.0.0.1:0` so the OS assigns an available port, avoiding conflicts.
- Adds note to observe the assigned port number and use it from that point on.