### PR TITLE
cmd/sgai/webapp: make inbox icon clickable

### DIFF
--- a/GOALS/2026_02_16_inbox_icon_clickable.md
+++ b/GOALS/2026_02_16_inbox_icon_clickable.md
@@ -1,0 +1,24 @@
+---
+flow: |
+  "backend-go-developer" -> "go-readability-reviewer"
+  "backend-go-developer" -> "stpa-analyst"
+  "go-readability-reviewer" -> "stpa-analyst"
+  "general-purpose" -> "stpa-analyst"
+  "react-developer" -> "react-reviewer"
+  "react-reviewer" -> "stpa-analyst"
+  "project-critic-council"
+  "skill-writer"
+models:
+  "coordinator": "anthropic/claude-opus-4-6 (max)"
+  "backend-go-developer": "anthropic/claude-opus-4-6"
+  "go-readability-reviewer": "anthropic/claude-opus-4-6"
+  "general-purpose": "anthropic/claude-opus-4-6"
+  "react-developer": "anthropic/claude-opus-4-6"
+  "react-reviewer": "anthropic/claude-opus-4-6"
+  "stpa-analyst": "anthropic/claude-opus-4-6"
+  "project-critic-council": ["anthropic/claude-opus-4-6"]
+  "skill-writer": "anthropic/claude-opus-4-6 (max)"
+completionGateScript: make test
+---
+
+- [x] In the frontend, there is place on the left that shows an inbox with a counter when one of the factories need attention, make it clickable.

--- a/cmd/sgai/webapp/src/pages/Dashboard.tsx
+++ b/cmd/sgai/webapp/src/pages/Dashboard.tsx
@@ -230,6 +230,7 @@ interface SidebarHeaderIndicatorsProps {
 }
 
 function SidebarHeaderIndicators({ workspaces }: SidebarHeaderIndicatorsProps) {
+  const navigate = useNavigate();
   const allWorkspaces = useMemo(() => collectAllWorkspaces(workspaces), [workspaces]);
 
   const needsInputCount = useMemo(
@@ -242,12 +243,26 @@ function SidebarHeaderIndicators({ workspaces }: SidebarHeaderIndicatorsProps) {
     [allWorkspaces],
   );
 
+  const handleInboxClick = useCallback(() => {
+    const firstNeedsInput = allWorkspaces.find((w) => w.needsInput);
+    if (firstNeedsInput) {
+      navigate(`/workspaces/${encodeURIComponent(firstNeedsInput.name)}/respond`);
+    }
+  }, [allWorkspaces, navigate]);
+
   return (
     <div className="flex items-center gap-2">
       {needsInputCount > 0 && (
         <Tooltip>
           <TooltipTrigger asChild>
-            <span className="relative inline-flex items-center text-primary cursor-help">
+            <button
+              type="button"
+              onClick={handleInboxClick}
+              aria-label={needsInputCount === 1
+                ? "1 workspace waiting for response"
+                : `${needsInputCount} workspaces waiting for response`}
+              className="relative inline-flex items-center text-primary cursor-pointer bg-transparent border-0 p-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm"
+            >
               <Inbox className="h-4 w-4" />
               <Badge
                 variant="destructive"
@@ -255,7 +270,7 @@ function SidebarHeaderIndicators({ workspaces }: SidebarHeaderIndicatorsProps) {
               >
                 {needsInputCount}
               </Badge>
-            </span>
+            </button>
           </TooltipTrigger>
           <TooltipContent>
             {needsInputCount === 1


### PR DESCRIPTION
## Summary

- Converts the inbox notification icon in the sidebar header from a static `<span>` to a clickable `<button>` that navigates to the first workspace needing user input (`/workspaces/:name/respond`).
- Adds proper `aria-label`, focus-visible styles, and a test verifying navigation on click.