### PR TITLE
cmd/sgai: add project summary feature with auto-generation and inline editing

### DIFF
--- a/GOALS/2026_02_23_project_summary.md
+++ b/GOALS/2026_02_23_project_summary.md
@@ -1,0 +1,44 @@
+---
+flow: |
+  "backend-go-developer" -> "go-readability-reviewer"
+  "react-developer" -> "react-reviewer"
+  "general-purpose"
+  "project-critic-council"
+  "stpa-analyst"
+  "skill-writer"
+models:
+  "coordinator": "anthropic/claude-opus-4-6 (max)"
+  "backend-go-developer": "anthropic/claude-opus-4-6"
+  "go-readability-reviewer": "anthropic/claude-opus-4-6"
+  "general-purpose": "anthropic/claude-opus-4-6"
+  "react-developer": "anthropic/claude-opus-4-6"
+  "react-reviewer": "anthropic/claude-opus-4-6"
+  "stpa-analyst": "anthropic/claude-opus-4-6"
+  "project-critic-council": ["anthropic/claude-opus-4-6"]
+  "skill-writer": "anthropic/claude-opus-4-6 (max)"
+completionGateScript: make test
+---
+
+I really like what we are doing here, but we need to improve the HCI/UX.
+
+Specifically, I want to add english text single sentence summary of the projects
+
+- [x] compose a summary and update the UI
+  - [x] when GOAL.md is saved, or when a summary is missing
+  - [x] when project is started and a summary is missing
+  - [x] BUG: when I click `Edit GOAL.md`, and then save it, it is not updating.
+
+- [x] allow the user to edit the summary manually if they want to
+  - [x] manual summaries are sticky, they shouldn't be overriden by automatic summaries
+
+- [x] show the summary on the left tree
+  - [x] in the tree
+  - [x] in the In Progress (pinned and in-progress sessions)
+- [x] show the summary on the workspace page
+- [x] show the summary on the Root Repository in Forked Mode
+  - [x] on each Forked Repository line inside the Root Repository in Forked Mode Page
+
+- [x] using the events systems already in place, make sure that `Edit GOAL.md` doesn't block (right now, it takes several seconds between saving and redirecting, becasue it needs to call opencode to compose the summary message)
+  - [x] do that in the background
+  - [x] handle debouncing and last-one-wins implementation, so that multiple edits are handled correctly (and avoid duplicated calls to opencode)
+

--- a/cmd/sgai/serve.go
+++ b/cmd/sgai/serve.go
@@ -234,6 +234,8 @@ type Server struct {
 
 	composerSessionsMu sync.Mutex
 	composerSessions   map[string]*composerSession
+
+	summaryGen *summaryGenerator
 }
 
 // NewServer creates a new Server instance with the given root directory.
