### PR TITLE
cmd/sgai: forward env vars and prefix stdout/stderr in adhoc runner

### DIFF
--- a/GOALS/2026_02_16_adhoc_output_stdout.md
+++ b/GOALS/2026_02_16_adhoc_output_stdout.md
@@ -1,0 +1,28 @@
+---
+flow: |
+  "backend-go-developer" -> "go-readability-reviewer"
+  "backend-go-developer" -> "stpa-analyst"
+  "go-readability-reviewer" -> "stpa-analyst"
+  "general-purpose" -> "stpa-analyst"
+  "react-developer" -> "react-reviewer"
+  "react-reviewer" -> "stpa-analyst"
+  "project-critic-council"
+  "skill-writer"
+models:
+  "coordinator": "anthropic/claude-opus-4-6 (max)"
+  "backend-go-developer": "anthropic/claude-opus-4-6"
+  "go-readability-reviewer": "anthropic/claude-opus-4-6"
+  "general-purpose": "anthropic/claude-opus-4-6"
+  "react-developer": "anthropic/claude-opus-4-6"
+  "react-reviewer": "anthropic/claude-opus-4-6"
+  "stpa-analyst": "anthropic/claude-opus-4-6"
+  "project-critic-council": ["anthropic/claude-opus-4-6"]
+  "skill-writer": "anthropic/claude-opus-4-6 (max)"
+completionGateScript: make test
+---
+
+I like the adhoc inference runners (Run tab in workspace and Ad-Hoc in the Root Repository page in Forked Mode)
+
+- [x] Ensure that when it shells out to opencode
+  - [x] all the env vars that would be available for runWorkflow are also available
+  - [x] ensure that the command executer also prints out to the sgai stdout/stderr with the same prefix logic that runWorkflows have.


### PR DESCRIPTION
## Summary

- Forward environment variables (including `OPENCODE_CONFIG_DIR`) to the adhoc opencode runner so it has the same env context as `runWorkflow`.
- Pipe adhoc runner stdout/stderr to sgai's own stdout/stderr using the same prefix logic that `runWorkflow` uses, enabling consistent log output.