### PR TITLE
cmd/sgai/webapp: fix Edit GOAL link route in WorkspaceDetail

### DIFF
--- a/cmd/sgai/webapp/src/pages/WorkspaceDetail.tsx
+++ b/cmd/sgai/webapp/src/pages/WorkspaceDetail.tsx
@@ -745,7 +745,7 @@ function NoWorkspaceState({ name, dir }: { name: string; dir: string }) {
       <div className="text-center py-8 text-muted-foreground italic">
         <p>No workspace configured for this directory.</p>
         <Link
-          to={`/workspaces/${encodeURIComponent(name)}/init`}
+          to={`/workspaces/${encodeURIComponent(name)}/goal/edit`}
           className="inline-block mt-4 px-4 py-2 text-sm rounded border hover:bg-muted transition-colors no-underline"
         >
           Edit GOAL


### PR DESCRIPTION
## Summary
- Fixes the "Edit GOAL" link in WorkspaceDetail to route to `/goal/edit` instead of `/init`

This corrects the navigation path for editing the GOAL file when no workspace is configured for a directory.