@@ -531,6 +533,7 @@ func cmdServe(args []string) {
 
 	srv := NewServer(rootDir)
 	srv.shutdownCtx = ctx
+	srv.summaryGen = newSummaryGenerator(ctx, srv)
 	if err := srv.loadPinnedProjects(); err != nil {
 		log.Println("warning: failed to load pinned projects:", err)
 	}
@@ -552,6 +555,7 @@ func cmdServe(args []string) {
 	}()
 
 	startMenuBar(ctx, baseURL, srv, stop)
+	srv.summaryGen.stop()
 	if errClose := httpServer.Close(); errClose != nil {
 		log.Println("http server close:", errClose)
 	}

--- a/cmd/sgai/skel/.sgai/skills/coding-practices/go-testing-coverage/SKILL.md
+++ b/cmd/sgai/skel/.sgai/skills/coding-practices/go-testing-coverage/SKILL.md
@@ -478,6 +478,31 @@ func TestHandler(t *testing.T) {
 - https://pkg.go.dev/slices
 - https://pkg.go.dev/testing/slogtest
 
+## Test Code Quality
+
+### Avoiding Dead Code in Tests
+
+Dead code in tests causes unnecessary review cycles. Before marking tests complete:
+
+- **No unused variables**: Remove any variable declared but never used
+- **No discarded values**: Never assign to `_` unless explicitly ignoring an error
+- **No unnecessary imports**: Remove unused imports (especially `sync/atomic` when not needed)
+- **Meaningful assertions**: Replace trivially-passing assertions with checks that verify actual behavior
+
+Example of bad code (from session):
+```go
+triggerCount := &atomic.Int32{} // unused
+originalRun := d.run             // captured and discarded
+```
+
+Example of good code:
+```go
+// Verify the debounce timer is still pending after 100ms
+if !d.timer.Stop() {
+    <-d.timer.C // drain channel to avoid leak
+}
+```
+
 ## Common Mistakes
 
 - **Testing implementation** - Test behavior, not internals

--- a/cmd/sgai/summary_generator.go
+++ b/cmd/sgai/summary_generator.go
@@ -1,0 +1,176 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/sandgardenhq/sgai/pkg/state"
+)
+
+type summaryGenerator struct {
+	mu          sync.Mutex
+	debounceMap map[string]*summaryDebouncer
+	shutdownCtx context.Context
+	server      *Server
+}
+
+type summaryDebouncer struct {
+	mu       sync.Mutex
+	timer    *time.Timer
+	cancelFn context.CancelFunc
+}
+
+func newSummaryGenerator(shutdownCtx context.Context, srv *Server) *summaryGenerator {
+	return &summaryGenerator{
+		debounceMap: make(map[string]*summaryDebouncer),
+		shutdownCtx: shutdownCtx,
+		server:      srv,
+	}
+}
+
+func (g *summaryGenerator) trigger(workspacePath string) {
+	g.mu.Lock()
+	d, ok := g.debounceMap[workspacePath]
+	if !ok {
+		d = &summaryDebouncer{}
+		g.debounceMap[workspacePath] = d
+	}
+	g.mu.Unlock()
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if d.cancelFn != nil {
+		d.cancelFn()
+		d.cancelFn = nil
+	}
+
+	if d.timer != nil {
+		d.timer.Stop()
+	}
+
+	d.timer = time.AfterFunc(2*time.Second, func() {
+		g.runGeneration(workspacePath)
+	})
+}
+
+func (g *summaryGenerator) runGeneration(workspacePath string) {
+	g.mu.Lock()
+	d := g.debounceMap[workspacePath]
+	g.mu.Unlock()
+
+	if d == nil {
+		return
+	}
+
+	ctx, cancel := context.WithCancel(g.shutdownCtx)
+	d.mu.Lock()
+	d.cancelFn = cancel
+	d.mu.Unlock()
+
+	defer cancel()
+
+	goalBody := readGoalBody(workspacePath)
+	if goalBody == "" {
+		return
+	}
+
+	summary := generateSummaryViaOpenCode(ctx, workspacePath, goalBody)
+	if summary == "" {
+		return
+	}
+
+	saveSummaryIfNotManual(workspacePath, summary)
+
+	g.server.publishGlobalAndWorkspace(filepath.Base(workspacePath), workspacePath, sseEvent{
+		Type: "session:update",
+		Data: map[string]string{"workspace": filepath.Base(workspacePath)},
+	})
+}
+
+func (g *summaryGenerator) stop() {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	for _, d := range g.debounceMap {
+		d.mu.Lock()
+		if d.timer != nil {
+			d.timer.Stop()
+		}
+		if d.cancelFn != nil {
+			d.cancelFn()
+		}
+		d.mu.Unlock()
+	}
+}
+
+func readGoalBody(workspacePath string) string {
+	data, errRead := os.ReadFile(filepath.Join(workspacePath, "GOAL.md"))
+	if errRead != nil {
+		return ""
+	}
+	body := extractBody(data)
+	return strings.TrimSpace(string(body))
+}
+
+func generateSummaryViaOpenCode(ctx context.Context, workspacePath, goalBody string) string {
+	modelSpecs := modelsForAgentFromGoal(workspacePath, "coordinator")
+	if len(modelSpecs) == 0 {
+		return ""
+	}
+
+	modelID, variant := parseModelAndVariant(modelSpecs[0])
+
+	args := []string{"run", "-m", modelID}
+	if variant != "" {
+		args = append(args, "--variant", variant)
+	}
+	args = append(args, "--agent", "build", "--title", "summary")
+
+	prompt := "Read this GOAL.md and produce a single English sentence summarizing the project goal. Output ONLY the summary sentence, nothing else.\n\n" + goalBody
+
+	cmd := exec.CommandContext(ctx, "opencode", args...)
+	cmd.Dir = workspacePath
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Env = append(os.Environ(), "OPENCODE_CONFIG_DIR="+filepath.Join(workspacePath, ".sgai"))
+	cmd.Stdin = strings.NewReader(prompt)
+
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = os.Stderr
+
+	if errRun := cmd.Run(); errRun != nil {
+		log.Println("summary generation failed:", errRun)
+		return ""
+	}
+
+	return cleanSummaryOutput(stdout.String())
+}
+
+func cleanSummaryOutput(raw string) string {
+	trimmed := strings.TrimSpace(raw)
+	trimmed = strings.Trim(trimmed, "\"'`")
+	trimmed = strings.TrimSpace(trimmed)
+	return trimmed
+}
+
+func saveSummaryIfNotManual(workspacePath, summary string) {
+	wfState, errLoad := state.Load(statePath(workspacePath))
+	if errLoad != nil {
+		return
+	}
+	if wfState.SummaryManual {
+		return
+	}
+	wfState.Summary = summary
+	if errSave := state.Save(statePath(workspacePath), wfState); errSave != nil {
+		log.Println("failed to save summary:", errSave)
+	}
+}

--- a/cmd/sgai/summary_generator_test.go
+++ b/cmd/sgai/summary_generator_test.go
@@ -1,0 +1,312 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sandgardenhq/sgai/pkg/state"
+)
+
+func TestCleanSummaryOutput(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"simple", "A simple summary.", "A simple summary."},
+		{"withQuotes", `"A quoted summary."`, "A quoted summary."},
+		{"withWhitespace", "  some text  \n", "some text"},
+		{"withBackticks", "`summary text`", "summary text"},
+		{"withSingleQuotes", "'summary text'", "summary text"},
+		{"empty", "", ""},
+		{"mixedQuotes", `"'summary'"`, "summary"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := cleanSummaryOutput(tc.in)
+			if got != tc.want {
+				t.Errorf("cleanSummaryOutput(%q) = %q; want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSaveSummaryIfNotManual(t *testing.T) {
+	t.Run("savesWhenNotManual", func(t *testing.T) {
+		rootDir := t.TempDir()
+		workspace := filepath.Join(rootDir, "test-project")
+		if errMkdir := os.MkdirAll(workspace, 0755); errMkdir != nil {
+			t.Fatal(errMkdir)
+		}
+		createsgaiDir(t, workspace)
+
+		if errSave := state.Save(statePath(workspace), state.Workflow{}); errSave != nil {
+			t.Fatal(errSave)
+		}
+
+		saveSummaryIfNotManual(workspace, "A test summary")
+
+		loaded, errLoad := state.Load(statePath(workspace))
+		if errLoad != nil {
+			t.Fatal(errLoad)
+		}
+		if loaded.Summary != "A test summary" {
+			t.Errorf("summary = %q; want %q", loaded.Summary, "A test summary")
+		}
+	})
+
+	t.Run("skipsWhenManual", func(t *testing.T) {
+		rootDir := t.TempDir()
+		workspace := filepath.Join(rootDir, "test-project")
+		if errMkdir := os.MkdirAll(workspace, 0755); errMkdir != nil {
+			t.Fatal(errMkdir)
+		}
+		createsgaiDir(t, workspace)
+
+		if errSave := state.Save(statePath(workspace), state.Workflow{
+			Summary:       "User written summary",
+			SummaryManual: true,
+		}); errSave != nil {
+			t.Fatal(errSave)
+		}
+
+		saveSummaryIfNotManual(workspace, "Auto generated summary")
+
+		loaded, errLoad := state.Load(statePath(workspace))
+		if errLoad != nil {
+			t.Fatal(errLoad)
+		}
+		if loaded.Summary != "User written summary" {
+			t.Errorf("summary = %q; want %q (should not be overwritten)", loaded.Summary, "User written summary")
+		}
+	})
+}
+
+func TestSummaryGeneratorDebounce(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	rootDir := t.TempDir()
+	srv := NewServer(rootDir)
+	srv.shutdownCtx = ctx
+
+	gen := newSummaryGenerator(ctx, srv)
+	t.Cleanup(gen.stop)
+
+	gen.trigger("/workspace/a")
+	gen.trigger("/workspace/a")
+	gen.trigger("/workspace/a")
+
+	time.Sleep(100 * time.Millisecond)
+
+	gen.mu.Lock()
+	d, ok := gen.debounceMap["/workspace/a"]
+	gen.mu.Unlock()
+
+	if !ok {
+		t.Fatal("expected debouncer entry for /workspace/a")
+	}
+
+	d.mu.Lock()
+	hasTimer := d.timer != nil
+	d.mu.Unlock()
+
+	if !hasTimer {
+		t.Fatal("debounce timer should still be pending (2s debounce, only 100ms elapsed)")
+	}
+}
+
+func TestSummaryGeneratorStopCancelsTimers(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	rootDir := t.TempDir()
+	srv := NewServer(rootDir)
+	srv.shutdownCtx = ctx
+
+	gen := newSummaryGenerator(ctx, srv)
+
+	gen.trigger("/workspace/a")
+	gen.trigger("/workspace/b")
+
+	gen.stop()
+
+	gen.mu.Lock()
+	for _, d := range gen.debounceMap {
+		d.mu.Lock()
+		if d.timer != nil {
+			if !d.timer.Stop() {
+				t.Log("timer was already fired or stopped")
+			}
+		}
+		d.mu.Unlock()
+	}
+	gen.mu.Unlock()
+}
+
+func TestReadGoalBody(t *testing.T) {
+	t.Run("withFrontmatter", func(t *testing.T) {
+		rootDir := t.TempDir()
+		goalContent := "---\nflow: |\n  \"a\" -> \"b\"\n---\n\nBuild a cool project.\n"
+		if errWrite := os.WriteFile(filepath.Join(rootDir, "GOAL.md"), []byte(goalContent), 0644); errWrite != nil {
+			t.Fatal(errWrite)
+		}
+
+		body := readGoalBody(rootDir)
+		if body != "Build a cool project." {
+			t.Errorf("readGoalBody() = %q; want %q", body, "Build a cool project.")
+		}
+	})
+
+	t.Run("noFile", func(t *testing.T) {
+		body := readGoalBody(t.TempDir())
+		if body != "" {
+			t.Errorf("readGoalBody() = %q; want empty", body)
+		}
+	})
+}
+
+func TestHandleAPIUpdateSummary(t *testing.T) {
+	rootDir := t.TempDir()
+	workspace := filepath.Join(rootDir, "test-project")
+	if errMkdir := os.MkdirAll(workspace, 0755); errMkdir != nil {
+		t.Fatal(errMkdir)
+	}
+	createsgaiDir(t, workspace)
+	if errSave := state.Save(statePath(workspace), state.Workflow{Summary: "old summary"}); errSave != nil {
+		t.Fatal(errSave)
+	}
+
+	srv := NewServer(rootDir)
+	mux := http.NewServeMux()
+	srv.registerAPIRoutes(mux)
+
+	body := `{"summary": "My custom summary"}`
+	req := httptest.NewRequest("PUT", "/api/v1/workspaces/test-project/summary", strings.NewReader(body))
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d; want %d; body = %s", rr.Code, http.StatusOK, rr.Body.String())
+	}
+
+	var resp apiUpdateSummaryResponse
+	if errDecode := json.NewDecoder(rr.Body).Decode(&resp); errDecode != nil {
+		t.Fatal(errDecode)
+	}
+	if !resp.Updated {
+		t.Fatal("expected Updated=true")
+	}
+	if resp.Summary != "My custom summary" {
+		t.Errorf("summary = %q; want %q", resp.Summary, "My custom summary")
+	}
+
+	loaded, errLoad := state.Load(statePath(workspace))
+	if errLoad != nil {
+		t.Fatal(errLoad)
+	}
+	if loaded.Summary != "My custom summary" {
+		t.Errorf("persisted summary = %q; want %q", loaded.Summary, "My custom summary")
+	}
+	if !loaded.SummaryManual {
+		t.Fatal("SummaryManual should be true after manual update")
+	}
+}
+
+func TestHandleAPIUpdateSummaryPreventsAutoOverwrite(t *testing.T) {
+	rootDir := t.TempDir()
+	workspace := filepath.Join(rootDir, "test-project")
+	if errMkdir := os.MkdirAll(workspace, 0755); errMkdir != nil {
+		t.Fatal(errMkdir)
+	}
+	createsgaiDir(t, workspace)
+
+	if errSave := state.Save(statePath(workspace), state.Workflow{}); errSave != nil {
+		t.Fatal(errSave)
+	}
+
+	srv := NewServer(rootDir)
+	mux := http.NewServeMux()
+	srv.registerAPIRoutes(mux)
+
+	body := `{"summary": "Manual summary"}`
+	req := httptest.NewRequest("PUT", "/api/v1/workspaces/test-project/summary", strings.NewReader(body))
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d; want %d", rr.Code, http.StatusOK)
+	}
+
+	saveSummaryIfNotManual(workspace, "This should not overwrite")
+
+	loaded, errLoad := state.Load(statePath(workspace))
+	if errLoad != nil {
+		t.Fatal(errLoad)
+	}
+	if loaded.Summary != "Manual summary" {
+		t.Errorf("summary = %q; want %q (should remain manual)", loaded.Summary, "Manual summary")
+	}
+	if !loaded.SummaryManual {
+		t.Fatal("SummaryManual should remain true")
+	}
+}
+
+func TestBuildWorkspaceDetailIncludesSummary(t *testing.T) {
+	rootDir := t.TempDir()
+	workspace := filepath.Join(rootDir, "test-project")
+	if errMkdir := os.MkdirAll(workspace, 0755); errMkdir != nil {
+		t.Fatal(errMkdir)
+	}
+	createsgaiDir(t, workspace)
+
+	if errSave := state.Save(statePath(workspace), state.Workflow{
+		Summary:       "Test project summary",
+		SummaryManual: true,
+	}); errSave != nil {
+		t.Fatal(errSave)
+	}
+
+	srv := NewServer(rootDir)
+	detail := srv.buildWorkspaceDetail(workspace)
+	if detail.Summary != "Test project summary" {
+		t.Errorf("detail.Summary = %q; want %q", detail.Summary, "Test project summary")
+	}
+	if !detail.SummaryManual {
+		t.Fatal("detail.SummaryManual should be true")
+	}
+}
+
+func TestConvertWorkspaceInfoIncludesSummary(t *testing.T) {
+	rootDir := t.TempDir()
+	workspace := filepath.Join(rootDir, "test-project")
+	if errMkdir := os.MkdirAll(workspace, 0755); errMkdir != nil {
+		t.Fatal(errMkdir)
+	}
+	createsgaiDir(t, workspace)
+
+	if errSave := state.Save(statePath(workspace), state.Workflow{
+		Summary: "Sidebar summary",
+	}); errSave != nil {
+		t.Fatal(errSave)
+	}
+
+	info := workspaceInfo{
+		Directory:    workspace,
+		DirName:      "test-project",
+		HasWorkspace: true,
+	}
+
+	entry := convertWorkspaceInfo(info)
+	if entry.Summary != "Sidebar summary" {
+		t.Errorf("entry.Summary = %q; want %q", entry.Summary, "Sidebar summary")
+	}
+}

