### PR TITLE
cmd/sgai/webapp: fix adhoc run tab state persistence, mobile layout, and prompt history

### DIFF
--- a/GOALS/2026_02_23_fix_adhoc_run.md
+++ b/GOALS/2026_02_23_fix_adhoc_run.md
@@ -1,0 +1,29 @@
+---
+flow: |
+  "backend-go-developer" -> "go-readability-reviewer"
+  "backend-go-developer" -> "stpa-analyst"
+  "go-readability-reviewer" -> "stpa-analyst"
+  "general-purpose" -> "stpa-analyst"
+  "react-developer" -> "react-reviewer"
+  "react-reviewer" -> "stpa-analyst"
+  "project-critic-council"
+  "stpa-analyst"
+  "skill-writer"
+models:
+  "coordinator": "anthropic/claude-opus-4-6 (max)"
+  "backend-go-developer": "anthropic/claude-opus-4-6"
+  "go-readability-reviewer": "anthropic/claude-opus-4-6"
+  "general-purpose": "anthropic/claude-opus-4-6"
+  "react-developer": "anthropic/claude-opus-4-6"
+  "react-reviewer": "anthropic/claude-opus-4-6"
+  "stpa-analyst": "anthropic/claude-opus-4-6"
+  "project-critic-council": ["anthropic/claude-opus-4-6"]
+  "skill-writer": "anthropic/claude-opus-4-6 (max)"
+completionGateScript: make test
+---
+
+I like AdRoc Run tabs, they are useful, however there are few problems we need to fix.
+
+- [x] When I browse away and then back, I lose the state; it must survive me browsing away
+- [x] In Mobile Phone, the Run Tab layout isn't great, it should be more vertical
+- [x] I want to be able to store the history of messages sent in the Run tabs, and then be able to list and replay one of them

