### PR TITLE
cmd/sgai: fix stale CurrentAgent leak across continuous-mode cycles

### DIFF
--- a/GOALS/2026_02_24_fix_continuous_mode_agent_reset.md
+++ b/GOALS/2026_02_24_fix_continuous_mode_agent_reset.md
@@ -1,0 +1,30 @@
+---
+flow: |
+  "backend-go-developer" -> "go-readability-reviewer"
+  "backend-go-developer" -> "stpa-analyst"
+  "go-readability-reviewer" -> "stpa-analyst"
+  "general-purpose" -> "stpa-analyst"
+  "react-developer" -> "react-reviewer"
+  "react-reviewer" -> "stpa-analyst"
+  "project-critic-council"
+  "skill-writer"
+models:
+  "coordinator": "anthropic/claude-opus-4-6 (max)"
+  "backend-go-developer": "anthropic/claude-sonnet-4-6"
+  "go-readability-reviewer": "anthropic/claude-opus-4-6"
+  "general-purpose": "anthropic/claude-sonnet-4-6"
+  "react-developer": "anthropic/claude-sonnet-4-6"
+  "react-reviewer": "anthropic/claude-opus-4-6"
+  "stpa-analyst": "anthropic/claude-opus-4-6"
+  "project-critic-council": ["anthropic/claude-opus-4-6"]
+  "skill-writer": "anthropic/claude-opus-4-6 (max)"
+completionGateScript: make test
+---
+
+
+I see this error: ```
+[00:00:00.564][merge-dependabot-prs][continuous-mode        :0001] !  agent "continuous-mode" not found. Falling back to default agent
+```
+
+- [x] Is the current code broken?
+  - [x] if so, what the problem is? `resetWorkflowForNextCycle` in `cmd/sgai/continuous.go:282` resets `Status` and `InteractionMode` but does not reset `CurrentAgent`, so the stale value `"continuous-mode"` (set at line 99 as a progress-tracking label) leaks into the next workflow cycle at `main.go:270-272`, causing `opencode run --agent continuous-mode` to be invoked against a nonexistent agent definition.

--- a/cmd/sgai/continuous.go
+++ b/cmd/sgai/continuous.go
@@ -286,6 +286,7 @@ func resetWorkflowForNextCycle(stateJSONPath string) {
 	}
 	wfState.Status = state.StatusWorking
 	wfState.InteractionMode = state.ModeContinuous
+	wfState.CurrentAgent = "coordinator"
 	if errSave := state.Save(stateJSONPath, wfState); errSave != nil {
 		log.Println("failed to reset workflow for next cycle:", errSave)
 	}

--- a/cmd/sgai/continuous_test.go
+++ b/cmd/sgai/continuous_test.go
@@ -484,7 +484,8 @@ func TestResetWorkflowForNextCycle(t *testing.T) {
 
 	stateJSONPath := filepath.Join(sgaiDir, "state.json")
 	wfState := state.Workflow{
-		Status: state.StatusComplete,
+		Status:       state.StatusComplete,
+		CurrentAgent: "continuous-mode",
 	}
 	if err := state.Save(stateJSONPath, wfState); err != nil {
 		t.Fatal(err)
@@ -502,6 +503,9 @@ func TestResetWorkflowForNextCycle(t *testing.T) {
 	}
 	if loaded.InteractionMode != state.ModeContinuous {
 		t.Errorf("expected interactionMode %q, got %q", state.ModeContinuous, loaded.InteractionMode)
+	}
+	if loaded.CurrentAgent != "coordinator" {
+		t.Errorf("expected currentAgent to be reset to coordinator, got %q", loaded.CurrentAgent)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Fix `resetWorkflowForNextCycle` to reset `CurrentAgent` to `"coordinator"`, preventing the stale `"continuous-mode"` label from leaking into the next workflow cycle and triggering a nonexistent agent lookup.
- Add test coverage for the `CurrentAgent` reset behavior.
- Archive GOAL.md to `GOALS/2026_02_24_fix_continuous_mode_agent_reset.md`.