### PR TITLE
cmd/sgai: add continuous mode for always-on factory operation

### DIFF
--- a/GOALS/2026_02_16_continuous_mode.md
+++ b/GOALS/2026_02_16_continuous_mode.md
@@ -1,0 +1,80 @@
+---
+flow: |
+  "backend-go-developer" -> "go-readability-reviewer"
+  "backend-go-developer" -> "stpa-analyst"
+  "go-readability-reviewer" -> "stpa-analyst"
+  "general-purpose" -> "stpa-analyst"
+  "react-developer" -> "react-reviewer"
+  "react-reviewer" -> "stpa-analyst"
+  "project-critic-council"
+  "skill-writer"
+models:
+  "coordinator": "anthropic/claude-opus-4-6 (max)"
+  "backend-go-developer": "anthropic/claude-opus-4-6"
+  "go-readability-reviewer": "anthropic/claude-opus-4-6"
+  "general-purpose": "anthropic/claude-opus-4-6"
+  "react-developer": "anthropic/claude-opus-4-6"
+  "react-reviewer": "anthropic/claude-opus-4-6"
+  "stpa-analyst": "anthropic/claude-opus-4-6"
+  "project-critic-council": ["anthropic/claude-opus-4-6"]
+  "skill-writer": "anthropic/claude-opus-4-6 (max)"
+completionGateScript: make test
+---
+
+I want to add a continuous mode. 
+
+What's the continuous mode? It is a mode that the factory is always running, basically reacting to either changes in GOAL.md or to steering messages. 
+
+In essence, it starts once and when the coordinator mark state:complete, the factory stores the checksum of GOAL.md in memory and keeps an eye in the message bus. 
+
+If a new human partner message comes in, or, GOAL.md checksum changes, it starts a new workflow. 
+
+When the reason to restart the workflow is the steering message, the factory prepends the message to the start of GOAL.md, right after the frontmatter. 
+
+When is the continuous mode enabled? When the GOAL.md attribute "continuousModePrompt" is set. 
+
+Basically, what happens is that when in continuous mode, that the coordinator decides to mark state:complete, it will then invoke opencode (using the same environment variables as regular workflow agents) using as prompt the "continuousModePrompt", only then store the GOAL.md checksum in memory and observe the message hub. 
+
+
+- [x] Interview the human partner and expand the GOAL.md with the tasks necessary to carry the goal above.
+
+## Implementation Tasks
+
+### Backend Go Changes (cmd/sgai/)
+
+- [x] Add `ContinuousModePrompt` field to `GoalMetadata` struct in `main.go`
+- [x] Create new file `continuous.go` with:
+  - [x] `runContinuousWorkflow()` - outer loop wrapping `runWorkflow()`
+  - [x] `runContinuousModePrompt()` - invokes opencode with prompt (3 retries, logs task/progress/currentAgent to state.json for UI visibility)
+  - [x] `watchForTrigger()` - polls GOAL.md checksum + Human Partner messages every 2s
+  - [x] `prependSteeringMessage()` - inserts steering text after GOAL.md frontmatter, marks message as read
+  - [x] `hasHumanPartnerMessage()` - checks for unread messages from "Human Partner"
+- [x] Modify `serve.go` `startSession()` goroutine to call `runContinuousWorkflow()` when `continuousModePrompt` is set (always auto-mode), otherwise `runWorkflow()` as before
+- [x] Add `continuousMode` boolean field to workspace detail API response in `serve_api.go`
+
+### Frontend React Changes (cmd/sgai/webapp/)
+
+- [x] Add `continuousMode: boolean` field to `ApiWorkspaceDetailResponse` in `types/index.ts`
+- [x] Update `WorkspaceDetail.tsx` button rendering:
+  - When `continuousMode` is true: show only "Continuous Self-Drive" + "Stop"
+  - When `continuousMode` is false: show normal "Self-Drive" | "Start" | "Stop"
+
+### Tests
+
+- [x] Create `continuous_test.go` with unit tests for all new functions (watchForTrigger, prependSteeringMessage, hasHumanPartnerMessage, runContinuousModePrompt observability)
+- [x] Update `WorkspaceDetail.test.tsx` with continuous mode button rendering tests
+- [x] `make test` passes (all existing + new tests)
+- [x] `make lint` passes
+- [x] `make build` succeeds
+
+### Verification
+
+- [x] Playwright screenshot showing "Continuous Self-Drive" button when GOAL.md has continuousModePrompt
+- [x] Playwright screenshot showing normal buttons when no continuousModePrompt
+- [x] Progress entries visible in UI during continuous mode prompt step between cycles
+
+### PR
+
+- [x] Create a draft PR in sandgardenhq/sgai
+
+