--- a/cmd/sgai/webapp/src/lib/api.ts
+++ b/cmd/sgai/webapp/src/lib/api.ts
@@ -39,6 +39,7 @@ import type {
   ApiOpenEditorResponse,
   ApiOpenOpencodeResponse,
   ApiDeleteForkResponse,
+  ApiUpdateSummaryResponse,
 } from "../types";
 
 class ApiError extends Error {
@@ -221,6 +222,11 @@ export const api = {
       fetchJSON<ApiDeleteForkResponse>(
         `/api/v1/workspaces/${encodeURIComponent(name)}/delete-fork`,
         { method: "POST", body: JSON.stringify({ forkDir, confirm: true }) },
+      ),
+    updateSummary: (name: string, summary: string) =>
+      fetchJSON<ApiUpdateSummaryResponse>(
+        `/api/v1/workspaces/${encodeURIComponent(name)}/summary`,
+        { method: "PUT", body: JSON.stringify({ summary }) },
       ),
   },
 

--- a/cmd/sgai/webapp/src/pages/Dashboard.tsx
+++ b/cmd/sgai/webapp/src/pages/Dashboard.tsx
@@ -92,7 +92,7 @@ function WorkspaceTreeItem({ workspace, selectedName }: WorkspaceTreeItemProps) 
           <button
             type="button"
             onClick={() => setExpanded((prev) => !prev)}
-            className="w-5 h-5 inline-flex items-center justify-center rounded text-xs font-semibold shrink-0 mr-1 bg-muted text-muted-foreground hover:bg-secondary hover:text-secondary-foreground transition-colors"
+            className="w-5 h-5 inline-flex items-center justify-center rounded text-xs font-semibold shrink-0 mr-1 bg-muted text-muted-foreground hover:bg-secondary hover:text-secondary-foreground transition-colors self-start mt-1"
             aria-label="Toggle forks"
           >
             {expanded ? "−" : "+"}
@@ -106,14 +106,26 @@ function WorkspaceTreeItem({ workspace, selectedName }: WorkspaceTreeItemProps) 
           className="flex-1 min-w-0"
         >
           <Link to={`/workspaces/${encodeURIComponent(workspace.name)}/progress`}>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <span className="flex-1 overflow-hidden text-ellipsis whitespace-nowrap">
-                  {workspace.name}
-                </span>
-              </TooltipTrigger>
-              <TooltipContent side="right">{workspace.name}</TooltipContent>
-            </Tooltip>
+            <span className="flex-1 min-w-0 flex flex-col">
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span className="overflow-hidden text-ellipsis whitespace-nowrap">
+                    {workspace.name}
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent side="right">{workspace.name}</TooltipContent>
+              </Tooltip>
+              {workspace.summary && (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span className="text-[0.65rem] text-muted-foreground overflow-hidden text-ellipsis whitespace-nowrap leading-tight">
+                      {workspace.summary}
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent side="right" className="max-w-xs">{workspace.summary}</TooltipContent>
+                </Tooltip>
+              )}
+            </span>
             <WorkspaceIndicators workspace={workspace} />
           </Link>
         </SidebarMenuButton>
@@ -132,14 +144,26 @@ function WorkspaceTreeItem({ workspace, selectedName }: WorkspaceTreeItemProps) 
                   className="relative before:content-[''] before:absolute before:left-[-0.875rem] before:top-1/2 before:w-3.5 before:h-0.5 before:bg-border before:rounded-sm"
                 >
                   <Link to={`/workspaces/${encodeURIComponent(fork.name)}/progress`}>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <span className="flex-1 overflow-hidden text-ellipsis whitespace-nowrap">
-                          {fork.name}
-                        </span>
-                      </TooltipTrigger>
-                      <TooltipContent side="right">{fork.name}</TooltipContent>
-                    </Tooltip>
+                    <span className="flex-1 min-w-0 flex flex-col">
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <span className="overflow-hidden text-ellipsis whitespace-nowrap">
+                            {fork.name}
+                          </span>
+                        </TooltipTrigger>
+                        <TooltipContent side="right">{fork.name}</TooltipContent>
+                      </Tooltip>
+                      {fork.summary && (
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <span className="text-[0.65rem] text-muted-foreground overflow-hidden text-ellipsis whitespace-nowrap leading-tight">
+                              {fork.summary}
+                            </span>
+                          </TooltipTrigger>
+                          <TooltipContent side="right" className="max-w-xs">{fork.summary}</TooltipContent>
+                        </Tooltip>
+                      )}
+                    </span>
                     <WorkspaceIndicators workspace={fork} />
                   </Link>
                 </SidebarMenuButton>
@@ -193,14 +217,26 @@ function InProgressSection({ workspaces, selectedName }: InProgressSectionProps)
                     : `/workspaces/${encodeURIComponent(w.name)}/progress`
                   }
                 >
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <span className="flex-1 overflow-hidden text-ellipsis whitespace-nowrap">
-                        {w.name}
-                      </span>
-                    </TooltipTrigger>
-                    <TooltipContent side="right">{w.name}</TooltipContent>
-                  </Tooltip>
+                  <span className="flex-1 min-w-0 flex flex-col">
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <span className="overflow-hidden text-ellipsis whitespace-nowrap">
+                          {w.name}
+                        </span>
+                      </TooltipTrigger>
+                      <TooltipContent side="right">{w.name}</TooltipContent>
+                    </Tooltip>
+                    {w.summary && (
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <span className="text-[0.65rem] text-muted-foreground overflow-hidden text-ellipsis whitespace-nowrap leading-tight">
+                            {w.summary}
+                          </span>
+                        </TooltipTrigger>
+                        <TooltipContent side="right" className="max-w-xs">{w.summary}</TooltipContent>
+                      </Tooltip>
+                    )}
+                  </span>
                   <WorkspaceIndicators workspace={w} />
                 </Link>
               </SidebarMenuButton>

