### PR TITLE
cmd/sgai/webapp: remove unnecessary inner scrollbar from messages tab

### DIFF
--- a/GOALS/2026_02_20_messages_tab_scrollbars.md
+++ b/GOALS/2026_02_20_messages_tab_scrollbars.md
@@ -1,0 +1,24 @@
+---
+flow: |
+  "backend-go-developer" -> "go-readability-reviewer"
+  "backend-go-developer" -> "stpa-analyst"
+  "go-readability-reviewer" -> "stpa-analyst"
+  "general-purpose" -> "stpa-analyst"
+  "react-developer" -> "react-reviewer"
+  "react-reviewer" -> "stpa-analyst"
+  "project-critic-council"
+  "skill-writer"
+models:
+  "coordinator": "anthropic/claude-opus-4-6 (max)"
+  "backend-go-developer": "anthropic/claude-opus-4-6"
+  "go-readability-reviewer": "anthropic/claude-opus-4-6"
+  "general-purpose": "anthropic/claude-opus-4-6"
+  "react-developer": "anthropic/claude-opus-4-6"
+  "react-reviewer": "anthropic/claude-opus-4-6"
+  "stpa-analyst": "anthropic/claude-opus-4-6"
+  "project-critic-council": ["anthropic/claude-opus-4-6"]
+  "skill-writer": "anthropic/claude-opus-4-6 (max)"
+completionGateScript: make test
+---
+
+- [x] In the messages tab, when there are a lot of messages, there's an inner scrollbar; this inner scrollbar is not necessary, just let it scroll.

--- a/cmd/sgai/webapp/src/pages/tabs/MessagesTab.tsx
+++ b/cmd/sgai/webapp/src/pages/tabs/MessagesTab.tsx
@@ -1,6 +1,5 @@
 import { useState, useEffect } from "react";
 import { Skeleton } from "@/components/ui/skeleton";
-import { ScrollArea } from "@/components/ui/scroll-area";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { MarkdownContent } from "@/components/MarkdownContent";
 import { api } from "@/lib/api";
@@ -120,12 +119,10 @@ export function MessagesTab({ workspaceName }: MessagesTabProps) {
   }
 
   return (
-    <ScrollArea className="max-h-[calc(100vh-16rem)]">
-      <div className="space-y-2">
-        {messages.map((msg) => (
-          <MessageItem key={msg.id} message={msg} />
-        ))}
-      </div>
-    </ScrollArea>
+    <div className="space-y-2">
+      {messages.map((msg) => (
+        <MessageItem key={msg.id} message={msg} />
+      ))}
+    </div>
   );
 }


### PR DESCRIPTION
## Summary

- Remove the `ScrollArea` wrapper from the messages list in `MessagesTab`, allowing messages to scroll naturally with the page instead of creating an unnecessary inner scrollbar.
- Drop the unused `ScrollArea` import.