### PR TITLE
cmd/sgai: add stop button, side-by-side layout, and shift+enter for adhoc runners

### DIFF
--- a/GOALS/2026_02_18_adhoc_improvements.md
+++ b/GOALS/2026_02_18_adhoc_improvements.md
@@ -1,0 +1,29 @@
+---
+flow: |
+  "backend-go-developer" -> "go-readability-reviewer"
+  "backend-go-developer" -> "stpa-analyst"
+  "go-readability-reviewer" -> "stpa-analyst"
+  "general-purpose" -> "stpa-analyst"
+  "react-developer" -> "react-reviewer"
+  "react-reviewer" -> "stpa-analyst"
+  "project-critic-council"
+  "skill-writer"
+models:
+  "coordinator": "opencode/glm-5"
+  "backend-go-developer": "opencode/glm-5"
+  "go-readability-reviewer": "opencode/glm-5"
+  "general-purpose": "opencode/glm-5"
+  "react-developer": "opencode/glm-5"
+  "react-reviewer": "opencode/glm-5"
+  "stpa-analyst": "opencode/glm-5"
+  "project-critic-council": ["opencode/glm-5-free", "opencode/kimi-k2.5-free",  "opencode/minimax-m2.5-free"]
+  "skill-writer": "opencode/glm-5"
+completionGateScript: make test
+---
+
+The adhoc runners in Root Repository in Forked Mode and Run tab in Standalone/Forked Repositories need some improvements
+
+- [x] runs must be stoppable - Add Stop button to all adhoc UIs (RunTab, InlineRunBox in ForksTab, AdhocOutput) with backend DELETE /api/v1/workspaces/{name}/adhoc endpoint
+  - [x] the stop button must ensure the underlying opencode process is properly stopped
+- [x] layout should be better - Make model selector and prompt textarea side-by-side layout
+- [x] shift+enter should work - Shift+Enter submits, plain Enter adds new line (code editor style)

--- a/cmd/sgai/serve_adhoc.go
+++ b/cmd/sgai/serve_adhoc.go
@@ -5,6 +5,8 @@ import (
 	"os/exec"
 	"regexp"
 	"sync"
+	"syscall"
+	"time"
 )
 
 var ansiEscapePattern = regexp.MustCompile(`\x1b\[[0-9;]*[a-zA-Z]|\x1b\].*?\x07|\x1b[^[\]].?`)
@@ -40,4 +42,38 @@ func (w *lockedWriter) Write(p []byte) (int, error) {
 	stripped := ansiEscapePattern.ReplaceAll(p, nil)
 	w.buf.Write(stripped)
 	return len(p), nil
+}
+
+func (st *adhocPromptState) stop() {
+	st.mu.Lock()
+	if !st.running {
+		st.mu.Unlock()
+		return
+	}
+	cmd := st.cmd
+	st.mu.Unlock()
+
+	if cmd != nil && cmd.Process != nil {
+		pgid := -cmd.Process.Pid
+		_ = syscall.Kill(pgid, syscall.SIGTERM)
+
+		done := make(chan struct{})
+		go func() {
+			_ = cmd.Wait()
+			close(done)
+		}()
+
+		select {
+		case <-done:
+		case <-time.After(gracefulShutdownTimeout):
+			_ = syscall.Kill(pgid, syscall.SIGKILL)
+			<-done
+		}
+	}
+
+	st.mu.Lock()
+	st.running = false
+	st.cmd = nil
+	st.output.WriteString("\n[stopped by user]\n")
+	st.mu.Unlock()
 }