--- a/cmd/sgai/webapp/src/components/PromptHistory.tsx
+++ b/cmd/sgai/webapp/src/components/PromptHistory.tsx
@@ -1,0 +1,94 @@
+import { useState } from "react";
+import { History, Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+  DialogClose,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+
+interface PromptHistoryProps {
+  history: string[];
+  onSelect: (entry: string) => void;
+  onClear: () => void;
+  disabled?: boolean;
+}
+
+export function PromptHistory({ history, onSelect, onClear, disabled }: PromptHistoryProps) {
+  const [open, setOpen] = useState(false);
+
+  if (history.length === 0) return null;
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <DialogTrigger asChild>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              disabled={disabled}
+              className="gap-1.5"
+            >
+              <History className="h-3.5 w-3.5" />
+              History ({history.length})
+            </Button>
+          </DialogTrigger>
+        </TooltipTrigger>
+        <TooltipContent>Browse prompt history</TooltipContent>
+      </Tooltip>
+
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Prompt History</DialogTitle>
+          <DialogDescription>
+            Select a previous prompt to re-fill the input field.
+          </DialogDescription>
+        </DialogHeader>
+
+        <ScrollArea className="max-h-[300px]">
+          <ul className="space-y-2">
+            {history.map((entry, idx) => (
+              <li key={`${idx}-${entry.slice(0, 20)}`}>
+                <DialogClose asChild>
+                  <button
+                    type="button"
+                    className="w-full text-left rounded-md border p-3 text-sm hover:bg-muted/50 transition-colors cursor-pointer"
+                    onClick={() => {
+                      onSelect(entry);
+                      setOpen(false);
+                    }}
+                  >
+                    <span className="line-clamp-2 break-words">{entry}</span>
+                  </button>
+                </DialogClose>
+              </li>
+            ))}
+          </ul>
+        </ScrollArea>
+
+        <div className="flex justify-end pt-2">
+          <Button
+            type="button"
+            variant="destructive"
+            size="sm"
+            onClick={() => {
+              onClear();
+              setOpen(false);
+            }}
+          >
+            <Trash2 className="mr-1.5 h-3.5 w-3.5" />
+            Clear History
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/cmd/sgai/webapp/src/hooks/useAdhocRun.test.ts
+++ b/cmd/sgai/webapp/src/hooks/useAdhocRun.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
+import { renderHook, act, cleanup } from "@testing-library/react";
+import { useAdhocRun } from "./useAdhocRun";
+import type { ApiModelsResponse } from "@/types";
+
+const mockFetch = mock(() => Promise.resolve(new Response("{}")));
+
+const modelsResponse: ApiModelsResponse = {
+  models: [
+    { id: "model-a", name: "Model A" },
+    { id: "model-b", name: "Model B" },
+  ],
+  defaultModel: "model-a",
+};
+
+beforeEach(() => {
+  mockFetch.mockReset();
+  globalThis.fetch = mockFetch as unknown as typeof fetch;
+  window.localStorage.clear();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+function defaultMock() {
+  mockFetch.mockImplementation((input: string | URL | Request) => {
+    const url = input.toString();
+    if (url.includes("/api/v1/models")) {
+      return Promise.resolve(new Response(JSON.stringify(modelsResponse)));
+    }
+    if (url.includes("/adhoc")) {
+      return Promise.resolve(new Response(JSON.stringify({ running: false, output: "", message: "" })));
+    }
+    return Promise.resolve(new Response("{}"));
+  });
+}
+
+describe("useAdhocRun", () => {
+  it("initializes with empty state", () => {
+    defaultMock();
+    const { result } = renderHook(() =>
+      useAdhocRun({ workspaceName: "ws1" }),
+    );
+    expect(result.current.prompt).toBe("");
+    expect(result.current.output).toBe("");
+    expect(result.current.isRunning).toBe(false);
+    expect(result.current.runError).toBeNull();
+    expect(result.current.promptHistory).toEqual([]);
+  });
+
+  it("restores prompt from localStorage", () => {
+    window.localStorage.setItem("adhoc-prompt-ws1", JSON.stringify("saved"));
+    defaultMock();
+    const { result } = renderHook(() =>
+      useAdhocRun({ workspaceName: "ws1" }),
+    );
+    expect(result.current.prompt).toBe("saved");
+  });
+
+  it("restores model from localStorage", () => {
+    window.localStorage.setItem("adhoc-model-ws1", JSON.stringify("model-b"));
+    defaultMock();
+    const { result } = renderHook(() =>
+      useAdhocRun({ workspaceName: "ws1" }),
+    );
+    expect(result.current.selectedModel).toBe("model-b");
+  });
+
+  it("restores history from localStorage", () => {
+    window.localStorage.setItem("adhoc-history-ws1", JSON.stringify(["a", "b"]));
+    defaultMock();
+    const { result } = renderHook(() =>
+      useAdhocRun({ workspaceName: "ws1" }),
+    );
+    expect(result.current.promptHistory).toEqual(["a", "b"]);
+  });
+
+  it("persists prompt to localStorage on setPrompt", () => {
+    defaultMock();
+    const { result } = renderHook(() =>
+      useAdhocRun({ workspaceName: "ws1" }),
+    );
+    act(() => {
+      result.current.setPrompt("new prompt");
+    });
+    expect(result.current.prompt).toBe("new prompt");
+    expect(JSON.parse(window.localStorage.getItem("adhoc-prompt-ws1")!)).toBe("new prompt");
+  });
+
+  it("persists model to localStorage on setSelectedModel", () => {
+    defaultMock();
+    const { result } = renderHook(() =>
+      useAdhocRun({ workspaceName: "ws1" }),
+    );
+    act(() => {
+      result.current.setSelectedModel("model-b");
+    });
+    expect(result.current.selectedModel).toBe("model-b");
+    expect(JSON.parse(window.localStorage.getItem("adhoc-model-ws1")!)).toBe("model-b");
+  });
+
+  it("selectFromHistory updates prompt", () => {
+    window.localStorage.setItem("adhoc-history-ws1", JSON.stringify(["old prompt"]));
+    defaultMock();
+    const { result } = renderHook(() =>
+      useAdhocRun({ workspaceName: "ws1" }),
+    );
+    act(() => {
+      result.current.selectFromHistory("old prompt");
+    });
+    expect(result.current.prompt).toBe("old prompt");
+  });
+
+  it("clearHistory empties the history", () => {
+    window.localStorage.setItem("adhoc-history-ws1", JSON.stringify(["a", "b"]));
+    defaultMock();
+    const { result } = renderHook(() =>
+      useAdhocRun({ workspaceName: "ws1" }),
+    );
+    expect(result.current.promptHistory).toEqual(["a", "b"]);
+    act(() => {
+      result.current.clearHistory();
+    });
+    expect(result.current.promptHistory).toEqual([]);
+    expect(JSON.parse(window.localStorage.getItem("adhoc-history-ws1")!)).toEqual([]);
+  });
+
+  it("skips model fetch when skipModelsFetch is true", async () => {
+    defaultMock();
+    renderHook(() =>
+      useAdhocRun({ workspaceName: "ws1", skipModelsFetch: true }),
+    );
+    await act(async () => { await new Promise((r) => setTimeout(r, 50)); });
+
+    const modelCalls = mockFetch.mock.calls.filter((call) =>
+      (call[0] as string).includes("/api/v1/models"),
+    );
+    expect(modelCalls.length).toBe(0);
+  });
+});

--- a/cmd/sgai/webapp/src/hooks/useAdhocRun.ts
+++ b/cmd/sgai/webapp/src/hooks/useAdhocRun.ts
@@ -1,0 +1,340 @@
+import { useState, useEffect, useCallback, useRef } from "react";
+import { api, ApiError } from "@/lib/api";
+import type { ApiModelsResponse } from "@/types";
+
+const MAX_HISTORY_ENTRIES = 20;
+const POLL_INTERVAL_MS = 2000;
+
+function storageKey(workspaceName: string, suffix: string): string {
+  return `adhoc-${suffix}-${workspaceName}`;
+}
+
+function readLocalStorage<T>(key: string, fallback: T): T {
+  try {
+    const raw = window.localStorage.getItem(key);
+    if (raw === null) return fallback;
+    return JSON.parse(raw) as T;
+  } catch {
+    return fallback;
+  }
+}
+
+function writeLocalStorage<T>(key: string, value: T): void {
+  try {
+    window.localStorage.setItem(key, JSON.stringify(value));
+  } catch {
+    // quota exceeded or unavailable — silently ignore
+  }
+}
+
+export interface UseAdhocRunOptions {
+  workspaceName: string;
+  currentModel?: string;
+  /** When true, skip fetching model list (AdhocOutput uses a text input) */
+  skipModelsFetch?: boolean;
+}
+
+export interface UseAdhocRunResult {
+  models: ApiModelsResponse | null;
+  modelsLoading: boolean;
+  modelsError: Error | null;
+  selectedModel: string;
+  setSelectedModel: (model: string) => void;
+  prompt: string;
+  setPrompt: (prompt: string) => void;
+  output: string;
+  isRunning: boolean;
+  runError: string | null;
+  startRun: (promptOverride?: string, modelOverride?: string) => void;
+  stopRun: () => void;
+  handleSubmit: (event: React.FormEvent) => void;
+  handleKeyDown: (event: React.KeyboardEvent) => void;
+  outputRef: React.RefObject<HTMLPreElement | null>;
+  promptHistory: string[];
+  selectFromHistory: (entry: string) => void;
+  clearHistory: () => void;
+}
+
+export function useAdhocRun({
+  workspaceName,
+  currentModel,
+  skipModelsFetch = false,
+}: UseAdhocRunOptions): UseAdhocRunResult {
+  const [models, setModels] = useState<ApiModelsResponse | null>(null);
+  const [modelsLoading, setModelsLoading] = useState(!skipModelsFetch);
+  const [modelsError, setModelsError] = useState<Error | null>(null);
+
+  const [selectedModel, setSelectedModelState] = useState(() =>
+    readLocalStorage(storageKey(workspaceName, "model"), ""),
+  );
+  const [prompt, setPromptState] = useState(() =>
+    readLocalStorage(storageKey(workspaceName, "prompt"), ""),
+  );
+  const [output, setOutput] = useState("");
+  const [isRunning, setIsRunning] = useState(false);
+  const [runError, setRunError] = useState<string | null>(null);
+  const [promptHistory, setPromptHistory] = useState<string[]>(() =>
+    readLocalStorage<string[]>(storageKey(workspaceName, "history"), []),
+  );
+
+  const outputRef = useRef<HTMLPreElement | null>(null);
+  const pollTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const mountedRef = useRef(true);
+
+  // -- persist helpers --
+
+  const setSelectedModel = useCallback(
+    (model: string) => {
+      setSelectedModelState(model);
+      writeLocalStorage(storageKey(workspaceName, "model"), model);
+    },
+    [workspaceName],
+  );
+
+  const setPrompt = useCallback(
+    (value: string) => {
+      setPromptState(value);
+      writeLocalStorage(storageKey(workspaceName, "prompt"), value);
+    },
+    [workspaceName],
+  );
+
+  const addToHistory = useCallback(
+    (entry: string) => {
+      setPromptHistory((prev) => {
+        const deduped = prev.filter((p) => p !== entry);
+        const next = [entry, ...deduped].slice(0, MAX_HISTORY_ENTRIES);
+        writeLocalStorage(storageKey(workspaceName, "history"), next);
+        return next;
+      });
+    },
+    [workspaceName],
+  );
+
+  const clearHistory = useCallback(() => {
+    setPromptHistory([]);
+    writeLocalStorage(storageKey(workspaceName, "history"), []);
+  }, [workspaceName]);
+
+  const selectFromHistory = useCallback(
+    (entry: string) => {
+      setPrompt(entry);
+    },
+    [setPrompt],
+  );
+
+  // -- polling --
+
+  const stopPolling = useCallback(() => {
+    if (pollTimerRef.current) {
+      clearInterval(pollTimerRef.current);
+      pollTimerRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      stopPolling();
+    };
+  }, [stopPolling]);
+
+  // auto-scroll output
+  useEffect(() => {
+    if (outputRef.current) {
+      outputRef.current.scrollTop = outputRef.current.scrollHeight;
+    }
+  }, [output]);
+
+  // -- fetch models --
+
+  useEffect(() => {
+    if (skipModelsFetch || !workspaceName) return;
+
+    let cancelled = false;
+    setModels(null);
+    setModelsLoading(true);
+    setModelsError(null);
+
+    api.models
+      .list(workspaceName)
+      .then((response) => {
+        if (!cancelled) {
+          setModels(response);
+          setModelsLoading(false);
+        }
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) {
+          setModelsError(err instanceof Error ? err : new Error(String(err)));
+          setModelsLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [workspaceName, skipModelsFetch]);
+
+  // -- auto-select default model --
+
+  useEffect(() => {
+    if (!models || selectedModel) return;
+    const fallbackModel = models.defaultModel ?? currentModel;
+    if (fallbackModel && models.models.some((m) => m.id === fallbackModel)) {
+      setSelectedModel(fallbackModel);
+    }
+  }, [models, selectedModel, currentModel, setSelectedModel]);
+
+  // -- restore running state on mount --
+
+  useEffect(() => {
+    if (!workspaceName) return;
+
+    let cancelled = false;
+
+    api.workspaces
+      .adhocStatus(workspaceName)
+      .then((status) => {
+        if (cancelled) return;
+        if (status.output) {
+          setOutput(status.output);
+        }
+        if (status.running) {
+          setIsRunning(true);
+          pollTimerRef.current = setInterval(async () => {
+            try {
+              const poll = await api.workspaces.adhocStatus(workspaceName);
+              if (!mountedRef.current) return;
+              if (poll.output) {
+                setOutput(poll.output);
+              }
+              if (!poll.running) {
+                stopPolling();
+                setIsRunning(false);
+              }
+            } catch {
+              stopPolling();
+              setIsRunning(false);
+            }
+          }, POLL_INTERVAL_MS);
+        }
+      })
+      .catch(() => {
+        // no active run — that's fine
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [workspaceName, stopPolling]);
+
+  // -- run adhoc --
+
+  const startRun = useCallback(
+    async (promptOverride?: string, modelOverride?: string) => {
+      const trimmedPrompt = (promptOverride ?? prompt).trim();
+      const trimmedModel = (modelOverride ?? selectedModel).trim();
+      if (!workspaceName || isRunning || !trimmedPrompt || !trimmedModel) return;
+
+      stopPolling();
+      setIsRunning(true);
+      setRunError(null);
+      setOutput("");
+      addToHistory(trimmedPrompt);
+
+      try {
+        const result = await api.workspaces.adhoc(workspaceName, trimmedPrompt, trimmedModel);
+        if (result.output) {
+          setOutput(result.output);
+        }
+        if (!result.running) {
+          setIsRunning(false);
+          return;
+        }
+
+        pollTimerRef.current = setInterval(async () => {
+          try {
+            const poll = await api.workspaces.adhocStatus(workspaceName);
+            if (!mountedRef.current) return;
+            if (poll.output) {
+              setOutput(poll.output);
+            }
+            if (!poll.running) {
+              stopPolling();
+              setIsRunning(false);
+            }
+          } catch {
+            stopPolling();
+            setIsRunning(false);
+          }
+        }, POLL_INTERVAL_MS);
+      } catch (err) {
+        if (err instanceof ApiError) {
+          setRunError(err.message);
+        } else {
+          setRunError("Failed to execute ad-hoc prompt");
+        }
+        setIsRunning(false);
+      }
+    },
+    [workspaceName, isRunning, prompt, selectedModel, stopPolling, addToHistory],
+  );
+
+  const stopRun = useCallback(async () => {
+    if (!workspaceName || !isRunning) return;
+
+    try {
+      await api.workspaces.adhocStop(workspaceName);
+      stopPolling();
+      setIsRunning(false);
+      setOutput((prev) => (prev ? prev + "\n\nStopped." : "Stopped."));
+    } catch (err) {
+      if (err instanceof ApiError) {
+        setRunError(err.message);
+      } else {
+        setRunError("Failed to stop ad-hoc prompt");
+      }
+    }
+  }, [workspaceName, isRunning, stopPolling]);
+
+  const handleSubmit = useCallback(
+    (event: React.FormEvent) => {
+      event.preventDefault();
+      startRun();
+    },
+    [startRun],
+  );
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent) => {
+      if (event.key === "Enter" && event.shiftKey) {
+        event.preventDefault();
+        startRun();
+      }
+    },
+    [startRun],
+  );
+
+  return {
+    models,
+    modelsLoading,
+    modelsError,
+    selectedModel,
+    setSelectedModel,
+    prompt,
+    setPrompt,
+    output,
+    isRunning,
+    runError,
+    startRun,
+    stopRun,
+    handleSubmit,
+    handleKeyDown,
+    outputRef,
+    promptHistory,
+    selectFromHistory,
+    clearHistory,
+  };
+}

--- a/cmd/sgai/webapp/src/pages/tabs/ForksTab.test.tsx
+++ b/cmd/sgai/webapp/src/pages/tabs/ForksTab.test.tsx
@@ -29,6 +29,7 @@ beforeEach(() => {
   globalThis.fetch = mockFetch as unknown as typeof fetch;
   (globalThis as unknown as Record<string, unknown>).EventSource = MockEventSource;
   resetDefaultSSEStore();
+  window.localStorage.clear();
 });
 
 afterEach(() => {
@@ -109,6 +110,9 @@ function mockForksAndWorkspaces() {
     }
     if (url.includes("/api/v1/models")) {
       return Promise.resolve(new Response(JSON.stringify(modelsResponse)));
+    }
+    if (url.includes("/adhoc")) {
+      return Promise.resolve(new Response(JSON.stringify({ running: false, output: "", message: "" })));
     }
     return Promise.resolve(new Response("{}"));
   });
@@ -191,6 +195,9 @@ describe("ForksTab", () => {
       if (url.includes("/api/v1/models")) {
         return Promise.resolve(new Response(JSON.stringify(modelsResponse)));
       }
+      if (url.includes("/adhoc")) {
+        return Promise.resolve(new Response(JSON.stringify({ running: false, output: "", message: "" })));
+      }
       return Promise.resolve(new Response("{}"));
     });
     renderForksTab();
@@ -214,13 +221,11 @@ describe("ForksTab", () => {
     renderForksTab();
 
     await waitFor(() => {
-      expect(mockFetch).toHaveBeenCalledTimes(3);
+      const calledUrls = mockFetch.mock.calls.map((call) => (call[0] as string));
+      expect(calledUrls.some((url) => url.includes("/api/v1/workspaces/test-project/forks"))).toBe(true);
+      expect(calledUrls.some((url) => url.endsWith("/api/v1/workspaces"))).toBe(true);
+      expect(calledUrls.some((url) => url.includes("/api/v1/models"))).toBe(true);
     });
-
-    const calledUrls = mockFetch.mock.calls.map((call) => (call[0] as string));
-    expect(calledUrls.some((url) => url.includes("/api/v1/workspaces/test-project/forks"))).toBe(true);
-    expect(calledUrls.some((url) => url.endsWith("/api/v1/workspaces"))).toBe(true);
-    expect(calledUrls.some((url) => url.includes("/api/v1/models"))).toBe(true);
   });
 
   it("renders run box with model selector after forks load", async () => {
@@ -255,6 +260,9 @@ describe("ForksTab", () => {
       }
       if (url.includes("/api/v1/models")) {
         return Promise.resolve(new Response(JSON.stringify(modelsResponse)));
+      }
+      if (url.includes("/adhoc")) {
+        return Promise.resolve(new Response(JSON.stringify({ running: false, output: "", message: "" })));
       }
       return Promise.resolve(new Response("{}"));
     });


### PR DESCRIPTION
## Summary

- Fix adhoc run tab state loss when navigating away and back by extracting state management into a dedicated `useAdhocRun` hook with persistence
- Improve mobile layout for the Run Tab with a more vertical arrangement
- Add prompt history feature allowing users to store, list, and replay previously sent messages in Run tabs
- Add GOALS spec file `2026_02_23_fix_adhoc_run.md`