--- a/cmd/sgai/webapp/src/pages/tabs/ForksTab.tsx
+++ b/cmd/sgai/webapp/src/pages/tabs/ForksTab.tsx
@@ -119,16 +119,28 @@ function ForkRow({ fork, rootName, needsInput, onRefresh }: { fork: ApiForkEntry
   return (
     <div className="border rounded-lg overflow-hidden">
       <div className="flex items-center gap-4 p-4 bg-muted/20">
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <span className="font-medium text-sm truncate max-w-[200px] cursor-help">
-              {fork.name}
-            </span>
-          </TooltipTrigger>
-          <TooltipContent>{fork.name}</TooltipContent>
-        </Tooltip>
+        <div className="flex flex-col min-w-0 max-w-[300px]">
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span className="font-medium text-sm truncate cursor-help">
+                {fork.name}
+              </span>
+            </TooltipTrigger>
+            <TooltipContent>{fork.name}</TooltipContent>
+          </Tooltip>
+          {fork.summary && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span className="text-xs text-muted-foreground truncate cursor-help">
+                  {fork.summary}
+                </span>
+              </TooltipTrigger>
+              <TooltipContent className="max-w-xs">{fork.summary}</TooltipContent>
+            </Tooltip>
+          )}
+        </div>
 
-        <span className="text-xs text-muted-foreground">
+        <span className="text-xs text-muted-foreground shrink-0">
           {fork.commitAhead} commits ahead
         </span>
 

--- a/cmd/sgai/webapp/src/types/index.ts
+++ b/cmd/sgai/webapp/src/types/index.ts
@@ -44,6 +44,7 @@ export interface ApiWorkspaceEntry {
   isRoot: boolean;
   status: string;
   hasSgai: boolean;
+  summary?: string;
   forks?: ApiWorkspaceEntry[];
 }
 
@@ -62,6 +63,7 @@ export interface ApiWorkspaceForkSummary {
   dir: string;
   running: boolean;
   commitAhead: number;
+  summary?: string;
 }
 
 export interface SessionCost {
@@ -100,6 +102,8 @@ export interface ApiWorkspaceDetailResponse {
   latestProgress: string;
   agentSequence: ApiAgentSequenceEntry[];
   cost: SessionCost;
+  summary?: string;
+  summaryManual?: boolean;
   forks?: ApiWorkspaceForkSummary[];
 }
 
@@ -395,6 +399,7 @@ export interface ApiForkEntry {
   dir: string;
   running: boolean;
   commitAhead: number;
+  summary?: string;
   commits: ApiForkCommit[];
 }
 
@@ -503,6 +508,11 @@ export interface ApiRenameResponse {
   name: string;
   oldName: string;
   dir: string;
+}
+
+export interface ApiUpdateSummaryResponse {
+  updated: boolean;
+  workspace: string;
 }
 
 export interface ApiUpdateGoalRequest {

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -154,6 +154,15 @@ type Workflow struct {
 	// CurrentModel tracks the currently executing model in multi-model agents.
 	// Format is "agentName:modelSpec".
 	CurrentModel string `json:"currentModel,omitempty"`
+
+	// Summary is a single-sentence summary of the project goal.
+	// Generated automatically when GOAL.md is saved or workspace starts,
+	// unless SummaryManual is true (indicating user has manually edited it).
+	Summary string `json:"summary,omitempty"`
+
+	// SummaryManual indicates whether the summary was manually edited by user.
+	// When true, automatic summary generation is skipped.
+	SummaryManual bool `json:"summaryManual,omitempty"`
 }
 
 // ToolsAllowed reports whether the current interaction mode permits


### PR DESCRIPTION
## Summary

- Add GOALS spec `GOALS/2026_02_23_project_summary.md` for the project summary feature
- Implement single-sentence project summary with auto-generation via opencode and debounced background execution
- Add inline summary editing in workspace detail page with manual-sticky support
- Show summaries in the sidebar tree, workspace page, and root repository forked mode fork list