--- a/cmd/sgai/continuous.go
+++ b/cmd/sgai/continuous.go
@@ -1,0 +1,289 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/sandgardenhq/sgai/pkg/state"
+)
+
+type triggerKind string
+
+const (
+	triggerNone     triggerKind = ""
+	triggerGoal     triggerKind = "goal-changed"
+	triggerSteering triggerKind = "steering-message"
+)
+
+const (
+	continuousModeMaxRetries   = 3
+	continuousModePollInterval = 2 * time.Second
+)
+
+func runContinuousWorkflow(ctx context.Context, args []string, continuousPrompt string, mcpURL string, logWriter io.Writer) {
+	if len(args) < 1 {
+		log.Fatalln("usage: sgai <target_directory>")
+	}
+
+	dir, errAbs := filepath.Abs(args[0])
+	if errAbs != nil {
+		log.Fatalln(errAbs)
+	}
+
+	goalPath := filepath.Join(dir, "GOAL.md")
+	stateJSONPath := filepath.Join(dir, ".sgai", "state.json")
+
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+
+		runWorkflow(ctx, args, mcpURL, logWriter)
+
+		if ctx.Err() != nil {
+			return
+		}
+
+		runContinuousModePrompt(ctx, dir, continuousPrompt, mcpURL)
+
+		if ctx.Err() != nil {
+			return
+		}
+
+		checksum, errChecksum := computeGoalChecksum(goalPath)
+		if errChecksum != nil {
+			log.Println("failed to compute GOAL.md checksum:", errChecksum)
+			return
+		}
+
+		trigger := watchForTrigger(ctx, dir, stateJSONPath, checksum)
+		if trigger == triggerNone {
+			return
+		}
+
+		if trigger == triggerSteering {
+			wfState, errLoad := state.Load(stateJSONPath)
+			if errLoad != nil {
+				log.Println("failed to load state for steering message:", errLoad)
+				return
+			}
+			found, msg := hasHumanPartnerMessage(wfState.Messages)
+			if found && msg != nil {
+				if errPrepend := prependSteeringMessage(goalPath, msg.Body); errPrepend != nil {
+					log.Println("failed to prepend steering message:", errPrepend)
+				}
+				markMessageAsRead(stateJSONPath, msg.ID)
+			}
+		}
+
+		resetWorkflowForNextCycle(stateJSONPath)
+	}
+}
+
+func runContinuousModePrompt(ctx context.Context, dir string, prompt string, mcpURL string) {
+	stateJSONPath := filepath.Join(dir, ".sgai", "state.json")
+
+	updateContinuousModeState(stateJSONPath, "Running continuous mode prompt...", "continuous-mode", "continuous mode prompt started")
+
+	for attempt := range continuousModeMaxRetries {
+		if ctx.Err() != nil {
+			return
+		}
+
+		cmd := exec.CommandContext(ctx, "opencode", "run", "--title", "continuous-mode-prompt")
+		cmd.Dir = dir
+		cmd.Env = append(os.Environ(),
+			"OPENCODE_CONFIG_DIR="+filepath.Join(dir, ".sgai"),
+			"SGAI_MCP_URL="+mcpURL,
+			"SGAI_AGENT_IDENTITY=continuous-mode",
+			"SGAI_MCP_INTERACTIVE=auto")
+		cmd.Stdin = strings.NewReader(prompt)
+
+		if errRun := cmd.Run(); errRun != nil {
+			progressMsg := fmt.Sprintf("continuous mode prompt attempt %d/%d failed: %v", attempt+1, continuousModeMaxRetries, errRun)
+			updateContinuousModeProgress(stateJSONPath, progressMsg)
+			continue
+		}
+
+		updateContinuousModeProgress(stateJSONPath, "continuous mode prompt completed successfully")
+		return
+	}
+
+	updateContinuousModeProgress(stateJSONPath, "continuous mode prompt failed after all retries, proceeding to watch loop")
+}
+
+func watchForTrigger(ctx context.Context, dir string, stateJSONPath string, lastChecksum string) triggerKind {
+	goalPath := filepath.Join(dir, "GOAL.md")
+	for {
+		select {
+		case <-ctx.Done():
+			return triggerNone
+		case <-time.After(continuousModePollInterval):
+		}
+
+		currentChecksum, errChecksum := computeGoalChecksum(goalPath)
+		if errChecksum != nil {
+			continue
+		}
+		if currentChecksum != lastChecksum {
+			return triggerGoal
+		}
+
+		wfState, errLoad := state.Load(stateJSONPath)
+		if errLoad != nil {
+			continue
+		}
+		found, _ := hasHumanPartnerMessage(wfState.Messages)
+		if found {
+			return triggerSteering
+		}
+	}
+}
+
+func prependSteeringMessage(goalPath string, message string) error {
+	content, errRead := os.ReadFile(goalPath)
+	if errRead != nil {
+		return fmt.Errorf("reading GOAL.md: %w", errRead)
+	}
+
+	delimiter := []byte("---")
+
+	if !bytes.HasPrefix(content, delimiter) {
+		newContent := message + "\n\n" + string(content)
+		return os.WriteFile(goalPath, []byte(newContent), 0644)
+	}
+
+	rest := content[len(delimiter):]
+	if len(rest) > 0 && rest[0] == '\n' {
+		rest = rest[1:]
+	}
+
+	closingIdx := bytes.Index(rest, delimiter)
+	if closingIdx == -1 {
+		newContent := message + "\n\n" + string(content)
+		return os.WriteFile(goalPath, []byte(newContent), 0644)
+	}
+
+	frontmatterEnd := len(delimiter) + 1 + closingIdx + len(delimiter)
+	if frontmatterEnd < len(content) && content[frontmatterEnd] == '\n' {
+		frontmatterEnd++
+	}
+
+	var buf bytes.Buffer
+	buf.Write(content[:frontmatterEnd])
+	buf.WriteString("\n")
+	buf.WriteString(message)
+	buf.WriteString("\n\n")
+	if frontmatterEnd < len(content) {
+		buf.Write(content[frontmatterEnd:])
+	}
+
+	return os.WriteFile(goalPath, buf.Bytes(), 0644)
+}
+
+func hasHumanPartnerMessage(messages []state.Message) (bool, *state.Message) {
+	for i := range messages {
+		if messages[i].Read {
+			continue
+		}
+		if messages[i].FromAgent == "Human Partner" {
+			return true, &messages[i]
+		}
+	}
+	return false, nil
+}
+
+func updateContinuousModeState(stateJSONPath, task, agent, progressMsg string) {
+	wfState, errLoad := state.Load(stateJSONPath)
+	if errLoad != nil {
+		return
+	}
+	wfState.Task = task
+	wfState.CurrentAgent = agent
+	wfState.Progress = append(wfState.Progress, state.ProgressEntry{
+		Timestamp:   time.Now().UTC().Format(time.RFC3339),
+		Agent:       agent,
+		Description: progressMsg,
+	})
+	if errSave := state.Save(stateJSONPath, wfState); errSave != nil {
+		log.Println("failed to update continuous mode state:", errSave)
+	}
+}
+
+func updateContinuousModeProgress(stateJSONPath, progressMsg string) {
+	wfState, errLoad := state.Load(stateJSONPath)
+	if errLoad != nil {
+		return
+	}
+	wfState.Progress = append(wfState.Progress, state.ProgressEntry{
+		Timestamp:   time.Now().UTC().Format(time.RFC3339),
+		Agent:       "continuous-mode",
+		Description: progressMsg,
+	})
+	if errSave := state.Save(stateJSONPath, wfState); errSave != nil {
+		log.Println("failed to update continuous mode progress:", errSave)
+	}
+}
+
+func markMessageAsRead(stateJSONPath string, messageID int) {
+	wfState, errLoad := state.Load(stateJSONPath)
+	if errLoad != nil {
+		return
+	}
+	for i := range wfState.Messages {
+		if wfState.Messages[i].ID == messageID {
+			wfState.Messages[i].Read = true
+			wfState.Messages[i].ReadAt = time.Now().UTC().Format(time.RFC3339)
+			wfState.Messages[i].ReadBy = "continuous-mode"
+			break
+		}
+	}
+	if errSave := state.Save(stateJSONPath, wfState); errSave != nil {
+		log.Println("failed to mark message as read:", errSave)
+	}
+}
+
+func resetWorkflowForNextCycle(stateJSONPath string) {
+	wfState, errLoad := state.Load(stateJSONPath)
+	if errLoad != nil {
+		return
+	}
+	wfState.Status = state.StatusWorking
+	wfState.InteractiveAutoLock = true
+	if errSave := state.Save(stateJSONPath, wfState); errSave != nil {
+		log.Println("failed to reset workflow for next cycle:", errSave)
+	}
+}
+
+func readContinuousModePrompt(workspacePath string) string {
+	goalPath := filepath.Join(workspacePath, "GOAL.md")
+	data, errRead := os.ReadFile(goalPath)
+	if errRead != nil {
+		return ""
+	}
+	metadata, errParse := parseYAMLFrontmatter(data)
+	if errParse != nil {
+		return ""
+	}
+	return metadata.ContinuousModePrompt
+}
+
+func setContinuousAutoMode(workspacePath string) {
+	stateJSONPath := filepath.Join(workspacePath, ".sgai", "state.json")
+	wfState, errLoad := state.Load(stateJSONPath)
+	if errLoad != nil {
+		return
+	}
+	wfState.InteractiveAutoLock = true
+	if errSave := state.Save(stateJSONPath, wfState); errSave != nil {
+		log.Println("failed to set continuous auto mode:", errSave)
+	}
+}