--- a/cmd/sgai/webapp/src/lib/api.ts
+++ b/cmd/sgai/webapp/src/lib/api.ts
@@ -174,6 +174,11 @@ export const api = {
       fetchJSON<ApiAdhocResponse>(
         `/api/v1/workspaces/${encodeURIComponent(name)}/adhoc`,
       ),
+    adhocStop: (name: string) =>
+      fetchJSON<ApiAdhocResponse>(
+        `/api/v1/workspaces/${encodeURIComponent(name)}/adhoc`,
+        { method: "DELETE" },
+      ),
     retroAnalyze: (name: string, session: string) =>
       fetchJSON<ApiRetroActionResponse>(
         `/api/v1/workspaces/${encodeURIComponent(name)}/retrospective/analyze`,

--- a/cmd/sgai/webapp/src/pages/AdhocOutput.test.tsx
+++ b/cmd/sgai/webapp/src/pages/AdhocOutput.test.tsx
@@ -108,7 +108,7 @@ describe("AdhocOutput", () => {
     await act(async () => { fireEvent.click(button); });
     await act(async () => { await new Promise((r) => setTimeout(r, 50)); });
 
-    expect(screen.getByText("Running...")).toBeTruthy();
+    expect(screen.getByRole("button", { name: /stop/i })).toBeTruthy();
   });
 
   test("shows error on failure", async () => {

--- a/cmd/sgai/webapp/src/pages/tabs/RunTab.test.tsx
+++ b/cmd/sgai/webapp/src/pages/tabs/RunTab.test.tsx
@@ -72,16 +72,16 @@ describe("RunTab", () => {
     expect(screen.getByRole("button", { name: "Submit" })).toBeDefined();
   });
 
-  it("places model selector and submit button on the same row", async () => {
+  it("places model selector and prompt textarea side-by-side in a grid layout", async () => {
     mockFetch.mockResolvedValue(new Response(JSON.stringify(modelsResponse)));
     renderRunTab();
 
     const modelSelect = await screen.findByRole("combobox", { name: "Model" });
-    const submitButton = screen.getByRole("button", { name: "Submit" });
+    const promptTextarea = screen.getByRole("textbox", { name: "Prompt" });
 
-    const row = modelSelect.parentElement;
-    expect(row).toBeTruthy();
-    expect(row?.contains(submitButton)).toBe(true);
+    const grid = modelSelect.closest(".grid-cols-\\[200px_1fr\\]");
+    expect(grid).toBeTruthy();
+    expect(grid?.contains(promptTextarea)).toBe(true);
   });
 
   it("selects the default model when provided", async () => {

--- a/cmd/sgai/webapp/src/pages/tabs/RunTab.tsx
+++ b/cmd/sgai/webapp/src/pages/tabs/RunTab.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from "react";
-import { Loader2 } from "lucide-react";
+import { Square } from "lucide-react";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
@@ -145,11 +145,35 @@ export function RunTab({ workspaceName, currentModel }: RunTabProps): JSX.Elemen
     [workspaceName, isRunning, stopPolling],
   );
 
+  const handleStop = useCallback(async () => {
+    if (!workspaceName || !isRunning) return;
+
+    try {
+      await api.workspaces.adhocStop(workspaceName);
+      stopPolling();
+      setIsRunning(false);
+      setOutput((prev) => (prev ? prev + "\n\nStopped." : "Stopped."));
+    } catch (err) {
+      if (err instanceof ApiError) {
+        setRunError(err.message);
+      } else {
+        setRunError("Failed to stop ad-hoc prompt");
+      }
+    }
+  }, [workspaceName, isRunning, stopPolling]);
+
   const handleSubmit = (event: React.FormEvent) => {
     event.preventDefault();
     const trimmedPrompt = prompt.trim();
     if (!workspaceName || !selectedModel || !trimmedPrompt) return;
     runAdhoc(trimmedPrompt, selectedModel);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" && e.shiftKey) {
+      e.preventDefault();
+      handleSubmit(e);
+    }
   };
 
   if (loading && !models) return <RunTabSkeleton />;
@@ -173,41 +197,25 @@ export function RunTab({ workspaceName, currentModel }: RunTabProps): JSX.Elemen
       ) : null}
 
       <form onSubmit={handleSubmit} className="space-y-4">
-        <div className="space-y-4">
+        <div className="grid grid-cols-[200px_1fr] gap-4">
           <div className="space-y-2">
             <Label htmlFor="adhoc-model">Model</Label>
-            <div className="flex items-center gap-2">
-              <Select
-                id="adhoc-model"
-                value={selectedModel}
-                onChange={(event) => setSelectedModel(event.target.value)}
-                disabled={isRunning}
-                className="flex-1"
-              >
-                <SelectOption value="" disabled>
-                  Select a model
+            <Select
+              id="adhoc-model"
+              value={selectedModel}
+              onChange={(event) => setSelectedModel(event.target.value)}
+              disabled={isRunning}
+              className="w-full"
+            >
+              <SelectOption value="" disabled>
+                Select a model
+              </SelectOption>
+              {models.models.map((model) => (
+                <SelectOption key={model.id} value={model.id}>
+                  {model.name}
                 </SelectOption>
-                {models.models.map((model) => (
-                  <SelectOption key={model.id} value={model.id}>
-                    {model.name}
-                  </SelectOption>
-                ))}
-              </Select>
-              <Button
-                type="submit"
-                className="shrink-0"
-                disabled={isRunning || !selectedModel || !prompt.trim()}
-              >
-                {isRunning ? (
-                  <>
-                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                    Running...
-                  </>
-                ) : (
-                  "Submit"
-                )}
-              </Button>
-            </div>
+              ))}
+            </Select>
           </div>
 
           <div className="space-y-2">
@@ -216,12 +224,33 @@ export function RunTab({ workspaceName, currentModel }: RunTabProps): JSX.Elemen
               id="adhoc-prompt"
               value={prompt}
               onChange={(event) => setPrompt(event.target.value)}
+              onKeyDown={handleKeyDown}
               placeholder="Enter prompt..."
               rows={6}
               className="resize-y"
               disabled={isRunning}
             />
           </div>
+        </div>
+
+        <div className="flex gap-2">
+          {isRunning ? (
+            <Button
+              type="button"
+              variant="destructive"
+              onClick={handleStop}
+            >
+              <Square className="mr-2 h-4 w-4" />
+              Stop
+            </Button>
+          ) : (
+            <Button
+              type="submit"
+              disabled={!selectedModel || !prompt.trim()}
+            >
+              Submit
+            </Button>
+          )}
         </div>
       </form>
 


### PR DESCRIPTION
## Summary

- Add Stop button to all adhoc UIs (AdhocOutput, RunTab, ForksTab InlineRunBox) with backend `DELETE /api/v1/workspaces/{name}/adhoc` endpoint that properly terminates the underlying opencode process via process group signals (SIGTERM with graceful fallback to SIGKILL)
- Refactor adhoc form layout to side-by-side grid (model selector + prompt textarea) for better use of horizontal space
- Add Shift+Enter to submit prompt (plain Enter adds newline, code-editor style)