### PR TITLE
cmd/sgai: reduce verbosity of project summarizer

### DIFF
--- a/GOALS/2026_02_23_reduce_verbosity_project_summarizer.md
+++ b/GOALS/2026_02_23_reduce_verbosity_project_summarizer.md
@@ -1,0 +1,24 @@
+---
+flow: |
+  "backend-go-developer" -> "go-readability-reviewer"
+  "backend-go-developer" -> "stpa-analyst"
+  "go-readability-reviewer" -> "stpa-analyst"
+  "general-purpose" -> "stpa-analyst"
+  "react-developer" -> "react-reviewer"
+  "react-reviewer" -> "stpa-analyst"
+  "project-critic-council"
+  "skill-writer"
+models:
+  "coordinator": "anthropic/claude-opus-4-6 (max)"
+  "backend-go-developer": "anthropic/claude-opus-4-6"
+  "go-readability-reviewer": "anthropic/claude-opus-4-6"
+  "general-purpose": "anthropic/claude-opus-4-6"
+  "react-developer": "anthropic/claude-opus-4-6"
+  "react-reviewer": "anthropic/claude-opus-4-6"
+  "stpa-analyst": "anthropic/claude-opus-4-6"
+  "project-critic-council": ["anthropic/claude-opus-4-6"]
+  "skill-writer": "anthropic/claude-opus-4-6 (max)"
+completionGateScript: make test
+---
+
+- [x] reduce verbosity of the project summarizer

--- a/cmd/sgai/summary_generator.go
+++ b/cmd/sgai/summary_generator.go
@@ -134,7 +134,7 @@ func generateSummaryViaOpenCode(ctx context.Context, workspacePath, goalBody str
 	}
 	args = append(args, "--agent", "build", "--title", "summary")
 
-	prompt := "Read this GOAL.md and produce a single English sentence summarizing the project goal. Output ONLY the summary sentence, nothing else.\n\n" + goalBody
+	prompt := "Read this GOAL.md and produce a single English sentence summarizing the project goal. Output ONLY the shortest summary sentence you can, nothing else.\n\n" + goalBody
 
 	cmd := exec.CommandContext(ctx, "opencode", args...)
 	cmd.Dir = workspacePath


### PR DESCRIPTION
## Summary

- Simplify the project summarizer prompt to produce only the shortest summary sentence, reducing verbosity in generated summaries
- Add goal spec `GOALS/2026_02_23_reduce_verbosity_project_summarizer.md`