--- a/cmd/sgai/continuous_test.go
+++ b/cmd/sgai/continuous_test.go
@@ -1,0 +1,534 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sandgardenhq/sgai/pkg/state"
+)
+
+func TestPrependSteeringMessage(t *testing.T) {
+	t.Run("withFrontmatter", func(t *testing.T) {
+		dir := t.TempDir()
+		goalPath := filepath.Join(dir, "GOAL.md")
+		original := "---\nflow: |\n  a -> b\n---\n\nOriginal content here.\n"
+		if err := os.WriteFile(goalPath, []byte(original), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := prependSteeringMessage(goalPath, "STEERING: do this next"); err != nil {
+			t.Fatal(err)
+		}
+
+		result, err := os.ReadFile(goalPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		content := string(result)
+		if !strings.HasPrefix(content, "---\nflow: |\n  a -> b\n---\n") {
+			t.Error("frontmatter was corrupted")
+		}
+		if !strings.Contains(content, "STEERING: do this next") {
+			t.Error("steering message not found")
+		}
+		if !strings.Contains(content, "Original content here.") {
+			t.Error("original content was lost")
+		}
+
+		steeringIdx := strings.Index(content, "STEERING: do this next")
+		originalIdx := strings.Index(content, "Original content here.")
+		if steeringIdx >= originalIdx {
+			t.Error("steering message should appear before original content")
+		}
+	})
+
+	t.Run("withoutFrontmatter", func(t *testing.T) {
+		dir := t.TempDir()
+		goalPath := filepath.Join(dir, "GOAL.md")
+		original := "Just some content without frontmatter.\n"
+		if err := os.WriteFile(goalPath, []byte(original), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := prependSteeringMessage(goalPath, "STEERING: new instruction"); err != nil {
+			t.Fatal(err)
+		}
+
+		result, err := os.ReadFile(goalPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		content := string(result)
+		if !strings.HasPrefix(content, "STEERING: new instruction") {
+			t.Error("steering message should be at the beginning")
+		}
+		if !strings.Contains(content, "Just some content without frontmatter.") {
+			t.Error("original content was lost")
+		}
+	})
+
+	t.Run("multipleCalls", func(t *testing.T) {
+		dir := t.TempDir()
+		goalPath := filepath.Join(dir, "GOAL.md")
+		original := "---\nflow: |\n  x -> y\n---\n\nBase content.\n"
+		if err := os.WriteFile(goalPath, []byte(original), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := prependSteeringMessage(goalPath, "First steering"); err != nil {
+			t.Fatal(err)
+		}
+		if err := prependSteeringMessage(goalPath, "Second steering"); err != nil {
+			t.Fatal(err)
+		}
+
+		result, err := os.ReadFile(goalPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		content := string(result)
+		if !strings.Contains(content, "First steering") {
+			t.Error("first steering message was lost")
+		}
+		if !strings.Contains(content, "Second steering") {
+			t.Error("second steering message was lost")
+		}
+		if !strings.Contains(content, "Base content.") {
+			t.Error("original content was lost")
+		}
+
+		metadata, errParse := parseYAMLFrontmatter(result)
+		if errParse != nil {
+			t.Fatal("frontmatter corrupted after multiple prepends:", errParse)
+		}
+		if metadata.Flow == "" {
+			t.Error("flow metadata was lost after multiple prepends")
+		}
+	})
+
+	t.Run("unclosedFrontmatter", func(t *testing.T) {
+		dir := t.TempDir()
+		goalPath := filepath.Join(dir, "GOAL.md")
+		original := "---\nflow: |\n  a -> b\nUnclosed frontmatter content.\n"
+		if err := os.WriteFile(goalPath, []byte(original), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := prependSteeringMessage(goalPath, "STEERING: test"); err != nil {
+			t.Fatal(err)
+		}
+
+		result, err := os.ReadFile(goalPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		content := string(result)
+		if !strings.HasPrefix(content, "STEERING: test") {
+			t.Error("steering message should be at the beginning for unclosed frontmatter")
+		}
+	})
+}
+
+func TestHasHumanPartnerMessage(t *testing.T) {
+	t.Run("findsHumanPartnerMessage", func(t *testing.T) {
+		messages := []state.Message{
+			{ID: 1, FromAgent: "coordinator", ToAgent: "backend", Body: "do stuff", Read: false},
+			{ID: 2, FromAgent: "Human Partner", ToAgent: "coordinator", Body: "please fix this", Read: false},
+			{ID: 3, FromAgent: "backend", ToAgent: "coordinator", Body: "done", Read: false},
+		}
+
+		found, msg := hasHumanPartnerMessage(messages)
+		if !found {
+			t.Fatal("expected to find a Human Partner message")
+		}
+		if msg.ID != 2 {
+			t.Errorf("expected message ID 2, got %d", msg.ID)
+		}
+		if msg.Body != "please fix this" {
+			t.Errorf("unexpected message body: %s", msg.Body)
+		}
+	})
+
+	t.Run("ignoresReadMessages", func(t *testing.T) {
+		messages := []state.Message{
+			{ID: 1, FromAgent: "Human Partner", ToAgent: "coordinator", Body: "old message", Read: true},
+			{ID: 2, FromAgent: "coordinator", ToAgent: "backend", Body: "do stuff", Read: false},
+		}
+
+		found, msg := hasHumanPartnerMessage(messages)
+		if found {
+			t.Error("should not find read Human Partner messages")
+		}
+		if msg != nil {
+			t.Error("message should be nil when not found")
+		}
+	})
+
+	t.Run("ignoresAgentMessages", func(t *testing.T) {
+		messages := []state.Message{
+			{ID: 1, FromAgent: "coordinator", ToAgent: "backend", Body: "build feature", Read: false},
+			{ID: 2, FromAgent: "backend", ToAgent: "coordinator", Body: "done", Read: false},
+		}
+
+		found, _ := hasHumanPartnerMessage(messages)
+		if found {
+			t.Error("should not find agent-to-agent messages")
+		}
+	})
+
+	t.Run("emptyMessages", func(t *testing.T) {
+		found, msg := hasHumanPartnerMessage(nil)
+		if found {
+			t.Error("should return false for nil messages")
+		}
+		if msg != nil {
+			t.Error("msg should be nil for nil messages")
+		}
+
+		found, msg = hasHumanPartnerMessage([]state.Message{})
+		if found {
+			t.Error("should return false for empty messages")
+		}
+		if msg != nil {
+			t.Error("msg should be nil for empty messages")
+		}
+	})
+
+	t.Run("returnsFirstUnread", func(t *testing.T) {
+		messages := []state.Message{
+			{ID: 1, FromAgent: "Human Partner", ToAgent: "coordinator", Body: "first", Read: true},
+			{ID: 2, FromAgent: "Human Partner", ToAgent: "coordinator", Body: "second", Read: false},
+			{ID: 3, FromAgent: "Human Partner", ToAgent: "coordinator", Body: "third", Read: false},
+		}
+
+		found, msg := hasHumanPartnerMessage(messages)
+		if !found {
+			t.Fatal("expected to find message")
+		}
+		if msg.ID != 2 {
+			t.Errorf("expected first unread message (ID 2), got ID %d", msg.ID)
+		}
+	})
+}
+
+func TestWatchForTrigger(t *testing.T) {
+	t.Run("detectsGoalChecksumChange", func(t *testing.T) {
+		dir := t.TempDir()
+		goalPath := filepath.Join(dir, "GOAL.md")
+		sgaiDir := filepath.Join(dir, ".sgai")
+		if err := os.MkdirAll(sgaiDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+
+		originalContent := "---\nflow: |\n  a -> b\n---\n\nOriginal goal.\n"
+		if err := os.WriteFile(goalPath, []byte(originalContent), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		originalChecksum, err := computeGoalChecksum(goalPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		stateJSONPath := filepath.Join(sgaiDir, "state.json")
+		wfState := state.Workflow{
+			Status:   state.StatusComplete,
+			Messages: []state.Message{},
+		}
+		if err := state.Save(stateJSONPath, wfState); err != nil {
+			t.Fatal(err)
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		t.Cleanup(cancel)
+
+		go func() {
+			time.Sleep(500 * time.Millisecond)
+			modifiedContent := "---\nflow: |\n  a -> b\n---\n\nModified goal content.\n"
+			if err := os.WriteFile(goalPath, []byte(modifiedContent), 0644); err != nil {
+				t.Error(err)
+			}
+		}()
+
+		trigger := watchForTrigger(ctx, dir, stateJSONPath, originalChecksum)
+		if trigger != triggerGoal {
+			t.Errorf("expected trigger %q, got %q", triggerGoal, trigger)
+		}
+	})
+
+	t.Run("detectsHumanPartnerMessage", func(t *testing.T) {
+		dir := t.TempDir()
+		goalPath := filepath.Join(dir, "GOAL.md")
+		sgaiDir := filepath.Join(dir, ".sgai")
+		if err := os.MkdirAll(sgaiDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+
+		goalContent := "---\nflow: |\n  a -> b\n---\n\nGoal content.\n"
+		if err := os.WriteFile(goalPath, []byte(goalContent), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		checksum, err := computeGoalChecksum(goalPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		stateJSONPath := filepath.Join(sgaiDir, "state.json")
+		wfState := state.Workflow{
+			Status:   state.StatusComplete,
+			Messages: []state.Message{},
+		}
+		if err := state.Save(stateJSONPath, wfState); err != nil {
+			t.Fatal(err)
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		t.Cleanup(cancel)
+
+		go func() {
+			time.Sleep(500 * time.Millisecond)
+			wfState.Messages = append(wfState.Messages, state.Message{
+				ID:        1,
+				FromAgent: "Human Partner",
+				ToAgent:   "coordinator",
+				Body:      "new steering instruction",
+				Read:      false,
+			})
+			if err := state.Save(stateJSONPath, wfState); err != nil {
+				t.Error(err)
+			}
+		}()
+
+		trigger := watchForTrigger(ctx, dir, stateJSONPath, checksum)
+		if trigger != triggerSteering {
+			t.Errorf("expected trigger %q, got %q", triggerSteering, trigger)
+		}
+	})
+
+	t.Run("exitsOnContextCancel", func(t *testing.T) {
+		dir := t.TempDir()
+		goalPath := filepath.Join(dir, "GOAL.md")
+		sgaiDir := filepath.Join(dir, ".sgai")
+		if err := os.MkdirAll(sgaiDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+
+		goalContent := "---\nflow: |\n  a -> b\n---\n\nGoal content.\n"
+		if err := os.WriteFile(goalPath, []byte(goalContent), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		checksum, err := computeGoalChecksum(goalPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		stateJSONPath := filepath.Join(sgaiDir, "state.json")
+		wfState := state.Workflow{
+			Status:   state.StatusComplete,
+			Messages: []state.Message{},
+		}
+		if err := state.Save(stateJSONPath, wfState); err != nil {
+			t.Fatal(err)
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		go func() {
+			time.Sleep(500 * time.Millisecond)
+			cancel()
+		}()
+
+		trigger := watchForTrigger(ctx, dir, stateJSONPath, checksum)
+		if trigger != triggerNone {
+			t.Errorf("expected trigger %q on cancel, got %q", triggerNone, trigger)
+		}
+	})
+}
+
+func TestRunContinuousModePromptObservability(t *testing.T) {
+	dir := t.TempDir()
+	sgaiDir := filepath.Join(dir, ".sgai")
+	if err := os.MkdirAll(sgaiDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	stateJSONPath := filepath.Join(sgaiDir, "state.json")
+	wfState := state.Workflow{
+		Status:   state.StatusWorking,
+		Messages: []state.Message{},
+		Progress: []state.ProgressEntry{},
+	}
+	if err := state.Save(stateJSONPath, wfState); err != nil {
+		t.Fatal(err)
+	}
+
+	updateContinuousModeState(stateJSONPath, "Running continuous mode prompt...", "continuous-mode", "continuous mode prompt started")
+
+	loaded, errLoad := state.Load(stateJSONPath)
+	if errLoad != nil {
+		t.Fatal(errLoad)
+	}
+
+	if loaded.Task != "Running continuous mode prompt..." {
+		t.Errorf("expected task 'Running continuous mode prompt...', got %q", loaded.Task)
+	}
+	if loaded.CurrentAgent != "continuous-mode" {
+		t.Errorf("expected currentAgent 'continuous-mode', got %q", loaded.CurrentAgent)
+	}
+	if len(loaded.Progress) == 0 {
+		t.Fatal("expected at least one progress entry")
+	}
+
+	lastProgress := loaded.Progress[len(loaded.Progress)-1]
+	if lastProgress.Agent != "continuous-mode" {
+		t.Errorf("expected progress agent 'continuous-mode', got %q", lastProgress.Agent)
+	}
+	if lastProgress.Description != "continuous mode prompt started" {
+		t.Errorf("expected progress description 'continuous mode prompt started', got %q", lastProgress.Description)
+	}
+}
+
+func TestReadContinuousModePrompt(t *testing.T) {
+	t.Run("withPrompt", func(t *testing.T) {
+		dir := t.TempDir()
+		goalPath := filepath.Join(dir, "GOAL.md")
+		content := "---\ncontinuousModePrompt: Review and update project status\n---\n\nGoal content.\n"
+		if err := os.WriteFile(goalPath, []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		prompt := readContinuousModePrompt(dir)
+		if prompt != "Review and update project status" {
+			t.Errorf("expected prompt 'Review and update project status', got %q", prompt)
+		}
+	})
+
+	t.Run("withoutPrompt", func(t *testing.T) {
+		dir := t.TempDir()
+		goalPath := filepath.Join(dir, "GOAL.md")
+		content := "---\nflow: |\n  a -> b\n---\n\nGoal content.\n"
+		if err := os.WriteFile(goalPath, []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		prompt := readContinuousModePrompt(dir)
+		if prompt != "" {
+			t.Errorf("expected empty prompt, got %q", prompt)
+		}
+	})
+
+	t.Run("missingGoalFile", func(t *testing.T) {
+		dir := t.TempDir()
+		prompt := readContinuousModePrompt(dir)
+		if prompt != "" {
+			t.Errorf("expected empty prompt for missing file, got %q", prompt)
+		}
+	})
+}
+
+func TestMarkMessageAsRead(t *testing.T) {
+	dir := t.TempDir()
+	sgaiDir := filepath.Join(dir, ".sgai")
+	if err := os.MkdirAll(sgaiDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	stateJSONPath := filepath.Join(sgaiDir, "state.json")
+	wfState := state.Workflow{
+		Status: state.StatusWorking,
+		Messages: []state.Message{
+			{ID: 1, FromAgent: "Human Partner", ToAgent: "coordinator", Body: "fix this", Read: false},
+			{ID: 2, FromAgent: "coordinator", ToAgent: "backend", Body: "build", Read: false},
+		},
+	}
+	if err := state.Save(stateJSONPath, wfState); err != nil {
+		t.Fatal(err)
+	}
+
+	markMessageAsRead(stateJSONPath, 1)
+
+	loaded, err := state.Load(stateJSONPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !loaded.Messages[0].Read {
+		t.Error("message 1 should be marked as read")
+	}
+	if loaded.Messages[0].ReadBy != "continuous-mode" {
+		t.Errorf("expected readBy 'continuous-mode', got %q", loaded.Messages[0].ReadBy)
+	}
+	if loaded.Messages[0].ReadAt == "" {
+		t.Error("readAt should be set")
+	}
+	if loaded.Messages[1].Read {
+		t.Error("message 2 should remain unread")
+	}
+}
+
+func TestResetWorkflowForNextCycle(t *testing.T) {
+	dir := t.TempDir()
+	sgaiDir := filepath.Join(dir, ".sgai")
+	if err := os.MkdirAll(sgaiDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	stateJSONPath := filepath.Join(sgaiDir, "state.json")
+	wfState := state.Workflow{
+		Status:              state.StatusComplete,
+		InteractiveAutoLock: false,
+	}
+	if err := state.Save(stateJSONPath, wfState); err != nil {
+		t.Fatal(err)
+	}
+
+	resetWorkflowForNextCycle(stateJSONPath)
+
+	loaded, err := state.Load(stateJSONPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if loaded.Status != state.StatusWorking {
+		t.Errorf("expected status 'working', got %q", loaded.Status)
+	}
+	if !loaded.InteractiveAutoLock {
+		t.Error("expected interactiveAutoLock to be true")
+	}
+}
+
+func TestGoalMetadataContinuousModePromptParsing(t *testing.T) {
+	t.Run("parsesFromFrontmatter", func(t *testing.T) {
+		content := []byte("---\ncontinuousModePrompt: Verify all tasks are complete\nflow: |\n  a -> b\n---\n\nGoal.\n")
+		metadata, err := parseYAMLFrontmatter(content)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if metadata.ContinuousModePrompt != "Verify all tasks are complete" {
+			t.Errorf("expected prompt 'Verify all tasks are complete', got %q", metadata.ContinuousModePrompt)
+		}
+		if metadata.Flow == "" {
+			t.Error("flow should still be parsed")
+		}
+	})
+
+	t.Run("emptyWhenAbsent", func(t *testing.T) {
+		content := []byte("---\nflow: |\n  a -> b\n---\n\nGoal.\n")
+		metadata, err := parseYAMLFrontmatter(content)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if metadata.ContinuousModePrompt != "" {
+			t.Errorf("expected empty prompt, got %q", metadata.ContinuousModePrompt)
+		}
+	})
+}

--- a/cmd/sgai/main.go
+++ b/cmd/sgai/main.go
@@ -1028,6 +1028,7 @@ type GoalMetadata struct {
 	Flow                 string         `json:"flow,omitempty" yaml:"flow,omitempty"`
 	Models               map[string]any `json:"models,omitempty" yaml:"models,omitempty"`
 	CompletionGateScript string         `json:"completionGateScript,omitempty" yaml:"completionGateScript,omitempty"`
+	ContinuousModePrompt string         `json:"continuousModePrompt,omitempty" yaml:"continuousModePrompt,omitempty"`
 }
 
 type agentMetadata struct {

--- a/cmd/sgai/serve.go
+++ b/cmd/sgai/serve.go
@@ -438,7 +438,13 @@ func (s *Server) startSession(workspacePath string, autoMode bool) startSessionR
 			})
 		}()
 
-		runWorkflow(ctx, []string{workspacePath}, mcpURL, logWriter)
+		continuousPrompt := readContinuousModePrompt(workspacePath)
+		if continuousPrompt != "" {
+			setContinuousAutoMode(workspacePath)
+			runContinuousWorkflow(ctx, []string{workspacePath}, continuousPrompt, mcpURL, logWriter)
+		} else {
+			runWorkflow(ctx, []string{workspacePath}, mcpURL, logWriter)
+		}
 	}()
 
 	return startSessionResult{sess: sess}

--- a/cmd/sgai/serve_api.go
+++ b/cmd/sgai/serve_api.go
@@ -753,6 +753,7 @@ type apiWorkspaceDetailResponse struct {
 	HasSGAI         bool                      `json:"hasSgai"`
 	HasEditedGoal   bool                      `json:"hasEditedGoal"`
 	InteractiveAuto bool                      `json:"interactiveAuto"`
+	ContinuousMode  bool                      `json:"continuousMode"`
 	CurrentAgent    string                    `json:"currentAgent"`
 	CurrentModel    string                    `json:"currentModel"`
 	Task            string                    `json:"task"`
@@ -857,6 +858,7 @@ func (s *Server) buildWorkspaceDetail(workspacePath string) apiWorkspaceDetailRe
 		HasSGAI:         hassgaiDirectory(workspacePath),
 		HasEditedGoal:   hasEditedGoal,
 		InteractiveAuto: interactiveAuto,
+		ContinuousMode:  readContinuousModePrompt(workspacePath) != "",
 		CurrentAgent:    currentAgent,
 		CurrentModel:    resolveCurrentModel(workspacePath, wfState),
 		Task:            task,

--- a/cmd/sgai/webapp/src/pages/WorkspaceDetail.test.tsx
+++ b/cmd/sgai/webapp/src/pages/WorkspaceDetail.test.tsx
@@ -72,6 +72,7 @@ const workspaceDetail: ApiWorkspaceDetailResponse = {
   hasSgai: true,
   hasEditedGoal: true,
   interactiveAuto: false,
+  continuousMode: false,
   currentAgent: "react-developer",
   currentModel: "anthropic/claude-opus-4-6",
   task: "Implementing Dashboard component",
@@ -494,6 +495,59 @@ describe("WorkspaceDetail", () => {
     await waitFor(() => {
       expect(screen.getByText("stopped")).toBeDefined();
     });
+  });
+
+  it("renders Continuous Self-Drive button when continuousMode is true and not running", async () => {
+    const continuousDetail = { ...workspaceDetail, running: false, continuousMode: true };
+    mockFetch.mockResolvedValue(
+      new Response(JSON.stringify(continuousDetail)),
+    );
+    renderWorkspaceDetail();
+
+    expect(await screen.findByRole("button", { name: "Continuous Self-Drive" })).toBeDefined();
+    expect(screen.queryByRole("button", { name: "Self-drive" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Start" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Stop" })).toBeNull();
+  });
+
+  it("renders Continuous Self-Drive and Stop buttons when continuousMode is true and running", async () => {
+    const continuousRunning = { ...workspaceDetail, running: true, continuousMode: true };
+    mockFetch.mockResolvedValue(
+      new Response(JSON.stringify(continuousRunning)),
+    );
+    const { container } = renderWorkspaceDetail();
+    const view = within(container);
+
+    expect(await view.findByRole("button", { name: "Continuous Self-Drive" })).toBeDefined();
+    expect(view.getAllByRole("button", { name: "Stop" }).length).toBeGreaterThan(0);
+    expect(view.queryByRole("button", { name: "Self-Drive" })).toBeNull();
+    expect(view.queryByRole("button", { name: "Start" })).toBeNull();
+  });
+
+  it("renders normal buttons when continuousMode is false and not running", async () => {
+    const normalDetail = { ...workspaceDetail, running: false, continuousMode: false };
+    mockFetch.mockResolvedValue(
+      new Response(JSON.stringify(normalDetail)),
+    );
+    renderWorkspaceDetail();
+
+    expect(await screen.findByRole("button", { name: "Self-drive" })).toBeDefined();
+    expect(screen.getByRole("button", { name: "Start" })).toBeDefined();
+    expect(screen.queryByRole("button", { name: "Continuous Self-Drive" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Stop" })).toBeNull();
+  });
+
+  it("renders normal buttons when continuousMode is false and running", async () => {
+    const normalRunning = { ...workspaceDetail, running: true, continuousMode: false };
+    mockFetch.mockResolvedValue(
+      new Response(JSON.stringify(normalRunning)),
+    );
+    const { container } = renderWorkspaceDetail();
+    const view = within(container);
+
+    expect(await view.findByRole("button", { name: "Self-Drive" })).toBeDefined();
+    expect(view.getAllByRole("button", { name: "Stop" }).length).toBeGreaterThan(0);
+    expect(view.queryByRole("button", { name: "Continuous Self-Drive" })).toBeNull();
   });
 
   it("shows interrupted banner and reset action when status is working but session is stopped", async () => {

--- a/cmd/sgai/webapp/src/pages/WorkspaceDetail.tsx
+++ b/cmd/sgai/webapp/src/pages/WorkspaceDetail.tsx
@@ -463,36 +463,64 @@ export function WorkspaceDetail(): JSX.Element | null {
                       Respond
                     </Button>
                   )}
-                  <Button
-                    type="button"
-                    size="sm"
-                    variant={(detail.running && detail.interactiveAuto) ? "default" : "outline"}
-                    onClick={handleSelfDrive}
-                    disabled={isActionDisabled}
-                    aria-pressed={detail.running && detail.interactiveAuto}
-                  >
-                    {selfDriveLabel}
-                  </Button>
-                  <Button
-                    type="button"
-                    size="sm"
-                    variant={(detail.running && !detail.interactiveAuto) ? "default" : "outline"}
-                    onClick={handleStart}
-                    disabled={isActionDisabled}
-                    aria-pressed={detail.running && !detail.interactiveAuto}
-                  >
-                    Start
-                  </Button>
-                  {detail.running && (
-                    <Button
-                      type="button"
-                      size="sm"
-                      variant="outline"
-                      onClick={handleStop}
-                      disabled={isStartStopPending}
-                    >
-                      Stop
-                    </Button>
+                  {detail.continuousMode ? (
+                    <>
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant={(detail.running && detail.interactiveAuto) ? "default" : "outline"}
+                        onClick={handleSelfDrive}
+                        disabled={isActionDisabled}
+                        aria-pressed={detail.running && detail.interactiveAuto}
+                      >
+                        Continuous Self-Drive
+                      </Button>
+                      {detail.running && (
+                        <Button
+                          type="button"
+                          size="sm"
+                          variant="outline"
+                          onClick={handleStop}
+                          disabled={isStartStopPending}
+                        >
+                          Stop
+                        </Button>
+                      )}
+                    </>
+                  ) : (
+                    <>
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant={(detail.running && detail.interactiveAuto) ? "default" : "outline"}
+                        onClick={handleSelfDrive}
+                        disabled={isActionDisabled}
+                        aria-pressed={detail.running && detail.interactiveAuto}
+                      >
+                        {selfDriveLabel}
+                      </Button>
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant={(detail.running && !detail.interactiveAuto) ? "default" : "outline"}
+                        onClick={handleStart}
+                        disabled={isActionDisabled}
+                        aria-pressed={detail.running && !detail.interactiveAuto}
+                      >
+                        Start
+                      </Button>
+                      {detail.running && (
+                        <Button
+                          type="button"
+                          size="sm"
+                          variant="outline"
+                          onClick={handleStop}
+                          disabled={isStartStopPending}
+                        >
+                          Stop
+                        </Button>
+                      )}
+                    </>
                   )}
                   {showForkAction && (
                     <Button

--- a/cmd/sgai/webapp/src/types/index.ts
+++ b/cmd/sgai/webapp/src/types/index.ts
@@ -86,6 +86,7 @@ export interface ApiWorkspaceDetailResponse {
   hasSgai: boolean;
   hasEditedGoal: boolean;
   interactiveAuto: boolean;
+  continuousMode: boolean;
   currentAgent: string;
   currentModel: string;
   task: string;


### PR DESCRIPTION
## Summary

Adds a continuous mode to the SGAI factory that keeps it running and reacting to changes, instead of stopping after workflow completion.

### What's Changed

- **New `continuous.go`** with outer loop wrapping `runWorkflow()`: watches for GOAL.md checksum changes and human partner steering messages between cycles
- **`runContinuousModePrompt()`** invokes opencode with the user-defined `continuousModePrompt` text after each completed cycle (3 retries, logs to state.json for UI visibility)
- **`watchForTrigger()`** polls GOAL.md checksum + message bus every 2s; restarts workflow on changes
- **`prependSteeringMessage()`** inserts steering messages after GOAL.md frontmatter when human partner sends new directions
- **API** exposes `continuousMode: boolean` on workspace detail endpoint
- **Frontend** shows "Continuous Self-Drive" button when `continuousModePrompt` is set, normal buttons otherwise

### How to Enable

Add `continuousModePrompt` to GOAL.md frontmatter:

```yaml
---
continuousModePrompt: "Review the current state and plan next steps"
---
```

### Tests

- 20+ new Go unit tests in `continuous_test.go`
- 4 new React component tests for continuous mode button rendering
- `make test` / `make lint` / `make build` all pass

### Verification

Playwright screenshots confirm:
- "Continuous Self-Drive" button appears when `continuousModePrompt` is set
- Normal "Self-drive" + "Start" buttons appear when `continuousModePrompt` is absent
- Progress entries from `continuous-mode` agent visible in UI timeline between cycles

### Files Changed (946 additions, 31 deletions)

| File | Change |
|------|--------|
| `cmd/sgai/continuous.go` | New: continuous mode loop, prompt runner, trigger watcher |
| `cmd/sgai/continuous_test.go` | New: comprehensive unit tests |
| `cmd/sgai/main.go` | Add `ContinuousModePrompt` to GoalMetadata |
| `cmd/sgai/serve.go` | Call `runContinuousWorkflow()` when enabled |
| `cmd/sgai/serve_api.go` | Add `continuousMode` to API response |
| `cmd/sgai/webapp/src/types/index.ts` | Add `continuousMode: boolean` type |
| `cmd/sgai/webapp/src/pages/WorkspaceDetail.tsx` | Conditional button rendering |
| `cmd/sgai/webapp/src/pages/WorkspaceDetail.test.tsx` | Continuous mode button tests |