### PR TITLE
cmd/sgai: add auto and cron scheduling to continuous mode

### DIFF
--- a/GOALS/2026_02_17_improve_continuous_mode.md
+++ b/GOALS/2026_02_17_improve_continuous_mode.md
@@ -1,0 +1,40 @@
+---
+flow: |
+  "backend-go-developer" -> "go-readability-reviewer"
+  "backend-go-developer" -> "stpa-analyst"
+  "go-readability-reviewer" -> "stpa-analyst"
+  "general-purpose" -> "stpa-analyst"
+  "react-developer" -> "react-reviewer"
+  "react-reviewer" -> "stpa-analyst"
+  "project-critic-council"
+  "skill-writer"
+models:
+  "coordinator": "opencode/kimi-k2.5"
+  "backend-go-developer": "opencode/glm-5"
+  "go-readability-reviewer": "opencode/kimi-k2.5"
+  "general-purpose": "opencode/kimi-k2.5"
+  "react-developer": "opencode/glm-5"
+  "react-reviewer": "opencode/kimi-k2.5"
+  "stpa-analyst": "opencode/kimi-k2.5"
+  "project-critic-council": ["opencode/kimi-k2.5-free", "opencode/glm-5-free", "opencode/minimax-m2.5-free"]
+  "skill-writer": "opencode/kimi-k2.5"
+completionGateScript: make test
+---
+
+I like the Continuous Mode, and I think we can keep improving it.
+
+I have a desiderata; each desire should be its own commit, OK?
+
+- [x] I want a new frontmatter parameter to let the continuousMode loop itself
+      `continuousModeAuto: "duration of wait done compatible with Go's time.ParseDuration"`
+      Basically, when `continuousModeAuto` is set, it is going to wait for the duration set in `continuousModeAuto`, and it will let the workflow run again.
+
+- [x] I want a new frontmatter parameter to let the continuousMode loop itself on a periodic basis
+      `continuousModeCron: "crontab style to define when to run a factory or not"`
+      Basically, when `continuousModeCron` is set, it is going to wait for the deadline defined in `continuousModeCron`, and it will let the workflow run again.
+  - [x] use this dep https://github.com/adhocore/gronx?tab=readme-ov-file#next-tick
+
+
+# Post Success Activities
+- [ ] general-purpose: "copy GOAL.md into GOALS/ following the instructions from README.md"
+- [ ] general-purpose: "using GH, make a draft PR for the commit at @ (jj) - from here"

--- a/cmd/sgai/main.go
+++ b/cmd/sgai/main.go
@@ -1029,6 +1029,8 @@ type GoalMetadata struct {
 	Models               map[string]any `json:"models,omitempty" yaml:"models,omitempty"`
 	CompletionGateScript string         `json:"completionGateScript,omitempty" yaml:"completionGateScript,omitempty"`
 	ContinuousModePrompt string         `json:"continuousModePrompt,omitempty" yaml:"continuousModePrompt,omitempty"`
+	ContinuousModeAuto   string         `json:"continuousModeAuto,omitempty" yaml:"continuousModeAuto,omitempty"`
+	ContinuousModeCron   string         `json:"continuousModeCron,omitempty" yaml:"continuousModeCron,omitempty"`
 }
 
 type agentMetadata struct {

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/sandgardenhq/sgai
 go 1.25.7
 
 require (
+	github.com/adhocore/gronx v1.19.6
 	github.com/adrg/xdg v0.5.3
 	github.com/google/jsonschema-go v0.4.2
 	github.com/mactaggart/gographviz v0.0.0-20250815040658-9ffd0326c418

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/adhocore/gronx v1.19.6 h1:5KNVcoR9ACgL9HhEqCm5QXsab/gI4QDIybTAWcXDKDc=
+github.com/adhocore/gronx v1.19.6/go.mod h1:7oUY1WAU8rEJWmAxXR2DN0JaO4gi9khSgKjiRypqteg=
 github.com/adrg/xdg v0.5.3 h1:xRnxJXne7+oWDatRhR1JLnvuccuIeCoBu2rtuLqQB78=
 github.com/adrg/xdg v0.5.3/go.mod h1:nlTsY+NNiCBGCK2tpm09vRqfVzrc2fLmXGpBLF0zlTQ=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=


### PR DESCRIPTION

## Summary

Adds two new frontmatter parameters to enable automatic scheduling in continuous mode:

### Features

- **continuousModeAuto**: Duration-based scheduling (e.g., "1h30m", "30s")
  - Waits for the specified duration before triggering the next workflow run
  - Uses Go's standard time.ParseDuration

- **continuousModeCron**: Cron-based scheduling (e.g., "0 * * * *", "*/5 * * * *")
  - Waits for the next cron tick before triggering the next workflow run
  - Uses github.com/adhocore/gronx for parsing
  - Cron takes precedence over auto if both are set (earlier deadline wins)

### Implementation Details

- New trigger kinds: triggerAuto and triggerCron alongside existing triggerGoal and triggerSteering
- Modified watchForTrigger function to support deadline-based waiting
- Added gronx v1.19.6 as a direct dependency

### Testing

- 8+ new tests for auto/cron features
- Tests cover parsing, duration calculation, and trigger behavior
- All existing tests continue to pass

### Files Changed

- cmd/sgai/main.go: GoalMetadata struct additions
- cmd/sgai/continuous.go: Core scheduling logic
- cmd/sgai/continuous_test.go: New tests
- go.mod, go.sum: gronx dependency
- GOALS/2026_02_17_improve_continuous_mode.md: Specification file
