### PR TITLE
cmd/sgai: add action buttons bar to internals tab

### DIFF
--- a/GOALS/2026_02_23_action_buttons_bar.md
+++ b/GOALS/2026_02_23_action_buttons_bar.md
@@ -1,0 +1,55 @@
+---
+flow: |
+  "backend-go-developer" -> "go-readability-reviewer"
+  "backend-go-developer" -> "stpa-analyst"
+  "go-readability-reviewer" -> "stpa-analyst"
+  "general-purpose" -> "stpa-analyst"
+  "react-developer" -> "react-reviewer"
+  "react-reviewer" -> "stpa-analyst"
+  "project-critic-council"
+  "stpa-analyst"
+  "skill-writer"
+models:
+  "coordinator": "anthropic/claude-opus-4-6 (max)"
+  "backend-go-developer": "anthropic/claude-opus-4-6"
+  "go-readability-reviewer": "anthropic/claude-opus-4-6"
+  "general-purpose": "anthropic/claude-opus-4-6"
+  "react-developer": "anthropic/claude-opus-4-6"
+  "react-reviewer": "anthropic/claude-opus-4-6"
+  "stpa-analyst": "anthropic/claude-opus-4-6"
+  "project-critic-council": ["anthropic/claude-opus-4-6"]
+  "skill-writer": "anthropic/claude-opus-4-6 (max)"
+completionGateScript: make test
+---
+
+I need an action bar inside Internals tab.
+
+What's an action bar?
+
+An action bar is a set of prompts+model+variant+name buttons that when I click, they are executed for me.
+
+This should be part of the configuration that would go into sgai.json
+
+Basically:
+```
+{
+...
+"actions": [
+    {
+        "name": "Create PR",
+        "model": "anthropic/claude-opus-4-6 (max)",
+        "prompt": "using GH make a prompt"
+    }
+]
+...
+}
+```
+(note how it uses the same variant parsing logic of the attribute `models` in the frontmatter)
+
+- [x] Server side: Add the support for the Action Bar mechanic based on Run tab (adhoc runs)
+- [x] Add the button bar in the UI: Action Bar, inside Internal Tab, on the very top of the tab.
+- [x] The buttons can live freely on top, no need to encapsulate them in a box.
+- [x] variant handling, for example `"model": "anthropic/claude-opus-4-6 (max)",` becomes model claude-opus-4-6, variant max (the same logic that models attribute use to parse model names)
+- [x] print the CLI command you're going to run in the sgai stdout/stderr
+- [x] it must survive me to browse away and back, like Run tab does (maybe it's already done)
+- [x] I wonder if there is some kind of global lock blocking the whole clockwork? sometimes I browse and the browser doesn't load the page.

--- a/README.md
+++ b/README.md
@@ -170,6 +170,45 @@ not implementation. Focus on outcomes.
 | `completionGateScript`   | Shell command that determines workflow completion        |
 | `interactive` | `yes` (respond via web UI), `no` (exit when agent asks a question), `auto` (self-driving) |
 
+### Action Bar
+
+The Internals tab includes an **action bar** — a row of buttons that execute prompts with specified models. Each button triggers an ad-hoc agent run.
+
+**Default actions:** Three built-in actions are available out of the box:
+
+| Action          | Description                                          |
+|-----------------|------------------------------------------------------|
+| Create PR       | Archives GOAL.md, creates a draft PR via `gh`        |
+| Upstream Sync   | Fetches all remotes, rebases against `main@origin`   |
+
+**Custom actions via `sgai.json`:** Define an `actions` array to configure your own buttons:
+
+```json
+{
+  "actions": [
+    {
+      "name": "My Action",
+      "model": "anthropic/claude-opus-4-6 (max)",
+      "prompt": "do something useful"
+    }
+  ]
+}
+```
+
+Each action has three fields:
+
+| Field    | Description                                                     |
+|----------|-----------------------------------------------------------------|
+| `name`   | Button label shown in the action bar                            |
+| `model`  | Model to use (supports variant syntax, see below)               |
+| `prompt` | The prompt sent to the model when the button is clicked         |
+
+**Override behavior:** If you define **any** actions in `sgai.json`, **all** defaults are replaced. To keep the defaults alongside your own, re-define them in `sgai.json`.
+
+**Model variant syntax:** The `model` field supports the same variant syntax as the `models` frontmatter attribute. For example, `"anthropic/claude-opus-4-6 (max)"` resolves to model `claude-opus-4-6` with variant `max`.
+
+See [`sgai.example.json`](sgai.example.json) for a complete example.
+
 ## Usage
 
 ```sh

--- a/cmd/sgai/config.go
+++ b/cmd/sgai/config.go
@@ -10,12 +10,34 @@ import (
 
 const configFileName = "sgai.json"
 
+func defaultActionConfigs() []actionConfig {
+	return []actionConfig{
+		{
+			Name:   "Create PR",
+			Model:  "anthropic/claude-opus-4-6 (max)",
+			Prompt: "copy GOAL.md into GOALS/ following the instructions from README.md; store the git path (by querying jj) into GIT_DIR, and using GH, make a draft PR for the commit at @ (jj); CRITICAL: commit message, the PR title and body, must adhere to the standard of previous commits - update all of these if necessary; once you are done, using bash(`open`), open the PR for me.",
+		},
+		{
+			Name:   "Upstream Sync",
+			Model:  "anthropic/claude-opus-4-6 (max)",
+			Prompt: "`jj git fetch --all-remotes`; rebase against main@origin (`jj rebase -d main@origin`), fix merge conflicts, and push",
+		},
+	}
+}
+
+type actionConfig struct {
+	Name   string `json:"name"`
+	Model  string `json:"model"`
+	Prompt string `json:"prompt"`
+}
+
 // projectConfig represents the sgai.json configuration file.
 // The configuration file must be located at the project root, as a sibling to the .sgai directory.
 type projectConfig struct {
 	DefaultModel string                     `json:"defaultModel,omitempty"`
 	MCP          map[string]json.RawMessage `json:"mcp,omitempty"`
 	Editor       string                     `json:"editor,omitempty"`
+	Actions      []actionConfig             `json:"actions,omitempty"`
 }
 
 func loadProjectConfig(dir string) (*projectConfig, error) {

--- a/cmd/sgai/serve.go
+++ b/cmd/sgai/serve.go
@@ -236,6 +236,8 @@ type Server struct {
 	composerSessions   map[string]*composerSession
 
 	summaryGen *summaryGenerator
+
+	workspaceScanFlight singleflight[string, []workspaceGroup]
 }
 
 // NewServer creates a new Server instance with the given root directory.
@@ -1268,6 +1270,10 @@ func (s *Server) togglePin(dir string) error {
 }
 
 func (s *Server) scanWorkspaceGroups() ([]workspaceGroup, error) {
+	return s.workspaceScanFlight.do("scan", s.doScanWorkspaceGroups)
+}
+
+func (s *Server) doScanWorkspaceGroups() ([]workspaceGroup, error) {
 	projects, err := scanForProjects(s.rootDir)
 	if err != nil {
 		return nil, err

--- a/cmd/sgai/singleflight.go
+++ b/cmd/sgai/singleflight.go
@@ -1,0 +1,39 @@
+package main
+
+import "sync"
+
+type singleflightCall[V any] struct {
+	wg  sync.WaitGroup
+	val V
+	err error
+}
+
+type singleflight[K ~string, V any] struct {
+	mu    sync.Mutex
+	calls map[K]*singleflightCall[V]
+}
+
+func (s *singleflight[K, V]) do(key K, fn func() (V, error)) (V, error) {
+	s.mu.Lock()
+	if s.calls == nil {
+		s.calls = make(map[K]*singleflightCall[V])
+	}
+	if c, ok := s.calls[key]; ok {
+		s.mu.Unlock()
+		c.wg.Wait()
+		return c.val, c.err
+	}
+	c := &singleflightCall[V]{}
+	c.wg.Add(1)
+	s.calls[key] = c
+	s.mu.Unlock()
+
+	c.val, c.err = fn()
+	c.wg.Done()
+
+	s.mu.Lock()
+	delete(s.calls, key)
+	s.mu.Unlock()
+
+	return c.val, c.err
+}

--- a/cmd/sgai/singleflight_test.go
+++ b/cmd/sgai/singleflight_test.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestSingleflightBasicDedup(t *testing.T) {
+	var sf singleflight[string, int]
+	var callCount atomic.Int32
+
+	const goroutines = 10
+	var wg sync.WaitGroup
+
+	gate := make(chan struct{})
+	results := make([]int, goroutines)
+	errs := make([]error, goroutines)
+
+	for i := range goroutines {
+		wg.Go(func() {
+			<-gate
+			results[i], errs[i] = sf.do("key", func() (int, error) {
+				callCount.Add(1)
+				time.Sleep(50 * time.Millisecond)
+				return 42, nil
+			})
+		})
+	}
+
+	close(gate)
+	wg.Wait()
+
+	if got := callCount.Load(); got != 1 {
+		t.Errorf("expected fn called once, got %d", got)
+	}
+	for i := range goroutines {
+		if errs[i] != nil {
+			t.Errorf("goroutine %d: unexpected error: %v", i, errs[i])
+		}
+		if results[i] != 42 {
+			t.Errorf("goroutine %d: got %d, want 42", i, results[i])
+		}
+	}
+}
+
+func TestSingleflightErrorShared(t *testing.T) {
+	var sf singleflight[string, string]
+	errExpected := errors.New("test error")
+	var callCount atomic.Int32
+
+	const goroutines = 5
+	var wg sync.WaitGroup
+
+	gate := make(chan struct{})
+	errs := make([]error, goroutines)
+
+	for i := range goroutines {
+		wg.Go(func() {
+			<-gate
+			_, errs[i] = sf.do("key", func() (string, error) {
+				callCount.Add(1)
+				time.Sleep(50 * time.Millisecond)
+				return "", errExpected
+			})
+		})
+	}
+
+	close(gate)
+	wg.Wait()
+
+	if got := callCount.Load(); got != 1 {
+		t.Errorf("expected fn called once, got %d", got)
+	}
+	for i := range goroutines {
+		if !errors.Is(errs[i], errExpected) {
+			t.Errorf("goroutine %d: got error %v, want %v", i, errs[i], errExpected)
+		}
+	}
+}
+
+func TestSingleflightDifferentKeys(t *testing.T) {
+	var sf singleflight[string, string]
+	var callCount atomic.Int32
+
+	var wg sync.WaitGroup
+
+	gate := make(chan struct{})
+
+	wg.Go(func() {
+		<-gate
+		_, _ = sf.do("key1", func() (string, error) {
+			callCount.Add(1)
+			time.Sleep(50 * time.Millisecond)
+			return "a", nil
+		})
+	})
+
+	wg.Go(func() {
+		<-gate
+		_, _ = sf.do("key2", func() (string, error) {
+			callCount.Add(1)
+			time.Sleep(50 * time.Millisecond)
+			return "b", nil
+		})
+	})
+
+	close(gate)
+	wg.Wait()
+
+	if got := callCount.Load(); got != 2 {
+		t.Errorf("expected fn called twice (different keys), got %d", got)
+	}
+}
+
+func TestSingleflightSequentialCallsNotCached(t *testing.T) {
+	var sf singleflight[string, int]
+	var callCount atomic.Int32
+
+	for range 3 {
+		val, err := sf.do("key", func() (int, error) {
+			callCount.Add(1)
+			return 99, nil
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if val != 99 {
+			t.Fatalf("got %d, want 99", val)
+		}
+	}
+
+	if got := callCount.Load(); got != 3 {
+		t.Errorf("sequential calls should each execute fn, got %d calls", got)
+	}
+}
+
+func TestSingleflightZeroValue(t *testing.T) {
+	var sf singleflight[string, int]
+	val, err := sf.do("key", func() (int, error) {
+		return 0, nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if val != 0 {
+		t.Errorf("got %d, want 0", val)
+	}
+}

--- a/cmd/sgai/skel/.sgai/skills/coding-practices/go-code-review/SKILL.md
+++ b/cmd/sgai/skel/.sgai/skills/coding-practices/go-code-review/SKILL.md
@@ -344,12 +344,33 @@ func (s *Service) IsExpired() bool {
 - [ ] Range over functions for custom iteration patterns
 - [ ] Iterators return early when yield returns false
 
-**References:**
-- https://pkg.go.dev/slices
-- https://pkg.go.dev/maps
-- https://pkg.go.dev/iter
-- https://go.dev/doc/tutorial/generics
-- https://go.dev/blog/testing-time
+### WaitGroup.Go (Go 1.24+)
+
+- [ ] Uses `sync.WaitGroup.Go` for fire-and-forget goroutines
+- [ ] `wg.Go(fn)` is equivalent to `go func() { wg.Wait(); fn() }()` but simpler
+- [ ] Preferred over `go func() { defer wg.Done(); fn() }()` for simpler error handling
+
+```go
+// GOOD - Go 1.24+ WaitGroup.Go pattern
+var wg sync.WaitGroup
+for _, task := range tasks {
+    wg.Go(func() {
+        process(task)  // err handled inside
+    })
+}
+wg.Wait()
+
+// ACCEPTABLE - traditional pattern still works
+var wg sync.WaitGroup
+for _, task := range tasks {
+    wg.Add(1)
+    go func(t Task) {
+        defer wg.Done()
+        process(t)
+    }(task)
+}
+wg.Wait()
+```
 
 ## Quick Checklist
 
@@ -384,3 +405,12 @@ For fast reviews, check these critical items:
 
 ### Verdict: [PASS/NEEDS WORK]
 ```
+
+## Go References for Idomatic Code
+
+- https://pkg.go.dev/sync#WaitGroup.Go
+- https://pkg.go.dev/slices
+- https://pkg.go.dev/maps
+- https://pkg.go.dev/iter
+- https://go.dev/doc/tutorial/generics
+- https://go.dev/blog/testing-time

--- a/cmd/sgai/webapp/bun.lock
+++ b/cmd/sgai/webapp/bun.lock
@@ -1,13 +1,12 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "sgai-webapp",
       "dependencies": {
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
-        "lucide-react": "^0.564.0",
+        "lucide-react": "^0.575.0",
         "radix-ui": "^1.4.3",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -408,7 +407,7 @@
 
     "longest-streak": ["longest-streak@3.1.0", "", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
 
-    "lucide-react": ["lucide-react@0.564.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-JJ8GVTQqFwuliifD48U6+h7DXEHdkhJ/E87kksGByII3qHxtPciVb8T8woQONHBQgHVOl7rSMrrip3SeVNy7Fg=="],
+    "lucide-react": ["lucide-react@0.575.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-VuXgKZrk0uiDlWjGGXmKV6MSk9Yy4l10qgVvzGn2AWBx1Ylt0iBexKOAoA6I7JO3m+M9oeovJd3yYENfkUbOeg=="],
 
     "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
 

--- a/cmd/sgai/webapp/src/pages/WorkspaceDetail.tsx
+++ b/cmd/sgai/webapp/src/pages/WorkspaceDetail.tsx
@@ -9,7 +9,7 @@ import { Alert, AlertDescription } from "@/components/ui/alert";
 import { NotYetAvailable } from "@/components/NotYetAvailable";
 import { api } from "@/lib/api";
 import { useSSEEvent, useWorkspaceSSEEvent } from "@/hooks/useSSE";
-import type { ApiWorkspaceDetailResponse } from "@/types";
+import type { ApiWorkspaceDetailResponse, ApiActionEntry } from "@/types";
 import { cn } from "@/lib/utils";
 
 const SessionTab = lazy(() => import("./tabs/SessionTab").then((m) => ({ default: m.SessionTab })));
@@ -815,6 +815,7 @@ export function WorkspaceDetail(): JSX.Element | null {
               goalContent={detail.goalContent}
               pmContent={detail.pmContent}
               hasProjectMgmt={detail.hasProjectMgmt}
+              actions={detail.actions}
             />
           </Suspense>
         </div>
@@ -838,6 +839,7 @@ function TabContent({
   goalContent,
   pmContent,
   hasProjectMgmt,
+  actions,
 }: {
   activeTab: string;
   workspaceName: string;
@@ -845,6 +847,7 @@ function TabContent({
   goalContent?: string;
   pmContent?: string;
   hasProjectMgmt?: boolean;
+  actions?: ApiActionEntry[];
 }) {
   switch (activeTab) {
     case "progress":
@@ -858,7 +861,7 @@ function TabContent({
     case "messages":
       return <MessagesTab workspaceName={workspaceName} />;
     case "internals":
-      return <SessionTab workspaceName={workspaceName} pmContent={pmContent} hasProjectMgmt={hasProjectMgmt} />;
+      return <SessionTab workspaceName={workspaceName} pmContent={pmContent} hasProjectMgmt={hasProjectMgmt} actions={actions} />;
 
     case "run":
       return <RunTab workspaceName={workspaceName} currentModel={currentModel} />;

--- a/cmd/sgai/webapp/src/types/index.ts
+++ b/cmd/sgai/webapp/src/types/index.ts
@@ -74,6 +74,12 @@ export interface SessionCost {
   cacheReadInputTokens: number;
 }
 
+export interface ApiActionEntry {
+  name: string;
+  model: string;
+  prompt: string;
+}
+
 export interface ApiWorkspaceDetailResponse {
   name: string;
   dir: string;
@@ -105,6 +111,7 @@ export interface ApiWorkspaceDetailResponse {
   summary?: string;
   summaryManual?: boolean;
   forks?: ApiWorkspaceForkSummary[];
+  actions?: ApiActionEntry[];
 }
 
 export interface ApiCreateWorkspaceRequest {

--- a/sgai.json
+++ b/sgai.json
@@ -1,17 +1,4 @@
 {
-  "mcp": {
-    "memory": {
-      "type": "local",
-      "command": [
-        "npx",
-        "-y",
-        "@modelcontextprotocol/server-memory"
-      ],
-      "environment": {
-        "MEMORY_FILE_PATH": "{env:PWD}/.sgai/memory.jsonl"
-      }
-    }
-  },
   "actions": [
     {
       "name": "Create PR",


### PR DESCRIPTION
## Summary

- Add configurable action buttons bar to the Internals tab, driven by `sgai.json` actions config
- Implement server-side config parsing for action entries (name, model with variant, prompt)
- Add REST API endpoint to expose action bar configuration to the frontend
- Add React UI component rendering action buttons at the top of the Session/Internals tab
- Support model variant parsing for action entries (e.g. `anthropic/claude-opus-4-6 (max)`)
- Log CLI command and prompt text to adhoc run output for observability
- Add singleflight deduplication for workspace scanning to prevent browser loading stalls
- Add go-code-review skill and GOALS spec