### PR TITLE
cmd/sgai: add quit option to macOS menu bar

### DIFF
--- a/GOALS/2026_02_20_add_quit_to_menu_bar.md
+++ b/GOALS/2026_02_20_add_quit_to_menu_bar.md
@@ -1,0 +1,24 @@
+---
+flow: |
+  "backend-go-developer" -> "go-readability-reviewer"
+  "backend-go-developer" -> "stpa-analyst"
+  "go-readability-reviewer" -> "stpa-analyst"
+  "general-purpose" -> "stpa-analyst"
+  "react-developer" -> "react-reviewer"
+  "react-reviewer" -> "stpa-analyst"
+  "project-critic-council"
+  "skill-writer"
+models:
+  "coordinator": "opencode/glm-5"
+  "backend-go-developer": "opencode/glm-5"
+  "go-readability-reviewer": "opencode/glm-5"
+  "general-purpose": "opencode/glm-5"
+  "react-developer": "opencode/glm-5"
+  "react-reviewer": "opencode/glm-5"
+  "stpa-analyst": "opencode/glm-5"
+  "project-critic-council": ["opencode/glm-5", "opencode/kimi-k2.5", "opencode/minimax-m2.5"]
+  "skill-writer": "opencode/glm-5"
+completionGateScript: make test
+---
+
+- [x] I want you to add a section splitter (the menu equivalent of <hr/>) and a quit option that makes the factory stop itself gracefully in 5s, and then hard.

--- a/cmd/sgai/menubar_other.go
+++ b/cmd/sgai/menubar_other.go
@@ -4,6 +4,6 @@ package main
 
 import "context"
 
-func startMenuBar(ctx context.Context, _ string, _ *Server) {
+func startMenuBar(ctx context.Context, _ string, _ *Server, _ context.CancelFunc) {
 	<-ctx.Done()
 }

--- a/cmd/sgai/serve.go
+++ b/cmd/sgai/serve.go
@@ -550,7 +550,7 @@ func cmdServe(args []string) {
 		}
 	}()
 
-	startMenuBar(ctx, baseURL, srv)
+	startMenuBar(ctx, baseURL, srv, stop)
 	if errClose := httpServer.Close(); errClose != nil {
 		log.Println("http server close:", errClose)
 	}


### PR DESCRIPTION
## Summary

- Add a section separator and "Quit" option to the macOS menu bar that gracefully shuts down the factory
- Copy GOAL.md spec into GOALS/ directory following the contribution naming convention