### PR TITLE
cmd/sgai: replace boolean interaction flags with InteractionMode state machine

### DIFF
--- a/GOALS/2026_02_22_self_drive_broken_again.md
+++ b/GOALS/2026_02_22_self_drive_broken_again.md
@@ -1,0 +1,49 @@
+---
+flow: |
+  "backend-go-developer" -> "go-readability-reviewer"
+  "backend-go-developer" -> "stpa-analyst"
+  "go-readability-reviewer" -> "stpa-analyst"
+  "general-purpose" -> "stpa-analyst"
+  "react-developer" -> "react-reviewer"
+  "react-reviewer" -> "stpa-analyst"
+  "project-critic-council"
+  "stpa-analyst"
+  "skill-writer"
+models:
+  "coordinator": "anthropic/claude-opus-4-6 (max)"
+  "backend-go-developer": "anthropic/claude-opus-4-6"
+  "go-readability-reviewer": "anthropic/claude-opus-4-6"
+  "general-purpose": "anthropic/claude-opus-4-6"
+  "react-developer": "anthropic/claude-opus-4-6"
+  "react-reviewer": "anthropic/claude-opus-4-6"
+  "stpa-analyst": "anthropic/claude-opus-4-6"
+  "project-critic-council": ["anthropic/claude-opus-4-6"]
+  "skill-writer": "anthropic/claude-opus-4-6 (max)"
+completionGateScript: make test
+---
+
+It seems your colleague disagrees with you. 
+
+Check this out
+
+```
+1:26 PM
+coordinator
+Self-Drive bug fix complete. Changed condition in mcp.go from '!StartedInteractive || InteractiveAutoLock' to just 'InteractiveAutoLock'. All tests pass. Now continuing with original tasks.
+12:57 PM
+coordinator
+Self-Drive Bug Analysis Complete. Root cause: askUserQuestion() and askUserWorkGate() in mcp.go don't check StartedInteractive/InteractiveAutoLock flags. When self-drive mode is active, questions should be blocked/auto-approved but currently they're always asked.
+```
+
+- [x] red team your own solution, and think what else you could be missing to make it simpler. 
+
+---
+
+
+- [x] it seems Self-Drive is broken again, when I clicked Self-Drive it started, then it paused to ask me questions.
+- [x] I think we've been accruing complexity and it is time to clean it up.
+- [x] Use all analytical and debugging skills you may have (including root cause analysis) to figure what's wrong and to come up an clean, simple, and small implementation. 
+
+Self-Drive means Self-Drive, when I click Self-Drive no human interaction is allowed.
+
+When I click Start (the alternative to Self-Drive), that means we have three phases: brainstorming (that I can be asked question), Building (completely headless), and Retrospective (that I can be asked to approve changes, only when retrospective is enabled, and retrospective is enabled by default) 

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ deploy: build
 	killall -9 sgai-base
 
 absorb-sgai:
