### PR TITLE
cmd/sgai: add completion gate with forge-aware PR/MR creation

### DIFF
--- a/cmd/sgai/forge.go
+++ b/cmd/sgai/forge.go
@@ -1,0 +1,331 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/sandgardenhq/sgai/pkg/state"
+)
+
+const (
+	forgeGitHub  = "github"
+	forgeGitLab  = "gitlab"
+	forgeUnknown = "none"
+
+	choiceCreatePR       = "Create Pull Request"
+	choiceCreateMR       = "Create Merge Request"
+	choiceContinueWork   = "Continue working"
+	choiceDone           = "Done"
+	completionGatePrompt = "The workflow is complete. What would you like to do next?"
+)
+
+type forgeCapability struct {
+	forgeType    string
+	cliAvailable bool
+}
+
+func detectForge(dir string) forgeCapability {
+	remoteURL := readGitRemoteURL(dir)
+	if remoteURL == "" {
+		return forgeCapability{forgeType: forgeUnknown}
+	}
+	if containsGitHubHost(remoteURL) {
+		return forgeCapability{
+			forgeType:    forgeGitHub,
+			cliAvailable: isCommandAvailable("gh"),
+		}
+	}
+	if containsGitLabHost(remoteURL) {
+		return forgeCapability{
+			forgeType:    forgeGitLab,
+			cliAvailable: isCommandAvailable("glab"),
+		}
+	}
+	return forgeCapability{forgeType: forgeUnknown}
+}
+
+func readGitRemoteURL(dir string) string {
+	cmd := exec.Command("git", "remote", "-v")
+	cmd.Dir = dir
+	output, errCmd := cmd.Output()
+	if errCmd != nil {
+		return ""
+	}
+	return string(output)
+}
+
+func containsGitHubHost(remoteOutput string) bool {
+	return strings.Contains(remoteOutput, "github.com")
+}
+
+func containsGitLabHost(remoteOutput string) bool {
+	return strings.Contains(remoteOutput, "gitlab.com")
+}
+
+func isCommandAvailable(name string) bool {
+	_, err := exec.LookPath(name)
+	return err == nil
+}
+
+func buildCompletionGateChoices(fc forgeCapability) []string {
+	var choices []string
+	if fc.forgeType == forgeGitHub && fc.cliAvailable {
+		choices = append(choices, choiceCreatePR)
+	}
+	if fc.forgeType == forgeGitLab && fc.cliAvailable {
+		choices = append(choices, choiceCreateMR)
+	}
+	choices = append(choices, choiceContinueWork, choiceDone)
+	return choices
+}
+
+func pushBookmark(dir, workspaceName string) error {
+	bookmarkName := "sgai/" + workspaceName
+	setCmd := exec.Command("jj", "bookmark", "set", bookmarkName, "--allow-backwards")
+	setCmd.Dir = dir
+	if errSet := setCmd.Run(); errSet != nil {
+		return fmt.Errorf("setting bookmark %s: %w", bookmarkName, errSet)
+	}
+	pushCmd := exec.Command("jj", "git", "push", "--bookmark", bookmarkName)
+	pushCmd.Dir = dir
+	if errPush := pushCmd.Run(); errPush != nil {
+		return fmt.Errorf("pushing bookmark %s: %w", bookmarkName, errPush)
+	}
+	return nil
+}
+
+func generatePRBody(dir string) string {
+	if body := readPRTemplate(dir); body != "" {
+		return body
+	}
+	if body := extractContributingGuidelines(dir); body != "" {
+		return body
+	}
+	return generateFallbackPRBody(dir)
+}
+
+func readPRTemplate(dir string) string {
+	candidates := []string{
+		filepath.Join(dir, ".github", "PULL_REQUEST_TEMPLATE.md"),
+		filepath.Join(dir, ".github", "pull_request_template.md"),
+		filepath.Join(dir, "PULL_REQUEST_TEMPLATE.md"),
+		filepath.Join(dir, "pull_request_template.md"),
+	}
+	for _, path := range candidates {
+		content, errRead := os.ReadFile(path)
+		if errRead == nil && len(content) > 0 {
+			return string(content)
+		}
+	}
+	return ""
+}
+
+func extractContributingGuidelines(dir string) string {
+	candidates := []string{
+		filepath.Join(dir, "CONTRIBUTING.md"),
+		filepath.Join(dir, "contributing.md"),
+	}
+	for _, path := range candidates {
+		content, errRead := os.ReadFile(path)
+		if errRead == nil && len(content) > 0 {
+			return string(content)
+		}
+	}
+	return ""
+}
+
+func generateFallbackPRBody(dir string) string {
+	var sections []string
+	if title := readGoalTitle(dir); title != "" {
+		sections = append(sections, "## Goal\n\n"+title)
+	}
+	if logOutput := runJJLog(dir); logOutput != "" {
+		sections = append(sections, "## Changes\n\n```\n"+logOutput+"\n```")
+	}
+	if diffStat := runJJDiffStat(dir); diffStat != "" {
+		sections = append(sections, "## Diff Summary\n\n```\n"+diffStat+"\n```")
+	}
+	if len(sections) == 0 {
+		return "Pull request created by sgai."
+	}
+	return strings.Join(sections, "\n\n")
+}
+
+func readGoalTitle(dir string) string {
+	goalPath := filepath.Join(dir, "GOAL.md")
+	content, errRead := os.ReadFile(goalPath)
+	if errRead != nil {
+		return ""
+	}
+	body := extractBody(content)
+	for line := range strings.SplitSeq(strings.TrimSpace(string(body)), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}
+
+func runJJLog(dir string) string {
+	cmd := exec.Command("jj", "log", "--no-graph", "-r", "..@", "-T",
+		`change_id.short(8) ++ " " ++ coalesce(description.first_line(), "(no description)") ++ "\n"`)
+	cmd.Dir = dir
+	output, errCmd := cmd.Output()
+	if errCmd != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(output))
+}
+
+func runJJDiffStat(dir string) string {
+	cmd := exec.Command("jj", "diff", "--stat")
+	cmd.Dir = dir
+	output, errCmd := cmd.Output()
+	if errCmd != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(output))
+}
+
+func extractPRTitle(dir string) string {
+	title := readGoalTitle(dir)
+	if title == "" {
+		return "sgai: automated changes"
+	}
+	return title
+}
+
+func createGitHubPR(dir, workspaceName, baseBranch string) error {
+	title := extractPRTitle(dir)
+	body := generatePRBody(dir)
+	head := "sgai/" + workspaceName
+	cmd := exec.Command("gh", "pr", "create",
+		"--title", title,
+		"--body", body,
+		"--head", head,
+		"--base", baseBranch,
+	)
+	cmd.Dir = dir
+	output, errCmd := cmd.CombinedOutput()
+	if errCmd != nil {
+		return fmt.Errorf("gh pr create: %s: %w", strings.TrimSpace(string(output)), errCmd)
+	}
+	return nil
+}
+
+func createGitLabMR(dir, workspaceName, baseBranch string) error {
+	title := extractPRTitle(dir)
+	body := generatePRBody(dir)
+	source := "sgai/" + workspaceName
+	cmd := exec.Command("glab", "mr", "create",
+		"--title", title,
+		"--description", body,
+		"--source-branch", source,
+		"--target-branch", baseBranch,
+	)
+	cmd.Dir = dir
+	output, errCmd := cmd.CombinedOutput()
+	if errCmd != nil {
+		return fmt.Errorf("glab mr create: %s: %w", strings.TrimSpace(string(output)), errCmd)
+	}
+	return nil
+}
+
+type completionGateResult struct {
+	continueWorking bool
+}
+
+func handleCompletionGate(ctx context.Context, dir, stateJSONPath string, wfState state.Workflow, paddedsgai string) completionGateResult {
+	fc := detectForge(dir)
+	choices := buildCompletionGateChoices(fc)
+
+	wfState.MultiChoiceQuestion = &state.MultiChoiceQuestion{
+		Questions: []state.QuestionItem{
+			{
+				Question:    completionGatePrompt,
+				Choices:     choices,
+				MultiSelect: false,
+			},
+		},
+	}
+	wfState.HumanMessage = completionGatePrompt
+	wfState.Status = state.StatusWaitingForHuman
+
+	if errSave := state.Save(stateJSONPath, wfState); errSave != nil {
+		log.Println("failed to save completion gate state:", errSave)
+		return completionGateResult{}
+	}
+
+	fmt.Println("["+paddedsgai+"]", "waiting for completion gate response...")
+
+	humanResponse, cancelled := waitForStateTransition(ctx, dir, stateJSONPath)
+	if cancelled {
+		return completionGateResult{}
+	}
+
+	return dispatchCompletionGateResponse(dir, humanResponse, paddedsgai)
+}
+
+func dispatchCompletionGateResponse(dir, response, paddedsgai string) completionGateResult {
+	switch {
+	case strings.Contains(response, choiceCreatePR):
+		executeForgeCreation(dir, forgeGitHub, paddedsgai)
+		return completionGateResult{}
+	case strings.Contains(response, choiceCreateMR):
+		executeForgeCreation(dir, forgeGitLab, paddedsgai)
+		return completionGateResult{}
+	case strings.Contains(response, choiceContinueWork):
+		fmt.Println("["+paddedsgai+"]", "user chose to continue working")
+		return completionGateResult{continueWorking: true}
+	default:
+		fmt.Println("["+paddedsgai+"]", "workflow complete")
+		return completionGateResult{}
+	}
+}
+
+func executeForgeCreation(dir, targetForge, paddedsgai string) {
+	workspaceName := filepath.Base(dir)
+	rootDir := resolveRootDir(dir)
+	baseBranch := resolveBaseBookmark(rootDir)
+
+	fmt.Println("["+paddedsgai+"]", "pushing bookmark sgai/"+workspaceName+"...")
+	if errPush := pushBookmark(dir, workspaceName); errPush != nil {
+		fmt.Println("["+paddedsgai+"]", "failed to push bookmark:", errPush)
+		fmt.Println("["+paddedsgai+"]", "you can push manually and create the PR/MR yourself")
+		return
+	}
+
+	switch targetForge {
+	case forgeGitHub:
+		fmt.Println("["+paddedsgai+"]", "creating GitHub pull request...")
+		if errPR := createGitHubPR(dir, workspaceName, baseBranch); errPR != nil {
+			fmt.Println("["+paddedsgai+"]", "failed to create pull request:", errPR)
+			fmt.Println("["+paddedsgai+"]", "bookmark was pushed - you can create the PR manually")
+			return
+		}
+		fmt.Println("["+paddedsgai+"]", "pull request created successfully")
+	case forgeGitLab:
+		fmt.Println("["+paddedsgai+"]", "creating GitLab merge request...")
+		if errMR := createGitLabMR(dir, workspaceName, baseBranch); errMR != nil {
+			fmt.Println("["+paddedsgai+"]", "failed to create merge request:", errMR)
+			fmt.Println("["+paddedsgai+"]", "bookmark was pushed - you can create the MR manually")
+			return
+		}
+		fmt.Println("["+paddedsgai+"]", "merge request created successfully")
+	}
+}
+
+func resolveRootDir(dir string) string {
+	if classifyWorkspace(dir) == workspaceFork {
+		if root := getRootWorkspacePath(dir); root != "" {
+			return root
+		}
+	}
+	return dir
+}

