### PR TITLE
cmd/sgai: add elapsed timestamps to log output

### DIFF
--- a/GOALS/2026_02_19_add_log_timestamps.md
+++ b/GOALS/2026_02_19_add_log_timestamps.md
@@ -1,0 +1,28 @@
+---
+flow: |
+  "backend-go-developer" -> "go-readability-reviewer"
+  "backend-go-developer" -> "stpa-analyst"
+  "go-readability-reviewer" -> "stpa-analyst"
+  "general-purpose" -> "stpa-analyst"
+  "react-developer" -> "react-reviewer"
+  "react-reviewer" -> "stpa-analyst"
+  "project-critic-council"
+  "skill-writer"
+models:
+  "coordinator": "opencode/glm-5"
+  "backend-go-developer": "opencode/glm-5"
+  "go-readability-reviewer": "opencode/glm-5"
+  "general-purpose": "opencode/glm-5"
+  "react-developer": "opencode/glm-5"
+  "react-reviewer": "opencode/glm-5"
+  "stpa-analyst": "opencode/glm-5"
+  "project-critic-council": ["opencode/glm-5", "opencode/kimi-k2.5", "opencode/minimax-m2.5"]
+  "skill-writer": "opencode/glm-5"
+completionGateScript: make test
+---
+
+Currently, in the logs, everywhere I have this format
+
+[factoryname][agentname:####]
+
+- [x] add timestamp so that I can see how long each line is taking to run

--- a/cmd/sgai/serve_api.go
+++ b/cmd/sgai/serve_api.go
@@ -2432,8 +2432,8 @@ func (s *Server) handleAPIAdhoc(w http.ResponseWriter, r *http.Request) {
 	cmd.Stdin = strings.NewReader(st.promptText)
 	writer := &lockedWriter{mu: &st.mu, buf: &st.output}
 	prefix := fmt.Sprintf("[%s][adhoc:0000]", filepath.Base(workspacePath))
-	stdoutPW := &prefixWriter{prefix: prefix + " ", w: os.Stdout}
-	stderrPW := &prefixWriter{prefix: prefix + " ", w: os.Stderr}
+	stdoutPW := &prefixWriter{prefix: prefix + " ", w: os.Stdout, startTime: time.Now()}
+	stderrPW := &prefixWriter{prefix: prefix + " ", w: os.Stderr, startTime: time.Now()}
 	cmd.Stdout = io.MultiWriter(stdoutPW, writer)
 	cmd.Stderr = io.MultiWriter(stderrPW, writer)
 


### PR DESCRIPTION
## Summary

- Add `formatElapsed` helper that renders `[HH:MM:SS.mmm]` elapsed time since process start
- Inject timestamps into `prefixWriter` and `jsonPrettyWriter` so every log line shows how long each operation takes
- Covers both stderr prefix lines and JSON-formatted stdout output