-	@find sgai/ -type f | while read f; do \
+	@find sgai/ -type f | grep -v 'sgai/README.md' | while read f; do \
 		mkdir -p "$$(dirname "cmd/sgai/skel/.sgai/$${f#sgai/}")" || true; \
 		mv -v "$$f" "cmd/sgai/skel/.sgai/$${f#sgai/}"; \
 	done

--- a/cmd/sgai/continuous.go
+++ b/cmd/sgai/continuous.go
@@ -286,7 +286,7 @@ func resetWorkflowForNextCycle(stateJSONPath string) {
 		return
 	}
 	wfState.Status = state.StatusWorking
-	wfState.InteractiveAutoLock = true
+	wfState.InteractionMode = state.ModeSelfDrive
 	if errSave := state.Save(stateJSONPath, wfState); errSave != nil {
 		log.Println("failed to reset workflow for next cycle:", errSave)
 	}
@@ -335,7 +335,7 @@ func setContinuousAutoMode(workspacePath string) {
 	if errLoad != nil {
 		return
 	}
-	wfState.InteractiveAutoLock = true
+	wfState.InteractionMode = state.ModeSelfDrive
 	if errSave := state.Save(stateJSONPath, wfState); errSave != nil {
 		log.Println("failed to set continuous auto mode:", errSave)
 	}

--- a/cmd/sgai/continuous_test.go
+++ b/cmd/sgai/continuous_test.go
@@ -484,8 +484,7 @@ func TestResetWorkflowForNextCycle(t *testing.T) {
 
 	stateJSONPath := filepath.Join(sgaiDir, "state.json")
 	wfState := state.Workflow{
-		Status:              state.StatusComplete,
-		InteractiveAutoLock: false,
+		Status: state.StatusComplete,
 	}
 	if err := state.Save(stateJSONPath, wfState); err != nil {
 		t.Fatal(err)
@@ -501,8 +500,8 @@ func TestResetWorkflowForNextCycle(t *testing.T) {
 	if loaded.Status != state.StatusWorking {
 		t.Errorf("expected status 'working', got %q", loaded.Status)
 	}
-	if !loaded.InteractiveAutoLock {
-		t.Error("expected interactiveAutoLock to be true")
+	if loaded.InteractionMode != state.ModeSelfDrive {
+		t.Errorf("expected interactionMode %q, got %q", state.ModeSelfDrive, loaded.InteractionMode)
 	}
 }
 

--- a/cmd/sgai/dag.go
+++ b/cmd/sgai/dag.go
@@ -47,6 +47,19 @@ Successors (can pass work to): %SUCCESSORS%
 
 ABSOLUTELY CRITICAL: always USE SKILLS WHEN ONE SKILL IS AVAILABLE, DIG THE SKILL CONTENT TO BE SURE IT IS APPLICABLE. Use skills({"name":"skill-name"}) to get the skill content, or use skills({"name":"keywords"}) to find skills by tags.`
 
+const flowSectionSelfDriveMode = `# SELF-DRIVE MODE ACTIVE
+You are running in Self-Drive mode. This means:
+- NO human interaction is allowed at any point
+- The ask_user_question and ask_user_work_gate tools DO NOT EXIST
+- Skip the BRAINSTORMING step entirely - go directly to work
+- Skip the WORK-GATE step entirely - it is implicitly approved
+- If your instructions say to brainstorm or ask for approval, SKIP those steps completely
+`
+
+const flowSectionSelfDriveModeCoordinator = `- Your master plan starts at reading GOAL.md, then immediately delegate work to specialized agents
+- Proceed directly: read GOAL.md → create PROJECT_MANAGEMENT.md → delegate to agents → verify → complete
+`
+
 const flowSectionPostSkillsCoordinator = `IMPORTANT: YOU COMMUNICATE WITH THE HUMAN ONLY VIA ask_user_question (structured multi-choice questions).`
 
 const flowSectionPostSkillsNonCoordinator = `IMPORTANT: If you need human clarification, send a message to coordinator: sgai_send_message({toAgent: "coordinator", body: "QUESTION: <your question>"}). The coordinator will handle human communication.`
@@ -462,7 +475,12 @@ func buildFlowMessage(d *dag, currentAgent string, visitCounts map[string]int, d
 		msg += snippetNudge
 	}
 
-	if !selfDrive {
+	if selfDrive {
+		msg += "\n\n" + flowSectionSelfDriveMode
+		if currentAgent == "coordinator" {
+			msg += flowSectionSelfDriveModeCoordinator
+		}
+	} else {
 		msg += "\n\nCRITICAL: think hard and ASK ME QUESTIONS BEFORE BUILDING\n"
 	}
 

--- a/cmd/sgai/serve.go
+++ b/cmd/sgai/serve.go
@@ -115,14 +115,13 @@ func stripFrontmatter(content string) string {
 }
 
 type session struct {
-	mu              sync.Mutex
-	cmd             *exec.Cmd
-	cancel          context.CancelFunc
-	running         bool
-	interactiveAuto bool
-	outputLog       *circularLogBuffer
-	mcpCloseOnce    sync.Once
-	mcpCloseFn      func()
+	mu           sync.Mutex
+	cmd          *exec.Cmd
+	cancel       context.CancelFunc
+	running      bool
+	outputLog    *circularLogBuffer
+	mcpCloseOnce sync.Once
+	mcpCloseFn   func()
 }
 
 type editorOpener interface {
@@ -394,7 +393,7 @@ type startSessionResult struct {
 	startError     error
 }
 
-func (s *Server) startSession(workspacePath string, autoMode bool) startSessionResult {
+func (s *Server) startSession(workspacePath string) startSessionResult {
 	s.mu.Lock()
 	sess := s.sessions[workspacePath]
 	if sess != nil && sess.running {
@@ -402,7 +401,7 @@ func (s *Server) startSession(workspacePath string, autoMode bool) startSessionR
 		return startSessionResult{alreadyRunning: true, sess: sess}
 	}
 
-	sess = &session{running: true, interactiveAuto: autoMode, outputLog: newCircularLogBuffer()}
+	sess = &session{running: true, outputLog: newCircularLogBuffer()}
 	s.sessions[workspacePath] = sess
 	s.everStartedDirs[workspacePath] = true
 	s.mu.Unlock()

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -16,6 +16,14 @@ const (
 	StatusWaitingForHuman = "waiting-for-human"
 )
 
+// InteractionMode constants define the possible interaction modes of a sgai session.
+const (
+	ModeSelfDrive     = "self-drive"
+	ModeBrainstorming = "brainstorming"
+	ModeBuilding      = "building"
+	ModeRetrospective = "retrospective"
+)
+
 // IsHumanPending reports whether the given status indicates the workflow
 // is waiting for a human response.
 func IsHumanPending(status string) bool {
@@ -136,9 +144,7 @@ type Workflow struct {
 
 	Cost SessionCost `json:"cost"`
 
-	WorkGateApproved    bool `json:"workGateApproved,omitempty"`
-	InteractiveAutoLock bool `json:"interactiveAutoLock,omitempty"`
-	StartedInteractive  bool `json:"startedInteractive,omitempty"`
+	InteractionMode string `json:"interactionMode,omitempty"`
 
 	// ModelStatuses tracks per-model status in multi-model agents.
 	// Key is model ID (agent:modelSpec), value is "model-working", "model-done", or "model-error".
@@ -148,6 +154,18 @@ type Workflow struct {
 	// CurrentModel tracks the currently executing model in multi-model agents.
 	// Format is "agentName:modelSpec".
 	CurrentModel string `json:"currentModel,omitempty"`
+}
+
+// ToolsAllowed reports whether the current interaction mode permits
+// human-interaction tools (ask_user_question, ask_user_work_gate).
+func (w Workflow) ToolsAllowed() bool {
+	return w.InteractionMode == ModeBrainstorming || w.InteractionMode == ModeRetrospective
+}
+
+// IsAutoMode reports whether the current interaction mode runs without
+// human interaction (self-drive or building).
+func (w Workflow) IsAutoMode() bool {
+	return w.InteractionMode == ModeSelfDrive || w.InteractionMode == ModeBuilding
 }
 
 // Message represents an inter-agent message in the workflow system.


### PR DESCRIPTION
## Summary

- Replaces three boolean flags (`InteractiveAutoLock`, `StartedInteractive`, `WorkGateApproved`) with a single `InteractionMode` enum (`self-drive`, `brainstorming`, `building`, `retrospective`) in `pkg/state`
- Adds `ToolsAllowed()` and `IsAutoMode()` methods to `Workflow` for clean mode queries, eliminating scattered boolean logic across `cmd/sgai`
- Adds explicit self-drive instructions to flow messages so agents skip brainstorming and work-gate steps entirely when in self-drive mode
- Adds STPA hazard analysis section to brainstorming skill for state machine design safety