--- a/cmd/sgai/forge_test.go
+++ b/cmd/sgai/forge_test.go
@@ -1,0 +1,418 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestDetectForge(t *testing.T) {
+	cases := []struct {
+		name      string
+		remoteURL string
+		wantForge string
+	}{
+		{"github https", "https://github.com/user/repo.git", forgeGitHub},
+		{"github ssh", "git@github.com:user/repo.git", forgeGitHub},
+		{"gitlab https", "https://gitlab.com/user/repo.git", forgeGitLab},
+		{"gitlab ssh", "git@gitlab.com:user/repo.git", forgeGitLab},
+		{"bitbucket", "https://bitbucket.org/user/repo.git", forgeUnknown},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := setupGitRepoWithRemote(t, tc.remoteURL)
+			fc := detectForge(dir)
+			if fc.forgeType != tc.wantForge {
+				t.Errorf("detectForge() forgeType = %q; want %q", fc.forgeType, tc.wantForge)
+			}
+		})
+	}
+
+	t.Run("no remote", func(t *testing.T) {
+		dir := t.TempDir()
+		fc := detectForge(dir)
+		if fc.forgeType != forgeUnknown {
+			t.Errorf("detectForge() forgeType = %q; want %q", fc.forgeType, forgeUnknown)
+		}
+	})
+}
+
+func TestContainsGitHubHost(t *testing.T) {
+	cases := []struct {
+		name   string
+		input  string
+		expect bool
+	}{
+		{"https", "origin\thttps://github.com/user/repo.git (fetch)", true},
+		{"ssh", "origin\tgit@github.com:user/repo.git (fetch)", true},
+		{"no match", "origin\thttps://gitlab.com/user/repo.git (fetch)", false},
+		{"empty", "", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := containsGitHubHost(tc.input)
+			if got != tc.expect {
+				t.Errorf("containsGitHubHost(%q) = %v; want %v", tc.input, got, tc.expect)
+			}
+		})
+	}
+}
+
+func TestContainsGitLabHost(t *testing.T) {
+	cases := []struct {
+		name   string
+		input  string
+		expect bool
+	}{
+		{"https", "origin\thttps://gitlab.com/user/repo.git (fetch)", true},
+		{"ssh", "origin\tgit@gitlab.com:user/repo.git (fetch)", true},
+		{"no match", "origin\thttps://github.com/user/repo.git (fetch)", false},
+		{"empty", "", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := containsGitLabHost(tc.input)
+			if got != tc.expect {
+				t.Errorf("containsGitLabHost(%q) = %v; want %v", tc.input, got, tc.expect)
+			}
+		})
+	}
+}
+
+func TestBuildCompletionGateChoices(t *testing.T) {
+	cases := []struct {
+		name        string
+		fc          forgeCapability
+		wantChoices []string
+	}{
+		{
+			"github with cli",
+			forgeCapability{forgeType: forgeGitHub, cliAvailable: true},
+			[]string{choiceCreatePR, choiceContinueWork, choiceDone},
+		},
+		{
+			"gitlab with cli",
+			forgeCapability{forgeType: forgeGitLab, cliAvailable: true},
+			[]string{choiceCreateMR, choiceContinueWork, choiceDone},
+		},
+		{
+			"github without cli",
+			forgeCapability{forgeType: forgeGitHub, cliAvailable: false},
+			[]string{choiceContinueWork, choiceDone},
+		},
+		{
+			"no forge",
+			forgeCapability{forgeType: forgeUnknown},
+			[]string{choiceContinueWork, choiceDone},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := buildCompletionGateChoices(tc.fc)
+			if len(got) != len(tc.wantChoices) {
+				t.Fatalf("got %d choices %v; want %d choices %v", len(got), got, len(tc.wantChoices), tc.wantChoices)
+			}
+			for i, want := range tc.wantChoices {
+				if got[i] != want {
+					t.Errorf("choice[%d] = %q; want %q", i, got[i], want)
+				}
+			}
+		})
+	}
+}
+
+func TestReadPRTemplate(t *testing.T) {
+	cases := []struct {
+		name     string
+		setup    func(dir string) error
+		wantBody string
+	}{
+		{
+			"uppercase template in .github",
+			func(dir string) error {
+				githubDir := filepath.Join(dir, ".github")
+				if err := os.MkdirAll(githubDir, 0755); err != nil {
+					return err
+				}
+				return os.WriteFile(filepath.Join(githubDir, "PULL_REQUEST_TEMPLATE.md"),
+					[]byte("## Description\n\nPlease describe your changes."), 0644)
+			},
+			"## Description\n\nPlease describe your changes.",
+		},
+		{
+			"lowercase template in .github",
+			func(dir string) error {
+				githubDir := filepath.Join(dir, ".github")
+				if err := os.MkdirAll(githubDir, 0755); err != nil {
+					return err
+				}
+				return os.WriteFile(filepath.Join(githubDir, "pull_request_template.md"),
+					[]byte("lowercase template"), 0644)
+			},
+			"lowercase template",
+		},
+		{
+			"no template",
+			func(_ string) error { return nil },
+			"",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := tc.setup(dir); err != nil {
+				t.Fatal(err)
+			}
+			got := readPRTemplate(dir)
+			if got != tc.wantBody {
+				t.Errorf("readPRTemplate() = %q; want %q", got, tc.wantBody)
+			}
+		})
+	}
+}
+
+func TestExtractContributingGuidelines(t *testing.T) {
+	cases := []struct {
+		name     string
+		setup    func(dir string) error
+		wantBody string
+	}{
+		{
+			"with contributing file",
+			func(dir string) error {
+				return os.WriteFile(filepath.Join(dir, "CONTRIBUTING.md"),
+					[]byte("# Contributing\n\nPlease follow these guidelines."), 0644)
+			},
+			"# Contributing\n\nPlease follow these guidelines.",
+		},
+		{
+			"no contributing file",
+			func(_ string) error { return nil },
+			"",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := tc.setup(dir); err != nil {
+				t.Fatal(err)
+			}
+			got := extractContributingGuidelines(dir)
+			if got != tc.wantBody {
+				t.Errorf("extractContributingGuidelines() = %q; want %q", got, tc.wantBody)
+			}
+		})
+	}
+}
+
+func TestGeneratePRBody(t *testing.T) {
+	cases := []struct {
+		name      string
+		setup     func(dir string) error
+		wantExact string
+		wantNot   string
+		wantNE    bool
+	}{
+		{
+			"with template",
+			func(dir string) error {
+				githubDir := filepath.Join(dir, ".github")
+				if err := os.MkdirAll(githubDir, 0755); err != nil {
+					return err
+				}
+				return os.WriteFile(filepath.Join(githubDir, "PULL_REQUEST_TEMPLATE.md"),
+					[]byte("## PR Template\nDescribe changes."), 0644)
+			},
+			"## PR Template\nDescribe changes.",
+			"",
+			false,
+		},
+		{
+			"with contributing",
+			func(dir string) error {
+				return os.WriteFile(filepath.Join(dir, "CONTRIBUTING.md"),
+					[]byte("# Contributing Guidelines"), 0644)
+			},
+			"# Contributing Guidelines",
+			"",
+			false,
+		},
+		{
+			"fallback with goal",
+			func(dir string) error {
+				return os.WriteFile(filepath.Join(dir, "GOAL.md"),
+					[]byte("---\n---\nImplement the feature.\n"), 0644)
+			},
+			"",
+			"Pull request created by sgai.",
+			true,
+		},
+		{
+			"generic fallback",
+			func(_ string) error { return nil },
+			"Pull request created by sgai.",
+			"",
+			false,
+		},
+		{
+			"template takes priority over contributing",
+			func(dir string) error {
+				if err := os.WriteFile(filepath.Join(dir, "CONTRIBUTING.md"),
+					[]byte("contributing content"), 0644); err != nil {
+					return err
+				}
+				githubDir := filepath.Join(dir, ".github")
+				if err := os.MkdirAll(githubDir, 0755); err != nil {
+					return err
+				}
+				return os.WriteFile(filepath.Join(githubDir, "PULL_REQUEST_TEMPLATE.md"),
+					[]byte("template content"), 0644)
+			},
+			"template content",
+			"",
+			false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := tc.setup(dir); err != nil {
+				t.Fatal(err)
+			}
+			got := generatePRBody(dir)
+			if tc.wantExact != "" && got != tc.wantExact {
+				t.Errorf("generatePRBody() = %q; want %q", got, tc.wantExact)
+			}
+			if tc.wantNE && got == "" {
+				t.Error("expected non-empty fallback body")
+			}
+			if tc.wantNot != "" && got == tc.wantNot {
+				t.Errorf("generatePRBody() = %q; want something other than %q", got, tc.wantNot)
+			}
+		})
+	}
+}
+
+func TestReadGoalTitle(t *testing.T) {
+	cases := []struct {
+		name  string
+		setup func(dir string) error
+		want  string
+	}{
+		{
+			"with goal file",
+			func(dir string) error {
+				return os.WriteFile(filepath.Join(dir, "GOAL.md"),
+					[]byte("---\nflow: |\n  a -> b\n---\nImplement dark mode toggle.\n\n## Acceptance Criteria\n"), 0644)
+			},
+			"Implement dark mode toggle.",
+		},
+		{
+			"no goal file",
+			func(_ string) error { return nil },
+			"",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := tc.setup(dir); err != nil {
+				t.Fatal(err)
+			}
+			got := readGoalTitle(dir)
+			if got != tc.want {
+				t.Errorf("readGoalTitle() = %q; want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestExtractPRTitle(t *testing.T) {
+	cases := []struct {
+		name  string
+		setup func(dir string) error
+		want  string
+	}{
+		{
+			"with goal file",
+			func(dir string) error {
+				return os.WriteFile(filepath.Join(dir, "GOAL.md"),
+					[]byte("---\n---\nAdd authentication system.\n"), 0644)
+			},
+			"Add authentication system.",
+		},
+		{
+			"fallback",
+			func(_ string) error { return nil },
+			"sgai: automated changes",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := tc.setup(dir); err != nil {
+				t.Fatal(err)
+			}
+			got := extractPRTitle(dir)
+			if got != tc.want {
+				t.Errorf("extractPRTitle() = %q; want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDispatchCompletionGateResponse(t *testing.T) {
+	cases := []struct {
+		name         string
+		response     string
+		wantContinue bool
+	}{
+		{"continue working", "Selected: Continue working", true},
+		{"done", "Selected: Done", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			result := dispatchCompletionGateResponse(dir, tc.response, "test")
+			if result.continueWorking != tc.wantContinue {
+				t.Errorf("dispatchCompletionGateResponse(%q) continueWorking = %v; want %v",
+					tc.response, result.continueWorking, tc.wantContinue)
+			}
+		})
+	}
+}
+
+func TestResolveRootDirStandalone(t *testing.T) {
+	dir := t.TempDir()
+	got := resolveRootDir(dir)
+	if got != dir {
+		t.Errorf("resolveRootDir() = %q; want %q for standalone", got, dir)
+	}
+}
+
+func setupGitRepoWithRemote(t *testing.T, remoteURL string) string {
+	t.Helper()
+	dir := t.TempDir()
+	initCmd := exec.Command("git", "init")
+	initCmd.Dir = dir
+	if errInit := initCmd.Run(); errInit != nil {
+		t.Fatalf("git init failed: %v", errInit)
+	}
+	addCmd := exec.Command("git", "remote", "add", "origin", remoteURL)
+	addCmd.Dir = dir
+	if errAdd := addCmd.Run(); errAdd != nil {
+		t.Fatalf("git remote add failed: %v", errAdd)
+	}
+	return dir
+}


### PR DESCRIPTION
## Summary

- When a workflow completes, a **completion gate** now presents the user with contextual options: create a PR (GitHub), create an MR (GitLab), continue working, or mark as done
- **Forge detection** inspects git remotes to identify GitHub/GitLab and checks for `gh`/`glab` CLI availability before offering PR/MR creation
- Auto-generates PR/MR title from `GOAL.md` and body from PR templates, `CONTRIBUTING.md`, or a fallback with goal + commit log + diff stats
- Pushes a `jj` bookmark (`sgai/<workspace>`) to the remote before creating the PR/MR

## New Files

- `cmd/sgai/forge.go` — forge detection, PR/MR body generation, bookmark pushing, completion gate logic
- `cmd/sgai/forge_test.go` — comprehensive tests for forge detection, template reading, choice building, and dispatch

## Modified Files

- `cmd/sgai/main.go` — integrates `handleCompletionGate` at both flow-level and agent-level completion points, allowing users to loop back into work or finalize with a PR/MR