### PR TITLE
cmd/sgai: print assigned port when using dynamic listen address

### DIFF
--- a/GOALS/2026_02_16_print_assigned_port_on_dynamic_listen.md
+++ b/GOALS/2026_02_16_print_assigned_port_on_dynamic_listen.md
@@ -1,0 +1,25 @@
+---
+flow: |
+  "backend-go-developer" -> "go-readability-reviewer"
+  "backend-go-developer" -> "stpa-analyst"
+  "go-readability-reviewer" -> "stpa-analyst"
+  "general-purpose" -> "stpa-analyst"
+  "react-developer" -> "react-reviewer"
+  "react-reviewer" -> "stpa-analyst"
+  "project-critic-council"
+  "skill-writer"
+models:
+  "coordinator": "anthropic/claude-opus-4-6 (max)"
+  "backend-go-developer": "anthropic/claude-opus-4-6"
+  "go-readability-reviewer": "anthropic/claude-opus-4-6"
+  "general-purpose": "anthropic/claude-opus-4-6"
+  "react-developer": "anthropic/claude-opus-4-6"
+  "react-reviewer": "anthropic/claude-opus-4-6"
+  "stpa-analyst": "anthropic/claude-opus-4-6"
+  "project-critic-council": ["anthropic/claude-opus-4-6"]
+  "skill-writer": "anthropic/claude-opus-4-6 (max)"
+interactive: yes
+completionGateScript: make test
+---
+
+- [x] when I start `sgai serve --listen-addr 0.0.0.0:0`, it doesn't print what port has been assigned

--- a/cmd/sgai/serve.go
+++ b/cmd/sgai/serve.go
@@ -520,6 +520,11 @@ func cmdServe(args []string) {
 		}
 	}
 
+	listener, errListen := net.Listen("tcp", *listenAddr)
+	if errListen != nil {
+		log.Fatalln("failed to listen:", errListen)
+	}
+
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
@@ -534,14 +539,14 @@ func cmdServe(args []string) {
 	srv.registerAPIRoutes(mux)
 	handler := srv.spaMiddleware(mux)
 
-	httpServer := &http.Server{Addr: *listenAddr, Handler: handler}
+	httpServer := &http.Server{Handler: handler}
 
-	baseURL := dashboardBaseURL(*listenAddr)
+	baseURL := dashboardBaseURL(listener.Addr().String())
 	log.Println("sgai serve listening on", baseURL)
 
 	go func() {
-		if errListen := httpServer.ListenAndServe(); errListen != nil && !errors.Is(errListen, http.ErrServerClosed) {
-			log.Fatalln("server error:", errListen)
+		if errServe := httpServer.Serve(listener); errServe != nil && !errors.Is(errServe, http.ErrServerClosed) {
+			log.Fatalln("server error:", errServe)
 		}
 	}()
 


### PR DESCRIPTION
## Summary

- Pre-create a `net.Listener` before starting the HTTP server so the actual assigned port is known when using `:0` (dynamic port)
- Replace `httpServer.ListenAndServe()` with `httpServer.Serve(listener)` and pass `listener.Addr().String()` to `dashboardBaseURL` so the log line prints the real address