### PR TITLE
cmd/sgai: add external MCP server endpoint and sgai-skills documentation

### DIFF
--- a/GOALS/2026_02_27_add_external_mcp_server_and_skills.md
+++ b/GOALS/2026_02_27_add_external_mcp_server_and_skills.md
@@ -1,0 +1,43 @@
+---
+flow: |
+  "backend-go-developer" -> "go-readability-reviewer"
+  "react-developer" -> "react-reviewer"
+  "general-purpose"
+  "go-readability-reviewer"
+  "project-critic-council"
+  "skill-writer"
+  "stpa-analyst"
+models:
+  "coordinator": "anthropic/claude-opus-4-6 (max)"
+  "backend-go-developer": "anthropic/claude-sonnet-4-6"
+  "go-readability-reviewer": "anthropic/claude-opus-4-6"
+  "general-purpose": "anthropic/claude-sonnet-4-6"
+  "react-developer": "anthropic/claude-sonnet-4-6"
+  "react-reviewer": "anthropic/claude-opus-4-6"
+  "stpa-analyst": "anthropic/claude-opus-4-6"
+  "project-critic-council": ["anthropic/claude-opus-4-6"]
+  "skill-writer": "anthropic/claude-opus-4-6 (max)"
+completionGateScript: make test
+---
+
+- [x] I need a way to drive sgai from inside Claude Code, or Codex, or any other MCP / Skill powered harness
+  - [x] Create a MCP interface to sgai so that other harnesses can drive it
+    - [x] Add external MCP endpoint (`/mcp/external`) to `sgai serve` using streamable HTTP
+    - [x] 35 MCP tools with full parity to the web UI HTTP API (workspace lifecycle, session control, human interaction, monitoring, knowledge, compose, adhoc, list_models)
+    - [x] Service layer refactor: extract business logic from HTTP handlers into shared unexported functions in `cmd/sgai/`
+    - [x] MCP elicitation support: proactively push pending questions to harness via `elicitation/create` (form mode)
+    - [x] `make build` and `make lint` pass
+  - [x] And as alternative to MCP, create a set of skills for sgai so that other harnesses can drive it
+    - [x] `docs/sgai-skills/using-sgai.md` entrypoint with cyclical probing/polling loop instructions
+    - [x] Sub-skill docs: workspace-management, session-control, human-interaction, monitoring, knowledge, compose, adhoc
+    - [x] Each sub-skill has HTTP endpoint details, request/response examples, workflow instructions
+    - [x] README.md links to the entrypoint skill
+    - [x] the skills must conform to https://agentskills.io/specification
+- [x] syncing with upstream may have changed lot of assumptions, please, revalidate these changes, use https://github.com/steipete/mcporter to validate the MCP server
+
+- [x] based on sgai.json, follow "Create PR" to update  https://github.com/sandgardenhq/sgai/pull/299 correctly
+
+- [x] Update README.md with instructions on how to use the MCP and the new skills set
+  - [x] Add example configuration on how to configure the MCP in OpenCode https://opencode.ai/docs/mcp-servers/
+
+- [x] it seems that the MCP port number is not stable, and therefore it gets hard to configure it correctly.

--- a/cmd/sgai/mcp_external.go
+++ b/cmd/sgai/mcp_external.go
@@ -1,0 +1,901 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type externalMCPContext struct {
+	srv *Server
+}
+
+func buildExternalMCPHandler(srv *Server) http.Handler {
+	ctx := &externalMCPContext{srv: srv}
+	return mcp.NewStreamableHTTPHandler(func(_ *http.Request) *mcp.Server {
+		return buildExternalMCPServer(ctx)
+	}, nil)
+}
+
+func buildExternalMCPServer(ctx *externalMCPContext) *mcp.Server {
+	server := mcp.NewServer(&mcp.Implementation{Name: "sgai-external"}, nil)
+	registerExternalTools(server, ctx)
+	return server
+}
+
+func registerExternalTools(server *mcp.Server, ctx *externalMCPContext) {
+	registerStateTools(server, ctx)
+	registerWorkspaceTools(server, ctx)
+	registerSessionTools(server, ctx)
+	registerKnowledgeTools(server, ctx)
+	registerComposeTools(server, ctx)
+	registerAdhocTools(server, ctx)
+	registerEditorTools(server, ctx)
+	registerModelTools(server, ctx)
+	registerElicitationTool(server, ctx)
+}
+
+func textResult(text string) *mcp.CallToolResult {
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{&mcp.TextContent{Text: text}},
+	}
+}
+
+func jsonResult(v any) (*mcp.CallToolResult, error) {
+	data, errMarshal := json.Marshal(v)
+	if errMarshal != nil {
+		return nil, fmt.Errorf("failed to encode result: %w", errMarshal)
+	}
+	return textResult(string(data)), nil
+}
+
+type emptyExternalResult struct{}
+
+func (ctx *externalMCPContext) resolveWorkspacePath(name string) (string, error) {
+	if name == "" {
+		return "", fmt.Errorf("workspace name is required")
+	}
+	path := ctx.srv.resolveWorkspaceNameToPath(name)
+	if path == "" {
+		return "", fmt.Errorf("workspace not found: %s", name)
+	}
+	return path, nil
+}
+
+func (ctx *externalMCPContext) resolveAnyWorkspacePath(name string) (string, error) {
+	if name != "" {
+		path := ctx.srv.resolveWorkspaceNameToPath(name)
+		if path != "" {
+			return path, nil
+		}
+	}
+	groups, errScan := ctx.srv.scanWorkspaceGroups()
+	if errScan != nil || len(groups) == 0 {
+		return "", fmt.Errorf("no workspaces found")
+	}
+	return groups[0].Root.Directory, nil
+}
+
+func registerStateTools(server *mcp.Server, ctx *externalMCPContext) {
+	type listWorkspacesArgs struct{}
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "list_workspaces",
+		Description: "List all workspaces and their current status.",
+		InputSchema: mustSchema[listWorkspacesArgs](),
+	}, func(_ context.Context, _ *mcp.CallToolRequest, _ listWorkspacesArgs) (*mcp.CallToolResult, emptyExternalResult, error) {
+		state := ctx.srv.buildFullFactoryState()
+		result, err := jsonResult(state)
+		return result, emptyExternalResult{}, err
+	})
+
+	type getWorkspaceStateArgs struct {
+		Workspace string `json:"workspace" jsonschema:"The workspace name to get state for"`
+	}
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "get_workspace_state",
+		Description: "Get detailed state for a specific workspace.",
+		InputSchema: mustSchema[getWorkspaceStateArgs](),
+	}, func(_ context.Context, _ *mcp.CallToolRequest, args getWorkspaceStateArgs) (*mcp.CallToolResult, emptyExternalResult, error) {
+		stateResult, err := ctx.srv.getWorkspaceStateService(args.Workspace)
+		if err != nil {
+			return nil, emptyExternalResult{}, err
+		}
+		if !stateResult.Found {
+			return textResult(fmt.Sprintf("workspace not found: %s", args.Workspace)), emptyExternalResult{}, nil
+		}
+		result, err := jsonResult(stateResult.Workspace)
+		return result, emptyExternalResult{}, err
+	})
+
+	type getWorkflowSVGArgs struct {
+		Workspace string `json:"workspace" jsonschema:"The workspace name"`
+	}
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "get_workflow_svg",
+		Description: "Get the workflow diagram as SVG for a workspace.",
+		InputSchema: mustSchema[getWorkflowSVGArgs](),
+	}, func(_ context.Context, _ *mcp.CallToolRequest, args getWorkflowSVGArgs) (*mcp.CallToolResult, emptyExternalResult, error) {
+		workspacePath, err := ctx.resolveWorkspacePath(args.Workspace)
+		if err != nil {
+			return nil, emptyExternalResult{}, err
+		}
+		svg := ctx.srv.getWorkflowSVGService(workspacePath)
+		if svg == "" {
+			return textResult("workflow SVG not available"), emptyExternalResult{}, nil
+		}
+		return textResult(svg), emptyExternalResult{}, nil
+	})
+
+	type getWorkspaceDiffArgs struct {
+		Workspace string `json:"workspace" jsonschema:"The workspace name"`
+	}
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "get_workspace_diff",
+		Description: "Get the current git diff for a workspace.",
+		InputSchema: mustSchema[getWorkspaceDiffArgs](),
+	}, func(_ context.Context, _ *mcp.CallToolRequest, args getWorkspaceDiffArgs) (*mcp.CallToolResult, emptyExternalResult, error) {
+		workspacePath, err := ctx.resolveWorkspacePath(args.Workspace)
+		if err != nil {
+			return nil, emptyExternalResult{}, err
+		}
+		diffResult := ctx.srv.workspaceDiffService(workspacePath)
+		result, err := jsonResult(diffResult)
+		return result, emptyExternalResult{}, err
+	})
+}
+
+func registerWorkspaceTools(server *mcp.Server, ctx *externalMCPContext) {
+	type createWorkspaceArgs struct {
+		Name string `json:"name" jsonschema:"The workspace name (lowercase letters, numbers, dashes only)"`
+	}
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "create_workspace",
+		Description: "Create a new workspace with the given name.",
+		InputSchema: mustSchema[createWorkspaceArgs](),
+	}, func(_ context.Context, _ *mcp.CallToolRequest, args createWorkspaceArgs) (*mcp.CallToolResult, emptyExternalResult, error) {
+		createResult, err := ctx.srv.createWorkspaceService(args.Name)
+		if err != nil {
+			return textResult("error: " + err.Error()), emptyExternalResult{}, nil
+		}
+		result, err := jsonResult(createResult)
+		return result, emptyExternalResult{}, err
+	})
+
+	type forkWorkspaceArgs struct {
+		Workspace string `json:"workspace" jsonschema:"The parent workspace name to fork from"`
+		Name      string `json:"name" jsonschema:"The fork name"`
+	}
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "fork_workspace",
+		Description: "Create a fork of an existing workspace.",
+		InputSchema: mustSchema[forkWorkspaceArgs](),
+	}, func(_ context.Context, _ *mcp.CallToolRequest, args forkWorkspaceArgs) (*mcp.CallToolResult, emptyExternalResult, error) {
+		workspacePath, err := ctx.resolveWorkspacePath(args.Workspace)
+		if err != nil {
+			return nil, emptyExternalResult{}, err
+		}
+		forkResult, err := ctx.srv.forkWorkspaceService(workspacePath, args.Name)
+		if err != nil {
+			return textResult("error: " + err.Error()), emptyExternalResult{}, nil
+		}
+		result, err := jsonResult(forkResult)
+		return result, emptyExternalResult{}, err
+	})
+
+	type deleteForkArgs struct {
+		Workspace string `json:"workspace" jsonschema:"The root workspace name"`
+		ForkDir   string `json:"forkDir" jsonschema:"The full path of the fork directory to delete"`
+		Confirm   bool   `json:"confirm" jsonschema:"Must be true to confirm deletion"`
+	}
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "delete_fork",
+		Description: "Delete a fork workspace. Requires confirmation.",
+		InputSchema: mustSchema[deleteForkArgs](),
+	}, func(_ context.Context, _ *mcp.CallToolRequest, args deleteForkArgs) (*mcp.CallToolResult, emptyExternalResult, error) {
+		workspacePath, err := ctx.resolveWorkspacePath(args.Workspace)
+		if err != nil {
+			return nil, emptyExternalResult{}, err
+		}
+		deleteResult, err := ctx.srv.deleteForkService(workspacePath, args.ForkDir, args.Confirm)
+		if err != nil {
+			return textResult("error: " + err.Error()), emptyExternalResult{}, nil
+		}
+		result, err := jsonResult(deleteResult)
+		return result, emptyExternalResult{}, err
+	})
+
+	type renameWorkspaceArgs struct {
+		Workspace string `json:"workspace" jsonschema:"The workspace name to rename"`
+		Name      string `json:"name" jsonschema:"The new workspace name"`
+	}
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "rename_workspace",
+		Description: "Rename a fork workspace.",
+		InputSchema: mustSchema[renameWorkspaceArgs](),
+	}, func(_ context.Context, _ *mcp.CallToolRequest, args renameWorkspaceArgs) (*mcp.CallToolResult, emptyExternalResult, error) {
+		workspacePath, err := ctx.resolveWorkspacePath(args.Workspace)
+		if err != nil {
+			return nil, emptyExternalResult{}, err
+		}
+		renameResult, err := ctx.srv.renameWorkspaceService(workspacePath, args.Name)
+		if err != nil {
+			return textResult("error: " + err.Error()), emptyExternalResult{}, nil
+		}
+		result, err := jsonResult(renameResult)
+		return result, emptyExternalResult{}, err
+	})
+
+	type getGoalArgs struct {
+		Workspace string `json:"workspace" jsonschema:"The workspace name"`
+	}
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "get_goal",
+		Description: "Get the GOAL.md content for a workspace.",
+		InputSchema: mustSchema[getGoalArgs](),
+	}, func(_ context.Context, _ *mcp.CallToolRequest, args getGoalArgs) (*mcp.CallToolResult, emptyExternalResult, error) {
+		workspacePath, err := ctx.resolveWorkspacePath(args.Workspace)
+		if err != nil {
+			return nil, emptyExternalResult{}, err
+		}
+		goalResult, err := ctx.srv.getGoalService(workspacePath)
+		if err != nil {
+			return nil, emptyExternalResult{}, err
+		}
+		result, err := jsonResult(goalResult)
+		return result, emptyExternalResult{}, err
+	})
+
+	type updateGoalArgs struct {
+		Workspace string `json:"workspace" jsonschema:"The workspace name"`
+		Content   string `json:"content" jsonschema:"The new GOAL.md content"`
+	}
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "update_goal",
+		Description: "Update the GOAL.md content for a workspace.",
+		InputSchema: mustSchema[updateGoalArgs](),
+	}, func(_ context.Context, _ *mcp.CallToolRequest, args updateGoalArgs) (*mcp.CallToolResult, emptyExternalResult, error) {
+		workspacePath, err := ctx.resolveWorkspacePath(args.Workspace)
+		if err != nil {
+			return nil, emptyExternalResult{}, err
+		}
+		updateResult, err := ctx.srv.updateGoalService(workspacePath, args.Content)
+		if err != nil {
+			return textResult("error: " + err.Error()), emptyExternalResult{}, nil
+		}
+		result, err := jsonResult(updateResult)
+		return result, emptyExternalResult{}, err
+	})
+
+	type updateSummaryArgs struct {
+		Workspace string `json:"workspace" jsonschema:"The workspace name"`
+		Summary   string `json:"summary" jsonschema:"The summary text"`
+	}
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "update_summary",
+		Description: "Update the summary for a workspace.",
+		InputSchema: mustSchema[updateSummaryArgs](),
+	}, func(_ context.Context, _ *mcp.CallToolRequest, args updateSummaryArgs) (*mcp.CallToolResult, emptyExternalResult, error) {
+		workspacePath, err := ctx.resolveWorkspacePath(args.Workspace)
+		if err != nil {
+			return nil, emptyExternalResult{}, err
+		}
+		updateResult, err := ctx.srv.updateSummaryService(workspacePath, args.Summary)
+		if err != nil {
+			return nil, emptyExternalResult{}, err
+		}
+		result, err := jsonResult(updateResult)
+		return result, emptyExternalResult{}, err
+	})
+
+	type togglePinArgs struct {
+		Workspace string `json:"workspace" jsonschema:"The workspace name"`
+	}
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "toggle_pin",
+		Description: "Toggle the pinned state of a workspace.",
+		InputSchema: mustSchema[togglePinArgs](),
+	}, func(_ context.Context, _ *mcp.CallToolRequest, args togglePinArgs) (*mcp.CallToolResult, emptyExternalResult, error) {
+		workspacePath, err := ctx.resolveWorkspacePath(args.Workspace)
+		if err != nil {
+			return nil, emptyExternalResult{}, err
+		}
+		pinResult, err := ctx.srv.togglePinService(workspacePath)
+		if err != nil {
+			return nil, emptyExternalResult{}, err
+		}
+		result, err := jsonResult(pinResult)
+		return result, emptyExternalResult{}, err
+	})
+
+	type updateDescriptionArgs struct {
+		Workspace   string `json:"workspace" jsonschema:"The workspace name"`
+		Description string `json:"description" jsonschema:"The new commit description"`
+	}
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "update_description",
+		Description: "Update the jj commit description for a workspace.",
+		InputSchema: mustSchema[updateDescriptionArgs](),
+	}, func(_ context.Context, _ *mcp.CallToolRequest, args updateDescriptionArgs) (*mcp.CallToolResult, emptyExternalResult, error) {
+		workspacePath, err := ctx.resolveWorkspacePath(args.Workspace)
+		if err != nil {
+			return nil, emptyExternalResult{}, err
+		}
+		descResult, err := ctx.srv.updateDescriptionService(workspacePath, args.Description)
+		if err != nil {
+			return textResult("error: " + err.Error()), emptyExternalResult{}, nil
+		}
+		result, err := jsonResult(descResult)
+		return result, emptyExternalResult{}, err
+	})
+
+	type deleteMessageArgs struct {
+		Workspace string `json:"workspace" jsonschema:"The workspace name"`
+		ID        int    `json:"id" jsonschema:"The message ID to delete"`
+	}
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "delete_message",
+		Description: "Delete a message from a workspace.",
+		InputSchema: mustSchema[deleteMessageArgs](),
+	}, func(_ context.Context, _ *mcp.CallToolRequest, args deleteMessageArgs) (*mcp.CallToolResult, emptyExternalResult, error) {
+		workspacePath, err := ctx.resolveWorkspacePath(args.Workspace)
+		if err != nil {
+			return nil, emptyExternalResult{}, err
+		}
+		deleteResult, err := ctx.srv.deleteMessageService(workspacePath, args.ID)
+		if err != nil {
+			return textResult("error: " + err.Error()), emptyExternalResult{}, nil
+		}
+		result, err := jsonResult(deleteResult)
+		return result, emptyExternalResult{}, err
+	})
+}
+
+func registerSessionTools(server *mcp.Server, ctx *externalMCPContext) {
+	type startSessionArgs struct {
+		Workspace string `json:"workspace" jsonschema:"The workspace name"`
+		Auto      bool   `json:"auto,omitempty" jsonschema:"If true, start in self-drive mode (skip brainstorming)"`
+	}
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "start_session",
+		Description: "Start an agentic session for a workspace.",
+		InputSchema: mustSchema[startSessionArgs](),
+	}, func(_ context.Context, _ *mcp.CallToolRequest, args startSessionArgs) (*mcp.CallToolResult, emptyExternalResult, error) {
+		workspacePath, err := ctx.resolveWorkspacePath(args.Workspace)
+		if err != nil {
+			return nil, emptyExternalResult{}, err
+		}
+		sessionResult, err := ctx.srv.startSessionService(workspacePath, args.Auto)
+		if err != nil {
+			return textResult("error: " + err.Error()), emptyExternalResult{}, nil
+		}
+		result, err := jsonResult(sessionResult)
+		return result, emptyExternalResult{}, err
+	})
+
+	type stopSessionArgs struct {
+		Workspace string `json:"workspace" jsonschema:"The workspace name"`
+	}
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "stop_session",
+		Description: "Stop the running session for a workspace.",
+		InputSchema: mustSchema[stopSessionArgs](),
+	}, func(_ context.Context, _ *mcp.CallToolRequest, args stopSessionArgs) (*mcp.CallToolResult, emptyExternalResult, error) {
+		workspacePath, err := ctx.resolveWorkspacePath(args.Workspace)
+		if err != nil {
+			return nil, emptyExternalResult{}, err
+		}
+		stopResult := ctx.srv.stopSessionService(workspacePath)
+		result, err := jsonResult(stopResult)
+		return result, emptyExternalResult{}, err
+	})
+
+	type respondToQuestionArgs struct {
+		Workspace       string   `json:"workspace" jsonschema:"The workspace name"`
+		QuestionID      string   `json:"questionId" jsonschema:"The question ID from the pending question"`
+		Answer          string   `json:"answer,omitempty" jsonschema:"Free text answer"`
+		SelectedChoices []string `json:"selectedChoices,omitempty" jsonschema:"Selected choices for multi-choice questions"`
+	}
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "respond_to_question",
+		Description: "Respond to a pending question in a workspace session.",
+		InputSchema: mustSchema[respondToQuestionArgs](),
+	}, func(_ context.Context, _ *mcp.CallToolRequest, args respondToQuestionArgs) (*mcp.CallToolResult, emptyExternalResult, error) {
+		workspacePath, err := ctx.resolveWorkspacePath(args.Workspace)
+		if err != nil {
+			return nil, emptyExternalResult{}, err
+		}
+		respondResult, err := ctx.srv.respondService(workspacePath, args.QuestionID, args.Answer, args.SelectedChoices)
+		if err != nil {
+			return textResult("error: " + err.Error()), emptyExternalResult{}, nil
+		}
+		result, err := jsonResult(respondResult)
+		return result, emptyExternalResult{}, err
+	})
+
+	type steerAgentArgs struct {
+		Workspace string `json:"workspace" jsonschema:"The workspace name"`
+		Message   string `json:"message" jsonschema:"The steering instruction message"`
+	}
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "steer_agent",
+		Description: "Send a steering instruction to the running agent.",
+		InputSchema: mustSchema[steerAgentArgs](),
+	}, func(_ context.Context, _ *mcp.CallToolRequest, args steerAgentArgs) (*mcp.CallToolResult, emptyExternalResult, error) {
+		workspacePath, err := ctx.resolveWorkspacePath(args.Workspace)
+		if err != nil {
+			return nil, emptyExternalResult{}, err
+		}
+		steerRes, err := ctx.srv.steerService(workspacePath, args.Message)
+		if err != nil {
+			return textResult("error: " + err.Error()), emptyExternalResult{}, nil
+		}
+		result, err := jsonResult(steerRes)
+		return result, emptyExternalResult{}, err
+	})
+}
+
+func registerKnowledgeTools(server *mcp.Server, ctx *externalMCPContext) {
+	type listAgentsArgs struct {
+		Workspace string `json:"workspace,omitempty" jsonschema:"The workspace name (optional, uses first workspace if omitted)"`
+	}
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "list_agents",
+		Description: "List all agents available in a workspace.",
+		InputSchema: mustSchema[listAgentsArgs](),
+	}, func(_ context.Context, _ *mcp.CallToolRequest, args listAgentsArgs) (*mcp.CallToolResult, emptyExternalResult, error) {
+		workspacePath, err := ctx.resolveAnyWorkspacePath(args.Workspace)
+		if err != nil {
+			return nil, emptyExternalResult{}, err
+		}
+		agentsResult := ctx.srv.listAgentsService(workspacePath)
+		result, err := jsonResult(agentsResult)
+		return result, emptyExternalResult{}, err
+	})
+
+	type listSkillsArgs struct {
+		Workspace string `json:"workspace,omitempty" jsonschema:"The workspace name (optional)"`
+	}
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "list_skills",
+		Description: "List all skills available in a workspace.",
+		InputSchema: mustSchema[listSkillsArgs](),
+	}, func(_ context.Context, _ *mcp.CallToolRequest, args listSkillsArgs) (*mcp.CallToolResult, emptyExternalResult, error) {
+		workspacePath, err := ctx.resolveAnyWorkspacePath(args.Workspace)
+		if err != nil {
+			return nil, emptyExternalResult{}, err
+		}
+		skillsResult := ctx.srv.listSkillsService(workspacePath)
+		result, err := jsonResult(skillsResult)
+		return result, emptyExternalResult{}, err
+	})
+
+	type getSkillDetailArgs struct {
+		Workspace string `json:"workspace,omitempty" jsonschema:"The workspace name (optional)"`
+		Name      string `json:"name" jsonschema:"The skill path (e.g. 'coding-practices/go-code-review')"`
+	}
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "get_skill_detail",
+		Description: "Get detailed content for a specific skill.",
+		InputSchema: mustSchema[getSkillDetailArgs](),
+	}, func(_ context.Context, _ *mcp.CallToolRequest, args getSkillDetailArgs) (*mcp.CallToolResult, emptyExternalResult, error) {
+		workspacePath, err := ctx.resolveAnyWorkspacePath(args.Workspace)
+		if err != nil {
+			return nil, emptyExternalResult{}, err
+		}
+		skillResult := ctx.srv.skillDetailService(workspacePath, args.Name)
+		if !skillResult.Found {
+			return textResult("skill not found: " + args.Name), emptyExternalResult{}, nil
+		}
+		result, err := jsonResult(skillResult)
+		return result, emptyExternalResult{}, err
+	})
+
+	type listSnippetsArgs struct {
+		Workspace string `json:"workspace,omitempty" jsonschema:"The workspace name (optional)"`
+	}
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "list_snippets",
+		Description: "List all code snippets available in a workspace.",
+		InputSchema: mustSchema[listSnippetsArgs](),
+	}, func(_ context.Context, _ *mcp.CallToolRequest, args listSnippetsArgs) (*mcp.CallToolResult, emptyExternalResult, error) {
+		workspacePath, err := ctx.resolveAnyWorkspacePath(args.Workspace)
+		if err != nil {
+			return nil, emptyExternalResult{}, err
+		}
+		snippetsResult := ctx.srv.listSnippetsService(workspacePath)
+		result, err := jsonResult(snippetsResult)
+		return result, emptyExternalResult{}, err
+	})
+
+	type listSnippetsByLanguageArgs struct {
+		Workspace string `json:"workspace,omitempty" jsonschema:"The workspace name (optional)"`
+		Language  string `json:"language" jsonschema:"The programming language"`
+	}
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "list_snippets_by_language",
+		Description: "List code snippets for a specific programming language.",
+		InputSchema: mustSchema[listSnippetsByLanguageArgs](),
+	}, func(_ context.Context, _ *mcp.CallToolRequest, args listSnippetsByLanguageArgs) (*mcp.CallToolResult, emptyExternalResult, error) {
+		workspacePath, err := ctx.resolveAnyWorkspacePath(args.Workspace)
+		if err != nil {
+			return nil, emptyExternalResult{}, err
+		}
+		snippetsResult := ctx.srv.snippetsByLanguageService(workspacePath, args.Language)
+		if !snippetsResult.Found {
+			return textResult("language not found: " + args.Language), emptyExternalResult{}, nil
+		}
+		result, err := jsonResult(snippetsResult)
+		return result, emptyExternalResult{}, err
+	})
+
+	type getSnippetDetailArgs struct {
+		Workspace string `json:"workspace,omitempty" jsonschema:"The workspace name (optional)"`
+		Language  string `json:"language" jsonschema:"The programming language"`
+		FileName  string `json:"fileName" jsonschema:"The snippet file name (without extension)"`
+	}
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "get_snippet_detail",
+		Description: "Get detailed content for a specific code snippet.",
+		InputSchema: mustSchema[getSnippetDetailArgs](),
+	}, func(_ context.Context, _ *mcp.CallToolRequest, args getSnippetDetailArgs) (*mcp.CallToolResult, emptyExternalResult, error) {
+		workspacePath, err := ctx.resolveAnyWorkspacePath(args.Workspace)
+		if err != nil {
+			return nil, emptyExternalResult{}, err
+		}
+		snippetResult := ctx.srv.snippetDetailService(workspacePath, args.Language, args.FileName)
+		if !snippetResult.Found {
+			return textResult("snippet not found"), emptyExternalResult{}, nil
+		}
+		result, err := jsonResult(snippetResult)
+		return result, emptyExternalResult{}, err
+	})
+}
+
+func registerComposeTools(server *mcp.Server, ctx *externalMCPContext) {
+	type getComposeStateArgs struct {
+		Workspace string `json:"workspace,omitempty" jsonschema:"The workspace name (optional)"`
+	}
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "get_compose_state",
+		Description: "Get the compose wizard state for a workspace.",
+		InputSchema: mustSchema[getComposeStateArgs](),
+	}, func(_ context.Context, _ *mcp.CallToolRequest, args getComposeStateArgs) (*mcp.CallToolResult, emptyExternalResult, error) {
+		workspacePath, err := ctx.resolveAnyWorkspacePath(args.Workspace)
+		if err != nil {
+			return nil, emptyExternalResult{}, err
+		}
+		composeResult := ctx.srv.composeStateService(workspacePath)
+		result, err := jsonResult(composeResult)
+		return result, emptyExternalResult{}, err
+	})
+
+	type saveComposeArgs struct {
+		Workspace string `json:"workspace,omitempty" jsonschema:"The workspace name (optional)"`
+		IfMatch   string `json:"ifMatch,omitempty" jsonschema:"ETag for optimistic concurrency"`
+	}
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "save_compose",
+		Description: "Save the current compose state to GOAL.md.",
+		InputSchema: mustSchema[saveComposeArgs](),
+	}, func(_ context.Context, _ *mcp.CallToolRequest, args saveComposeArgs) (*mcp.CallToolResult, emptyExternalResult, error) {
+		workspacePath, err := ctx.resolveAnyWorkspacePath(args.Workspace)
+		if err != nil {
+			return nil, emptyExternalResult{}, err
+		}
+		saveResult, err := ctx.srv.composeSaveService(workspacePath, args.IfMatch)
+		if err != nil {
+			return textResult("error: " + err.Error()), emptyExternalResult{}, nil
+		}
+		result, err := jsonResult(saveResult)
+		return result, emptyExternalResult{}, err
+	})
+
+	type getComposeTemplatesArgs struct{}
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "get_compose_templates",
+		Description: "Get available workflow templates for the compose wizard.",
+		InputSchema: mustSchema[getComposeTemplatesArgs](),
+	}, func(_ context.Context, _ *mcp.CallToolRequest, _ getComposeTemplatesArgs) (*mcp.CallToolResult, emptyExternalResult, error) {
+		templatesResult := ctx.srv.composeTemplatesService()
+		result, err := jsonResult(templatesResult)
+		return result, emptyExternalResult{}, err
+	})
+
+	type getComposePreviewArgs struct {
+		Workspace string `json:"workspace,omitempty" jsonschema:"The workspace name (optional)"`
+	}
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "get_compose_preview",
+		Description: "Preview the GOAL.md that would be generated from the current compose state.",
+		InputSchema: mustSchema[getComposePreviewArgs](),
+	}, func(_ context.Context, _ *mcp.CallToolRequest, args getComposePreviewArgs) (*mcp.CallToolResult, emptyExternalResult, error) {
+		workspacePath, err := ctx.resolveAnyWorkspacePath(args.Workspace)
+		if err != nil {
+			return nil, emptyExternalResult{}, err
+		}
+		previewResult, err := ctx.srv.composePreviewService(workspacePath)
+		if err != nil {
+			return nil, emptyExternalResult{}, err
+		}
+		result, err := jsonResult(previewResult)
+		return result, emptyExternalResult{}, err
+	})
+
+	type saveComposeDraftArgs struct {
+		Workspace string         `json:"workspace,omitempty" jsonschema:"The workspace name (optional)"`
+		State     composerState  `json:"state" jsonschema:"The compose state to save as draft"`
+		Wizard    apiWizardState `json:"wizard" jsonschema:"The wizard state to save as draft"`
+	}
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "save_compose_draft",
+		Description: "Save the compose state as a draft without writing to GOAL.md.",
+		InputSchema: mustSchema[saveComposeDraftArgs](),
+	}, func(_ context.Context, _ *mcp.CallToolRequest, args saveComposeDraftArgs) (*mcp.CallToolResult, emptyExternalResult, error) {
+		workspacePath, err := ctx.resolveAnyWorkspacePath(args.Workspace)
+		if err != nil {
+			return nil, emptyExternalResult{}, err
+		}
+		draftResult := ctx.srv.composeDraftService(workspacePath, args.State, wizardState(args.Wizard))
+		result, err := jsonResult(draftResult)
+		return result, emptyExternalResult{}, err
+	})
+}
+
+func registerAdhocTools(server *mcp.Server, ctx *externalMCPContext) {
+	type getAdhocStatusArgs struct {
+		Workspace string `json:"workspace" jsonschema:"The workspace name"`
+	}
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "get_adhoc_status",
+		Description: "Get the status of the ad-hoc prompt for a workspace.",
+		InputSchema: mustSchema[getAdhocStatusArgs](),
+	}, func(_ context.Context, _ *mcp.CallToolRequest, args getAdhocStatusArgs) (*mcp.CallToolResult, emptyExternalResult, error) {
+		workspacePath, err := ctx.resolveWorkspacePath(args.Workspace)
+		if err != nil {
+			return nil, emptyExternalResult{}, err
+		}
+		statusResult := ctx.srv.adhocStatusService(workspacePath)
+		result, err := jsonResult(statusResult)
+		return result, emptyExternalResult{}, err
+	})
+
+	type startAdhocArgs struct {
+		Workspace string `json:"workspace" jsonschema:"The workspace name"`
+		Prompt    string `json:"prompt" jsonschema:"The prompt text to run"`
+		Model     string `json:"model" jsonschema:"The model to use (e.g. 'anthropic/claude-opus-4-6')"`
+	}
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "start_adhoc",
+		Description: "Start an ad-hoc prompt in a workspace.",
+		InputSchema: mustSchema[startAdhocArgs](),
+	}, func(_ context.Context, _ *mcp.CallToolRequest, args startAdhocArgs) (*mcp.CallToolResult, emptyExternalResult, error) {
+		workspacePath, err := ctx.resolveWorkspacePath(args.Workspace)
+		if err != nil {
+			return nil, emptyExternalResult{}, err
+		}
+		startResult := ctx.srv.adhocStartService(workspacePath, args.Prompt, args.Model)
+		if startResult.Error != nil {
+			return textResult("error: " + startResult.Error.Error()), emptyExternalResult{}, nil
+		}
+		result, err := jsonResult(startResult)
+		return result, emptyExternalResult{}, err
+	})
+
+	type stopAdhocArgs struct {
+		Workspace string `json:"workspace" jsonschema:"The workspace name"`
+	}
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "stop_adhoc",
+		Description: "Stop the running ad-hoc prompt in a workspace.",
+		InputSchema: mustSchema[stopAdhocArgs](),
+	}, func(_ context.Context, _ *mcp.CallToolRequest, args stopAdhocArgs) (*mcp.CallToolResult, emptyExternalResult, error) {
+		workspacePath, err := ctx.resolveWorkspacePath(args.Workspace)
+		if err != nil {
+			return nil, emptyExternalResult{}, err
+		}
+		stopResult := ctx.srv.adhocStopService(workspacePath)
+		result, err := jsonResult(stopResult)
+		return result, emptyExternalResult{}, err
+	})
+}
+
+func registerEditorTools(server *mcp.Server, ctx *externalMCPContext) {
+	type openEditorArgs struct {
+		Workspace string `json:"workspace" jsonschema:"The workspace name"`
+	}
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "open_editor",
+		Description: "Open the workspace in the configured editor.",
+		InputSchema: mustSchema[openEditorArgs](),
+	}, func(_ context.Context, _ *mcp.CallToolRequest, args openEditorArgs) (*mcp.CallToolResult, emptyExternalResult, error) {
+		workspacePath, err := ctx.resolveWorkspacePath(args.Workspace)
+		if err != nil {
+			return nil, emptyExternalResult{}, err
+		}
+		openResult, err := ctx.srv.openEditorService(workspacePath)
+		if err != nil {
+			return textResult("error: " + err.Error()), emptyExternalResult{}, nil
+		}
+		result, err := jsonResult(openResult)
+		return result, emptyExternalResult{}, err
+	})
+
+	type openEditorGoalArgs struct {
+		Workspace string `json:"workspace" jsonschema:"The workspace name"`
+	}
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "open_editor_goal",
+		Description: "Open the GOAL.md file in the configured editor.",
+		InputSchema: mustSchema[openEditorGoalArgs](),
+	}, func(_ context.Context, _ *mcp.CallToolRequest, args openEditorGoalArgs) (*mcp.CallToolResult, emptyExternalResult, error) {
+		workspacePath, err := ctx.resolveWorkspacePath(args.Workspace)
+		if err != nil {
+			return nil, emptyExternalResult{}, err
+		}
+		openResult, err := ctx.srv.openEditorGoalService(workspacePath)
+		if err != nil {
+			return textResult("error: " + err.Error()), emptyExternalResult{}, nil
+		}
+		result, err := jsonResult(openResult)
+		return result, emptyExternalResult{}, err
+	})
+
+	type openEditorPMArgs struct {
+		Workspace string `json:"workspace" jsonschema:"The workspace name"`
+	}
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "open_editor_pm",
+		Description: "Open the PROJECT_MANAGEMENT.md file in the configured editor.",
+		InputSchema: mustSchema[openEditorPMArgs](),
+	}, func(_ context.Context, _ *mcp.CallToolRequest, args openEditorPMArgs) (*mcp.CallToolResult, emptyExternalResult, error) {
+		workspacePath, err := ctx.resolveWorkspacePath(args.Workspace)
+		if err != nil {
+			return nil, emptyExternalResult{}, err
+		}
+		openResult, err := ctx.srv.openEditorProjectManagementService(workspacePath)
+		if err != nil {
+			return textResult("error: " + err.Error()), emptyExternalResult{}, nil
+		}
+		result, err := jsonResult(openResult)
+		return result, emptyExternalResult{}, err
+	})
+
+	type openOpencodeArgs struct {
+		Workspace string `json:"workspace" jsonschema:"The workspace name"`
+	}
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "open_opencode",
+		Description: "Open the workspace in OpenCode (terminal-based, localhost only).",
+		InputSchema: mustSchema[openOpencodeArgs](),
+	}, func(_ context.Context, _ *mcp.CallToolRequest, args openOpencodeArgs) (*mcp.CallToolResult, emptyExternalResult, error) {
+		workspacePath, err := ctx.resolveWorkspacePath(args.Workspace)
+		if err != nil {
+			return nil, emptyExternalResult{}, err
+		}
+		openResult, err := ctx.srv.openOpencodeService(workspacePath)
+		if err != nil {
+			return textResult("error: " + err.Error()), emptyExternalResult{}, nil
+		}
+		result, err := jsonResult(openResult)
+		return result, emptyExternalResult{}, err
+	})
+}
+
+func registerModelTools(server *mcp.Server, ctx *externalMCPContext) {
+	type listModelsArgs struct {
+		Workspace string `json:"workspace,omitempty" jsonschema:"The workspace name for default model lookup (optional)"`
+	}
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "list_models",
+		Description: "List all available AI models.",
+		InputSchema: mustSchema[listModelsArgs](),
+	}, func(_ context.Context, _ *mcp.CallToolRequest, args listModelsArgs) (*mcp.CallToolResult, emptyExternalResult, error) {
+		modelsResult := ctx.srv.listModelsService(args.Workspace)
+		result, err := jsonResult(modelsResult)
+		return result, emptyExternalResult{}, err
+	})
+}
+
+func registerElicitationTool(server *mcp.Server, ctx *externalMCPContext) {
+	type waitForQuestionArgs struct {
+		Workspace string `json:"workspace" jsonschema:"The workspace name to watch for pending questions"`
+	}
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "wait_for_question",
+		Description: "Wait for a pending question in a workspace and respond to it using MCP elicitation. Polls until a question is pending, then presents it to the harness for a response.",
+		InputSchema: mustSchema[waitForQuestionArgs](),
+	}, func(toolCtx context.Context, req *mcp.CallToolRequest, args waitForQuestionArgs) (*mcp.CallToolResult, emptyExternalResult, error) {
+		workspacePath, err := ctx.resolveWorkspacePath(args.Workspace)
+		if err != nil {
+			return nil, emptyExternalResult{}, err
+		}
+
+		questionID, answer, err := elicitPendingQuestion(toolCtx, req.Session, ctx.srv, workspacePath)
+		if err != nil {
+			return textResult("elicitation error: " + err.Error()), emptyExternalResult{}, nil
+		}
+		if answer == "" {
+			return textResult("no response provided"), emptyExternalResult{}, nil
+		}
+
+		respondResult, errRespond := ctx.srv.respondService(workspacePath, questionID, answer, nil)
+		if errRespond != nil {
+			return textResult("respond error: " + errRespond.Error()), emptyExternalResult{}, nil
+		}
+
+		result, err := jsonResult(respondResult)
+		return result, emptyExternalResult{}, err
+	})
+}
+
+func elicitPendingQuestion(ctx context.Context, session *mcp.ServerSession, srv *Server, workspacePath string) (questionID, answer string, err error) {
+	ticker := time.NewTicker(1 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return "", "", ctx.Err()
+		case <-ticker.C:
+			wfState := srv.workspaceCoordinator(workspacePath).State()
+			if !wfState.NeedsHumanInput() {
+				continue
+			}
+
+			qID := generateQuestionID(wfState)
+			message := wfState.HumanMessage
+			if message == "" {
+				message = "A workspace agent is waiting for your input."
+			}
+
+			schema := buildPendingQuestionSchema(wfState)
+
+			elicitResult, errElicit := session.Elicit(ctx, &mcp.ElicitParams{
+				Message:         message,
+				RequestedSchema: schema,
+			})
+			if errElicit != nil {
+				return "", "", fmt.Errorf("elicitation failed: %w", errElicit)
+			}
+
+			if elicitResult.Action != "accept" {
+				return qID, "", nil
+			}
+
+			ans := ""
+			if elicitResult.Content != nil {
+				if a, ok := elicitResult.Content["answer"].(string); ok {
+					ans = strings.TrimSpace(a)
+				}
+				if len(elicitResult.Content) > 0 && ans == "" {
+					var parts []string
+					for k, v := range elicitResult.Content {
+						parts = append(parts, fmt.Sprintf("%s=%v", k, v))
+					}
+					ans = strings.Join(parts, ", ")
+				}
+			}
+
+			return qID, ans, nil
+		}
+	}
+}
+
+func buildPendingQuestionSchema(_ interface{}) *jsonschema.Schema {
+	return &jsonschema.Schema{
+		Type: "object",
+		Properties: map[string]*jsonschema.Schema{
+			"answer": {
+				Type:        "string",
+				Description: "Your response to the agent's question",
+			},
+		},
+		Required: []string{"answer"},
+	}
+}

--- a/cmd/sgai/serve.go
+++ b/cmd/sgai/serve.go
@@ -597,6 +597,7 @@ func cmdServe(args []string) {
 
 	mux := http.NewServeMux()
 	srv.registerAPIRoutes(mux)
+	mux.Handle("/mcp/external", buildExternalMCPHandler(srv))
 	handler := srv.spaMiddleware(mux)
 
 	httpServer := &http.Server{Handler: handler}

--- a/cmd/sgai/serve_api.go
+++ b/cmd/sgai/serve_api.go
@@ -484,7 +484,7 @@ func (s *Server) spaMiddleware(mux *http.ServeMux) http.Handler {
 }
 
 func isAPIRoute(urlPath string) bool {
-	return strings.HasPrefix(urlPath, "/api/")
+	return strings.HasPrefix(urlPath, "/api/") || strings.HasPrefix(urlPath, "/mcp/")
 }
 
 func isStaticAsset(urlPath string) bool {

--- a/cmd/sgai/service_adhoc.go
+++ b/cmd/sgai/service_adhoc.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+)
+
+type adhocStatusResult struct {
+	Running bool
+	Output  string
+	Message string
+}
+
+func (s *Server) adhocStatusService(workspacePath string) adhocStatusResult {
+	st := s.getAdhocState(workspacePath)
+	st.mu.Lock()
+	running := st.running
+	output := st.output.String()
+	st.mu.Unlock()
+
+	return adhocStatusResult{Running: running, Output: output, Message: "adhoc status"}
+}
+
+type adhocStartResult struct {
+	Running bool
+	Output  string
+	Message string
+	Error   error
+}
+
+func (s *Server) adhocStartService(workspacePath, prompt, model string) adhocStartResult {
+	if strings.TrimSpace(prompt) == "" || strings.TrimSpace(model) == "" {
+		return adhocStartResult{Error: fmt.Errorf("prompt and model are required")}
+	}
+
+	st := s.getAdhocState(workspacePath)
+	st.mu.Lock()
+	if st.running {
+		output := st.output.String()
+		st.mu.Unlock()
+		return adhocStartResult{Running: true, Output: output, Message: "ad-hoc prompt already running"}
+	}
+
+	st.running = true
+	st.output.Reset()
+	st.selectedModel = strings.TrimSpace(model)
+	st.promptText = strings.TrimSpace(prompt)
+
+	args := buildAdhocArgs(st.selectedModel)
+	cmd := exec.Command("opencode", args...)
+	cmd.Dir = workspacePath
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Env = append(os.Environ(), "OPENCODE_CONFIG_DIR="+filepath.Join(workspacePath, ".sgai"))
+	cmd.Stdin = strings.NewReader(st.promptText)
+	writer := &lockedWriter{mu: &st.mu, buf: &st.output}
+	prefix := fmt.Sprintf("[%s][adhoc:0000]", filepath.Base(workspacePath))
+	stdoutPW := &prefixWriter{prefix: prefix + " ", w: os.Stdout, startTime: time.Now()}
+	stderrPW := &prefixWriter{prefix: prefix + " ", w: os.Stderr, startTime: time.Now()}
+	cmd.Stdout = io.MultiWriter(stdoutPW, writer)
+	cmd.Stderr = io.MultiWriter(stderrPW, writer)
+	commandLine := "$ opencode " + strings.Join(args, " ")
+	promptLine := "prompt: " + st.promptText
+	_, _ = fmt.Fprintln(stderrPW, commandLine)
+	_, _ = fmt.Fprintln(stderrPW, promptLine)
+	st.output.WriteString(commandLine + "\n")
+	st.output.WriteString(promptLine + "\n")
+
+	if errStart := cmd.Start(); errStart != nil {
+		st.running = false
+		st.mu.Unlock()
+		return adhocStartResult{Error: fmt.Errorf("failed to start command")}
+	}
+
+	st.cmd = cmd
+	st.mu.Unlock()
+
+	go func() {
+		errWait := cmd.Wait()
+		st.mu.Lock()
+		if errWait != nil {
+			st.output.WriteString("\n[command exited with error: " + errWait.Error() + "]\n")
+		}
+		st.running = false
+		st.cmd = nil
+		st.mu.Unlock()
+	}()
+
+	s.notifyStateChange()
+
+	return adhocStartResult{Running: true, Message: "ad-hoc prompt started"}
+}
+
+type adhocStopResult struct {
+	Running bool
+	Output  string
+	Message string
+}
+
+func (s *Server) adhocStopService(workspacePath string) adhocStopResult {
+	st := s.getAdhocState(workspacePath)
+	st.stop()
+	s.notifyStateChange()
+
+	st.mu.Lock()
+	output := st.output.String()
+	st.mu.Unlock()
+
+	return adhocStopResult{Running: false, Output: output, Message: "ad-hoc stopped"}
+}

--- a/cmd/sgai/service_compose.go
+++ b/cmd/sgai/service_compose.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+type composeStateResult struct {
+	Workspace      string
+	State          composerState
+	Wizard         apiWizardState
+	TechStackItems []apiTechStackItem
+	FlowError      string
+}
+
+func (s *Server) composeStateService(workspacePath string) composeStateResult {
+	cs := s.getComposerSession(workspacePath)
+	cs.mu.Lock()
+	currentState := cs.state
+	wizard := syncWizardState(cs.wizard, currentState)
+	cs.mu.Unlock()
+
+	var flowErr string
+	if currentState.Flow != "" {
+		if _, errParse := parseFlow(currentState.Flow, workspacePath); errParse != nil {
+			flowErr = errParse.Error()
+		}
+	}
+
+	return composeStateResult{
+		Workspace:      filepath.Base(workspacePath),
+		State:          currentState,
+		Wizard:         apiWizardState(wizard),
+		TechStackItems: buildAPITechStackItems(wizard.TechStack),
+		FlowError:      flowErr,
+	}
+}
+
+type composeSaveResult struct {
+	Saved     bool
+	Workspace string
+}
+
+func (s *Server) composeSaveService(workspacePath, ifMatch string) (composeSaveResult, error) {
+	goalPath := filepath.Join(workspacePath, "GOAL.md")
+
+	if ifMatch != "" {
+		currentContent, errRead := os.ReadFile(goalPath)
+		if errRead != nil && !os.IsNotExist(errRead) {
+			return composeSaveResult{}, fmt.Errorf("failed to read current GOAL.md")
+		}
+		currentEtag := computeEtag(currentContent)
+		if ifMatch != currentEtag {
+			return composeSaveResult{}, fmt.Errorf("GOAL.md has been modified by another session")
+		}
+	}
+
+	cs := s.getComposerSession(workspacePath)
+	cs.mu.Lock()
+	currentState := cs.state
+	cs.mu.Unlock()
+
+	goalContent := buildGOALContent(currentState)
+
+	if errWrite := os.WriteFile(goalPath, []byte(goalContent), 0644); errWrite != nil {
+		return composeSaveResult{}, fmt.Errorf("failed to save GOAL.md: %w", errWrite)
+	}
+
+	s.notifyStateChange()
+
+	return composeSaveResult{Saved: true, Workspace: filepath.Base(workspacePath)}, nil
+}
+
+type composeTemplatesResult struct {
+	Templates []apiComposeTemplateEntry
+}
+
+func (s *Server) composeTemplatesService() composeTemplatesResult {
+	entries := make([]apiComposeTemplateEntry, len(workflowTemplates))
+	for i, tmpl := range workflowTemplates {
+		entries[i] = apiComposeTemplateEntry(tmpl)
+	}
+	return composeTemplatesResult{Templates: entries}
+}
+
+type composePreviewResult struct {
+	Content   string
+	FlowError string
+	Etag      string
+}
+
+func (s *Server) composePreviewService(workspacePath string) (composePreviewResult, error) {
+	cs := s.getComposerSession(workspacePath)
+	cs.mu.Lock()
+	currentState := cs.state
+	cs.mu.Unlock()
+
+	preview := buildGOALContent(currentState)
+
+	var flowErr string
+	if currentState.Flow != "" {
+		if _, errParse := parseFlow(currentState.Flow, workspacePath); errParse != nil {
+			flowErr = errParse.Error()
+		}
+	}
+
+	goalPath := filepath.Join(workspacePath, "GOAL.md")
+	existingContent, errRead := os.ReadFile(goalPath)
+	if errRead != nil && !os.IsNotExist(errRead) {
+		return composePreviewResult{}, fmt.Errorf("failed to read current GOAL.md")
+	}
+	etag := computeEtag(existingContent)
+
+	return composePreviewResult{Content: preview, FlowError: flowErr, Etag: etag}, nil
+}
+
+type composeDraftResult struct {
+	Saved bool
+}
+
+func (s *Server) composeDraftService(workspacePath string, state composerState, wizard wizardState) composeDraftResult {
+	cs := s.getComposerSession(workspacePath)
+	cs.mu.Lock()
+	cs.state = state
+	cs.wizard = wizard
+	cs.mu.Unlock()
+
+	s.notifyStateChange()
+
+	return composeDraftResult{Saved: true}
+}

--- a/cmd/sgai/service_editor.go
+++ b/cmd/sgai/service_editor.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/sandgardenhq/sgai/pkg/state"
+)
+
+type openEditorResult struct {
+	Opened  bool
+	Editor  string
+	Message string
+}
+
+func (s *Server) openEditorService(workspacePath string) (openEditorResult, error) {
+	if !s.editorAvailable {
+		return openEditorResult{}, fmt.Errorf("no editor available")
+	}
+
+	if errOpen := s.editor.open(workspacePath); errOpen != nil {
+		return openEditorResult{}, fmt.Errorf("failed to open editor: %v", errOpen)
+	}
+
+	return openEditorResult{Opened: true, Editor: s.editorName, Message: "opened in editor"}, nil
+}
+
+func (s *Server) openEditorGoalService(workspacePath string) (openEditorResult, error) {
+	return s.openEditorFileService(workspacePath, "GOAL.md")
+}
+
+func (s *Server) openEditorProjectManagementService(workspacePath string) (openEditorResult, error) {
+	return s.openEditorFileService(workspacePath, filepath.Join(".sgai", "PROJECT_MANAGEMENT.md"))
+}
+
+func (s *Server) openEditorFileService(workspacePath, relPath string) (openEditorResult, error) {
+	if !s.editorAvailable {
+		return openEditorResult{}, fmt.Errorf("no editor available")
+	}
+
+	targetPath := filepath.Join(workspacePath, relPath)
+	if _, errStat := os.Stat(targetPath); errStat != nil {
+		return openEditorResult{}, fmt.Errorf("file not found")
+	}
+
+	if errOpen := s.editor.open(targetPath); errOpen != nil {
+		return openEditorResult{}, fmt.Errorf("failed to open editor: %v", errOpen)
+	}
+
+	return openEditorResult{Opened: true, Editor: s.editorName, Message: "opened in editor"}, nil
+}
+
+type openOpencodeResult struct {
+	Opened  bool
+	Message string
+}
+
+func (s *Server) openOpencodeService(workspacePath string) (openOpencodeResult, error) {
+	s.mu.Lock()
+	sess := s.sessions[workspacePath]
+	s.mu.Unlock()
+
+	if sess == nil {
+		return openOpencodeResult{}, fmt.Errorf("factory is not running")
+	}
+
+	sess.mu.Lock()
+	running := sess.running
+	sess.mu.Unlock()
+
+	if !running {
+		return openOpencodeResult{}, fmt.Errorf("factory is not running")
+	}
+
+	wfState := s.workspaceCoordinator(workspacePath).State()
+	currentAgent := wfState.CurrentAgent
+	sessionID := wfState.SessionID
+
+	models := modelsForAgentFromGoal(workspacePath, currentAgent)
+	var model string
+	if len(models) > 0 {
+		model, _ = parseModelAndVariant(models[0])
+	}
+
+	interactive := "yes"
+	if wfState.InteractionMode == state.ModeSelfDrive {
+		interactive = "auto"
+	}
+
+	execPath, errExec := os.Executable()
+	if errExec != nil {
+		return openOpencodeResult{}, fmt.Errorf("failed to resolve executable path")
+	}
+
+	opencodeCmd := fmt.Sprintf("opencode --session %q --agent %q", sessionID, currentAgent)
+	if model != "" {
+		opencodeCmd += fmt.Sprintf(" --model %q", model)
+	}
+	scriptContent := fmt.Sprintf("#!/bin/bash\ntrap 'rm -f \"$0\"' EXIT\ncd %q\nexport OPENCODE_CONFIG_DIR=.sgai\nexport SGAI_MCP_EXECUTABLE=%q\nexport SGAI_MCP_INTERACTIVE=%q\n%s\n",
+		workspacePath, execPath, interactive, opencodeCmd)
+
+	scriptPath, errScript := writeOpenCodeScript(scriptContent)
+	if errScript != nil {
+		return openOpencodeResult{}, fmt.Errorf("failed to prepare opencode script")
+	}
+
+	if errOpen := openInTerminal(scriptPath); errOpen != nil {
+		_ = os.Remove(scriptPath)
+		return openOpencodeResult{}, fmt.Errorf("failed to open terminal")
+	}
+
+	return openOpencodeResult{Opened: true, Message: "opened in opencode"}, nil
+}

--- a/cmd/sgai/service_knowledge.go
+++ b/cmd/sgai/service_knowledge.go
@@ -1,0 +1,153 @@
+package main
+
+import (
+	"io/fs"
+	"log"
+	"maps"
+	"os"
+	"path"
+	"path/filepath"
+	"slices"
+)
+
+type listAgentsResult struct {
+	Agents []apiAgentEntry
+}
+
+func (s *Server) listAgentsService(workspacePath string) listAgentsResult {
+	return listAgentsResult{Agents: collectAgents(workspacePath)}
+}
+
+type listSkillsResult struct {
+	Categories []apiSkillCategory
+}
+
+func (s *Server) listSkillsService(workspacePath string) listSkillsResult {
+	return listSkillsResult{Categories: collectSkillCategories(workspacePath)}
+}
+
+type skillDetailResult struct {
+	Name       string
+	FullPath   string
+	Content    string
+	RawContent string
+	Found      bool
+}
+
+func (s *Server) skillDetailService(workspacePath, skillName string) skillDetailResult {
+	skillsDir := filepath.Join(workspacePath, ".sgai", "skills")
+	skillsFS := os.DirFS(skillsDir)
+
+	skillFilePath := skillName + "/SKILL.md"
+	content, errRead := fs.ReadFile(skillsFS, skillFilePath)
+	if errRead != nil {
+		return skillDetailResult{Found: false}
+	}
+
+	stripped := stripFrontmatter(string(content))
+	rendered, errRender := renderMarkdown([]byte(stripped))
+	if errRender != nil {
+		rendered = stripped
+	}
+
+	return skillDetailResult{
+		Name:       path.Base(skillName),
+		FullPath:   skillName,
+		Content:    rendered,
+		RawContent: stripped,
+		Found:      true,
+	}
+}
+
+type listSnippetsResult struct {
+	Languages []apiLanguageCategory
+}
+
+func (s *Server) listSnippetsService(workspacePath string) listSnippetsResult {
+	languages := convertSnippetLanguages(gatherSnippetsByLanguage(workspacePath))
+	return listSnippetsResult{Languages: languages}
+}
+
+type snippetsByLanguageResult struct {
+	Language string
+	Snippets []apiSnippetEntry
+	Found    bool
+}
+
+func (s *Server) snippetsByLanguageService(workspacePath, lang string) snippetsByLanguageResult {
+	allLanguages := convertSnippetLanguages(gatherSnippetsByLanguage(workspacePath))
+	for _, lc := range allLanguages {
+		if lc.Name == lang {
+			return snippetsByLanguageResult{Language: lc.Name, Snippets: lc.Snippets, Found: true}
+		}
+	}
+	return snippetsByLanguageResult{Found: false}
+}
+
+type snippetDetailResult struct {
+	Name        string
+	FileName    string
+	Language    string
+	Description string
+	WhenToUse   string
+	Content     string
+	Found       bool
+}
+
+func (s *Server) snippetDetailService(workspacePath, lang, fileName string) snippetDetailResult {
+	snippetsDir := filepath.Join(workspacePath, ".sgai", "snippets")
+	snippetsFS := os.DirFS(snippetsDir)
+
+	extensions := []string{".go", ".html", ".css", ".js", ".ts", ".py", ".sh", ".yaml", ".yml", ".json", ".md", ".sql", ".txt", ""}
+	var content []byte
+	for _, ext := range extensions {
+		filePath := lang + "/" + fileName + ext
+		var errRead error
+		content, errRead = fs.ReadFile(snippetsFS, filePath)
+		if errRead == nil {
+			break
+		}
+	}
+
+	if content == nil {
+		return snippetDetailResult{Found: false}
+	}
+
+	fm := parseFrontmatterMap(content)
+	name := fm["name"]
+	if name == "" {
+		name = fileName
+	}
+
+	return snippetDetailResult{
+		Name:        name,
+		FileName:    fileName,
+		Language:    lang,
+		Description: fm["description"],
+		WhenToUse:   fm["when_to_use"],
+		Content:     stripFrontmatter(string(content)),
+		Found:       true,
+	}
+}
+
+type listModelsResult struct {
+	Models       []apiModelEntry
+	DefaultModel string
+}
+
+func (s *Server) listModelsService(workspaceName string) listModelsResult {
+	validModels, errFetch := fetchValidModels()
+	if errFetch != nil {
+		log.Println("cannot fetch models:", errFetch)
+		return listModelsResult{Models: []apiModelEntry{}}
+	}
+
+	modelNames := slices.Sorted(maps.Keys(validModels))
+	entries := make([]apiModelEntry, 0, len(modelNames))
+	for _, name := range modelNames {
+		entries = append(entries, apiModelEntry{ID: name, Name: name})
+	}
+
+	defaultModel := s.coordinatorModelFromWorkspace(workspaceName)
+	return listModelsResult{Models: entries, DefaultModel: defaultModel}
+}

--- a/cmd/sgai/service_session.go
+++ b/cmd/sgai/service_session.go
@@ -1,0 +1,230 @@
+package main
+
+import (
+	"fmt"
+	"path/filepath"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/sandgardenhq/sgai/pkg/state"
+)
+
+type startSessionResult2 struct {
+	Name           string
+	Status         string
+	Running        bool
+	Message        string
+	AlreadyRunning bool
+}
+
+func (s *Server) startSessionService(workspacePath string, auto bool) (startSessionResult2, error) {
+	if s.classifyWorkspaceCached(workspacePath) == workspaceRoot {
+		return startSessionResult2{}, fmt.Errorf("root workspace cannot start agentic work")
+	}
+
+	coord := s.workspaceCoordinator(workspacePath)
+	continuousPrompt := readContinuousModePrompt(workspacePath)
+
+	var interactionMode string
+	switch {
+	case continuousPrompt != "":
+		interactionMode = state.ModeContinuous
+	case auto:
+		interactionMode = state.ModeSelfDrive
+	default:
+		interactionMode = state.ModeBrainstorming
+	}
+
+	if errUpdate := coord.UpdateState(func(wf *state.Workflow) {
+		wf.InteractionMode = interactionMode
+	}); errUpdate != nil {
+		return startSessionResult2{}, fmt.Errorf("failed to save workflow state: %w", errUpdate)
+	}
+
+	result := s.startSession(workspacePath)
+
+	name := filepath.Base(workspacePath)
+
+	if result.alreadyRunning {
+		return startSessionResult2{
+			Name:           name,
+			Status:         "running",
+			Running:        true,
+			Message:        "session already running",
+			AlreadyRunning: true,
+		}, nil
+	}
+
+	if result.startError != nil {
+		return startSessionResult2{}, result.startError
+	}
+
+	s.notifyStateChange()
+
+	return startSessionResult2{
+		Name:    name,
+		Status:  "running",
+		Running: true,
+		Message: "session started",
+	}, nil
+}
+
+type stopSessionResult struct {
+	Name    string
+	Status  string
+	Running bool
+	Message string
+}
+
+func (s *Server) stopSessionService(workspacePath string) stopSessionResult {
+	s.mu.Lock()
+	sess := s.sessions[workspacePath]
+	s.mu.Unlock()
+
+	var alreadyStopped bool
+	if sess == nil {
+		alreadyStopped = true
+	} else {
+		sess.mu.Lock()
+		alreadyStopped = !sess.running
+		sess.mu.Unlock()
+	}
+
+	s.stopSession(workspacePath)
+
+	message := "session stopped"
+	if alreadyStopped {
+		message = "session already stopped"
+	}
+
+	s.notifyStateChange()
+
+	return stopSessionResult{
+		Name:    filepath.Base(workspacePath),
+		Status:  "stopped",
+		Running: false,
+		Message: message,
+	}
+}
+
+type respondResult struct {
+	Success bool
+	Message string
+}
+
+func (s *Server) respondService(workspacePath, questionID, answer string, selectedChoices []string) (respondResult, error) {
+	req := apiRespondRequest{
+		QuestionID:      questionID,
+		Answer:          answer,
+		SelectedChoices: selectedChoices,
+	}
+
+	coord := s.sessionCoordinator(workspacePath)
+	if coord != nil {
+		return s.respondViaCoordinatorService(coord, req)
+	}
+
+	return s.respondLegacyService(workspacePath, req)
+}
+
+func (s *Server) respondViaCoordinatorService(coord *state.Coordinator, req apiRespondRequest) (respondResult, error) {
+	wfState := coord.State()
+
+	if !wfState.NeedsHumanInput() {
+		return respondResult{}, fmt.Errorf("no pending question")
+	}
+
+	currentID := generateQuestionID(wfState)
+	if req.QuestionID != currentID {
+		return respondResult{}, fmt.Errorf("question expired")
+	}
+
+	responseText := buildAPIResponseText(req, wfState.MultiChoiceQuestion)
+	if responseText == "" {
+		return respondResult{}, fmt.Errorf("response cannot be empty")
+	}
+
+	if wfState.MultiChoiceQuestion != nil && wfState.MultiChoiceQuestion.IsWorkGate {
+		approvedViaSelection := slices.Contains(req.SelectedChoices, workGateApprovalText)
+		if approvedViaSelection {
+			if errUpdate := coord.UpdateState(func(wf *state.Workflow) {
+				if wf.InteractionMode == state.ModeBrainstorming {
+					wf.InteractionMode = state.ModeBuilding
+				}
+			}); errUpdate != nil {
+				return respondResult{}, fmt.Errorf("failed to save work gate approval: %w", errUpdate)
+			}
+		}
+	}
+
+	coord.Respond(responseText)
+	s.notifyStateChange()
+
+	return respondResult{Success: true, Message: "response submitted"}, nil
+}
+
+func (s *Server) respondLegacyService(workspacePath string, req apiRespondRequest) (respondResult, error) {
+	coord := s.workspaceCoordinator(workspacePath)
+	wfState := coord.State()
+
+	if !wfState.NeedsHumanInput() {
+		return respondResult{}, fmt.Errorf("no pending question in legacy path")
+	}
+
+	currentID := generateQuestionID(wfState)
+	if req.QuestionID != currentID {
+		return respondResult{}, fmt.Errorf("question expired")
+	}
+
+	responseText := buildAPIResponseText(req, wfState.MultiChoiceQuestion)
+	if responseText == "" {
+		return respondResult{}, fmt.Errorf("response cannot be empty")
+	}
+
+	if errUpdate := coord.UpdateState(func(wf *state.Workflow) {
+		wf.Status = state.StatusWorking
+		wf.HumanMessage = ""
+		wf.MultiChoiceQuestion = nil
+		wf.Task = ""
+	}); errUpdate != nil {
+		return respondResult{}, fmt.Errorf("failed to save state: %w", errUpdate)
+	}
+
+	s.notifyStateChange()
+
+	return respondResult{Success: true, Message: "response submitted"}, nil
+}
+
+type steerResult struct {
+	Success bool
+	Message string
+}
+
+func (s *Server) steerService(workspacePath, message string) (steerResult, error) {
+	if strings.TrimSpace(message) == "" {
+		return steerResult{}, fmt.Errorf("message cannot be empty")
+	}
+
+	coord := s.workspaceCoordinator(workspacePath)
+	steerBody := "Re-steering instruction: " + strings.TrimSpace(message)
+	steerCreatedAt := time.Now().UTC().Format(time.RFC3339)
+
+	if errUpdate := coord.UpdateState(func(wf *state.Workflow) {
+		newMsg := state.Message{
+			ID:        nextMessageID(wf.Messages),
+			FromAgent: "Human Partner",
+			ToAgent:   "coordinator",
+			Body:      steerBody,
+			CreatedAt: steerCreatedAt,
+		}
+		insertIdx := findSteerInsertPosition(wf.Messages)
+		wf.Messages = slices.Insert(wf.Messages, insertIdx, newMsg)
+	}); errUpdate != nil {
+		return steerResult{}, fmt.Errorf("failed to save state: %w", errUpdate)
+	}
+
+	s.notifyStateChange()
+
+	return steerResult{Success: true, Message: "steering instruction added"}, nil
+}

--- a/cmd/sgai/service_state.go
+++ b/cmd/sgai/service_state.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"fmt"
+	"os/exec"
+)
+
+type workspaceStateResult struct {
+	Workspace apiWorkspaceFullState
+	Found     bool
+}
+
+func (s *Server) getWorkspaceStateService(workspaceName string) (workspaceStateResult, error) {
+	groups, errScan := s.scanWorkspaceGroups()
+	if errScan != nil {
+		return workspaceStateResult{}, errScan
+	}
+
+	for _, grp := range groups {
+		if grp.Root.DirName == workspaceName {
+			ws := s.buildWorkspaceFullState(grp.Root, groups)
+			return workspaceStateResult{Workspace: ws, Found: true}, nil
+		}
+		for _, fork := range grp.Forks {
+			if fork.DirName == workspaceName {
+				ws := s.buildWorkspaceFullState(fork, groups)
+				return workspaceStateResult{Workspace: ws, Found: true}, nil
+			}
+		}
+	}
+
+	return workspaceStateResult{Found: false}, nil
+}
+
+func (s *Server) getWorkflowSVGService(workspacePath string) string {
+	wfState := s.workspaceCoordinator(workspacePath).State()
+	currentAgent := wfState.CurrentAgent
+	if currentAgent == "" {
+		currentAgent = "Unknown"
+	}
+	return s.getWorkflowSVGCached(workspacePath, currentAgent)
+}
+
+type workspaceDiffResult struct {
+	Diff string
+}
+
+func (s *Server) workspaceDiffService(workspacePath string) workspaceDiffResult {
+	if !hasJJRepo(workspacePath) {
+		return workspaceDiffResult{}
+	}
+	return workspaceDiffResult{Diff: collectJJFullDiff(workspacePath)}
+}
+
+type updateDescriptionResult struct {
+	Updated     bool
+	Description string
+}
+
+func (s *Server) updateDescriptionService(workspacePath, description string) (updateDescriptionResult, error) {
+	cmd := exec.Command("jj", "desc", "-m", description)
+	cmd.Dir = workspacePath
+	if output, errCmd := cmd.CombinedOutput(); errCmd != nil {
+		return updateDescriptionResult{}, fmt.Errorf("failed to update description: %s", output)
+	}
+
+	s.notifyStateChange()
+
+	return updateDescriptionResult{Updated: true, Description: description}, nil
+}

--- a/cmd/sgai/service_workspace.go
+++ b/cmd/sgai/service_workspace.go
@@ -1,0 +1,324 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/sandgardenhq/sgai/pkg/state"
+)
+
+type createWorkspaceResult struct {
+	Name string
+	Dir  string
+}
+
+func (s *Server) createWorkspaceService(name string) (createWorkspaceResult, error) {
+	if errMsg := validateWorkspaceName(name); errMsg != "" {
+		return createWorkspaceResult{}, fmt.Errorf("%s", errMsg)
+	}
+
+	workspacePath := filepath.Join(s.rootDir, name)
+	if _, errStat := os.Stat(workspacePath); errStat == nil {
+		return createWorkspaceResult{}, fmt.Errorf("a directory with this name already exists")
+	} else if !os.IsNotExist(errStat) {
+		return createWorkspaceResult{}, fmt.Errorf("failed to check workspace path")
+	}
+
+	if errMkdir := os.MkdirAll(workspacePath, 0755); errMkdir != nil {
+		return createWorkspaceResult{}, fmt.Errorf("failed to create workspace directory")
+	}
+
+	if errInit := initializeWorkspace(workspacePath); errInit != nil {
+		return createWorkspaceResult{}, fmt.Errorf("failed to initialize workspace")
+	}
+
+	s.invalidateWorkspaceScanCache()
+
+	return createWorkspaceResult{Name: name, Dir: workspacePath}, nil
+}
+
+type forkWorkspaceResult struct {
+	Name      string
+	Dir       string
+	Parent    string
+	CreatedAt string
+}
+
+func (s *Server) forkWorkspaceService(workspacePath, name string) (forkWorkspaceResult, error) {
+	if s.classifyWorkspaceCached(workspacePath) == workspaceFork {
+		return forkWorkspaceResult{}, fmt.Errorf("forks cannot create new forks")
+	}
+
+	normalized := normalizeForkName(name)
+	if errMsg := validateWorkspaceName(normalized); errMsg != "" {
+		return forkWorkspaceResult{}, fmt.Errorf("%s", errMsg)
+	}
+
+	parentDir := filepath.Dir(workspacePath)
+	forkPath := filepath.Join(parentDir, normalized)
+	if _, errStat := os.Stat(forkPath); errStat == nil {
+		return forkWorkspaceResult{}, fmt.Errorf("a directory with this name already exists")
+	} else if !os.IsNotExist(errStat) {
+		return forkWorkspaceResult{}, fmt.Errorf("failed to check workspace path")
+	}
+
+	cmd := exec.Command("jj", "workspace", "add", forkPath)
+	cmd.Dir = workspacePath
+	output, errFork := cmd.CombinedOutput()
+	if errFork != nil {
+		return forkWorkspaceResult{}, fmt.Errorf("failed to fork workspace: %v: %s", errFork, output)
+	}
+
+	if errSkel := unpackSkeleton(forkPath); errSkel != nil {
+		return forkWorkspaceResult{}, fmt.Errorf("failed to unpack skeleton: %w", errSkel)
+	}
+	if errExclude := addGitExclude(forkPath); errExclude != nil {
+		return forkWorkspaceResult{}, fmt.Errorf("failed to add git exclude: %w", errExclude)
+	}
+	if errGoal := writeGoalExample(forkPath); errGoal != nil {
+		return forkWorkspaceResult{}, fmt.Errorf("failed to create GOAL.md: %w", errGoal)
+	}
+
+	s.invalidateWorkspaceScanCache()
+	s.classifyCache.delete(workspacePath)
+	s.notifyStateChange()
+
+	return forkWorkspaceResult{
+		Name:      normalized,
+		Dir:       forkPath,
+		Parent:    filepath.Base(workspacePath),
+		CreatedAt: time.Now().UTC().Format(time.RFC3339),
+	}, nil
+}
+
+type deleteForkResult struct {
+	Deleted bool
+	Message string
+}
+
+func (s *Server) deleteForkService(workspacePath, forkDir string, confirm bool) (deleteForkResult, error) {
+	if s.classifyWorkspaceCached(workspacePath) != workspaceRoot {
+		return deleteForkResult{}, fmt.Errorf("workspace is not a root")
+	}
+
+	if !confirm {
+		return deleteForkResult{}, fmt.Errorf("confirmation required to delete fork")
+	}
+
+	validatedForkDir, errValidate := s.validateDirectory(forkDir)
+	if errValidate != nil {
+		return deleteForkResult{}, fmt.Errorf("invalid fork directory")
+	}
+
+	if s.classifyWorkspaceCached(validatedForkDir) != workspaceFork {
+		return deleteForkResult{}, fmt.Errorf("fork workspace not found")
+	}
+
+	if getRootWorkspacePath(validatedForkDir) != workspacePath {
+		return deleteForkResult{}, fmt.Errorf("fork does not belong to root")
+	}
+
+	forkName := filepath.Base(validatedForkDir)
+	s.stopSession(validatedForkDir)
+
+	forgetCmd := exec.Command("jj", "workspace", "forget", forkName)
+	forgetCmd.Dir = workspacePath
+	if _, errForget := forgetCmd.CombinedOutput(); errForget != nil {
+		return deleteForkResult{}, fmt.Errorf("failed to forget fork workspace")
+	}
+
+	if errRemove := os.RemoveAll(validatedForkDir); errRemove != nil {
+		return deleteForkResult{}, fmt.Errorf("failed to remove fork directory")
+	}
+
+	s.invalidateWorkspaceScanCache()
+	s.classifyCache.delete(workspacePath)
+	s.classifyCache.delete(validatedForkDir)
+	s.notifyStateChange()
+
+	return deleteForkResult{Deleted: true, Message: "fork deleted successfully"}, nil
+}
+
+type renameWorkspaceResult struct {
+	Name    string
+	OldName string
+	Dir     string
+}
+
+func (s *Server) renameWorkspaceService(workspacePath, newName string) (renameWorkspaceResult, error) {
+	if s.classifyWorkspaceCached(workspacePath) != workspaceFork {
+		return renameWorkspaceResult{}, fmt.Errorf("only forks can be renamed")
+	}
+
+	normalized := normalizeForkName(newName)
+	if errMsg := validateWorkspaceName(normalized); errMsg != "" {
+		return renameWorkspaceResult{}, fmt.Errorf("%s", errMsg)
+	}
+
+	s.mu.Lock()
+	sess := s.sessions[workspacePath]
+	s.mu.Unlock()
+	if sess != nil {
+		sess.mu.Lock()
+		running := sess.running
+		sess.mu.Unlock()
+		if running {
+			return renameWorkspaceResult{}, fmt.Errorf("cannot rename: session is running")
+		}
+	}
+
+	oldName := filepath.Base(workspacePath)
+	parentDir := filepath.Dir(workspacePath)
+	newPath := filepath.Join(parentDir, normalized)
+	if _, errStat := os.Stat(newPath); errStat == nil {
+		return renameWorkspaceResult{}, fmt.Errorf("a directory with this name already exists")
+	} else if !os.IsNotExist(errStat) {
+		return renameWorkspaceResult{}, fmt.Errorf("failed to check target path")
+	}
+
+	if errRename := os.Rename(workspacePath, newPath); errRename != nil {
+		return renameWorkspaceResult{}, fmt.Errorf("failed to rename directory: %v", errRename)
+	}
+
+	cmd := exec.Command("jj", "workspace", "rename", normalized)
+	cmd.Dir = newPath
+	if output, errJJ := cmd.CombinedOutput(); errJJ != nil {
+		return renameWorkspaceResult{}, fmt.Errorf("jj workspace rename failed: %v: %s", errJJ, output)
+	}
+
+	s.mu.Lock()
+	if existing, ok := s.sessions[workspacePath]; ok {
+		delete(s.sessions, workspacePath)
+		s.sessions[newPath] = existing
+	}
+	if s.everStartedDirs[workspacePath] {
+		delete(s.everStartedDirs, workspacePath)
+		s.everStartedDirs[newPath] = true
+	}
+	s.mu.Unlock()
+
+	s.invalidateWorkspaceScanCache()
+	s.notifyStateChange()
+
+	return renameWorkspaceResult{Name: normalized, OldName: oldName, Dir: newPath}, nil
+}
+
+type getGoalResult struct {
+	Content string
+}
+
+func (s *Server) getGoalService(workspacePath string) (getGoalResult, error) {
+	data, errRead := os.ReadFile(filepath.Join(workspacePath, "GOAL.md"))
+	if errRead != nil {
+		return getGoalResult{}, fmt.Errorf("failed to read GOAL.md: %w", errRead)
+	}
+	return getGoalResult{Content: string(data)}, nil
+}
+
+type updateGoalResult struct {
+	Updated   bool
+	Workspace string
+}
+
+func (s *Server) updateGoalService(workspacePath, content string) (updateGoalResult, error) {
+	if content == "" {
+		return updateGoalResult{}, fmt.Errorf("content cannot be empty")
+	}
+
+	goalPath := filepath.Join(workspacePath, "GOAL.md")
+	if errWrite := os.WriteFile(goalPath, []byte(content), 0644); errWrite != nil {
+		return updateGoalResult{}, fmt.Errorf("failed to write GOAL.md: %w", errWrite)
+	}
+
+	prefix := workspacePath + "|"
+	s.svgCache.deleteFunc(func(k string) bool {
+		return strings.HasPrefix(k, prefix)
+	})
+	s.notifyStateChange()
+
+	return updateGoalResult{Updated: true, Workspace: filepath.Base(workspacePath)}, nil
+}
+
+type updateSummaryResult struct {
+	Updated   bool
+	Summary   string
+	Workspace string
+}
+
+func (s *Server) updateSummaryService(workspacePath, summary string) (updateSummaryResult, error) {
+	coord := s.workspaceCoordinator(workspacePath)
+	trimmed := strings.TrimSpace(summary)
+
+	if errUpdate := coord.UpdateState(func(wf *state.Workflow) {
+		wf.Summary = trimmed
+		wf.SummaryManual = true
+	}); errUpdate != nil {
+		return updateSummaryResult{}, fmt.Errorf("failed to save workspace state: %w", errUpdate)
+	}
+
+	s.notifyStateChange()
+
+	return updateSummaryResult{
+		Updated:   true,
+		Summary:   trimmed,
+		Workspace: filepath.Base(workspacePath),
+	}, nil
+}
+
+type togglePinResult struct {
+	Pinned  bool
+	Message string
+}
+
+func (s *Server) togglePinService(workspacePath string) (togglePinResult, error) {
+	if errToggle := s.togglePin(workspacePath); errToggle != nil {
+		return togglePinResult{}, fmt.Errorf("failed to toggle pin: %w", errToggle)
+	}
+
+	s.invalidateWorkspaceScanCache()
+	s.notifyStateChange()
+
+	return togglePinResult{Pinned: s.isPinned(workspacePath), Message: "pin toggled"}, nil
+}
+
+type deleteMessageResult struct {
+	Deleted bool
+	ID      int
+	Message string
+}
+
+func (s *Server) deleteMessageService(workspacePath string, messageID int) (deleteMessageResult, error) {
+	coord := s.workspaceCoordinator(workspacePath)
+	wfState := coord.State()
+
+	found := false
+	for _, msg := range wfState.Messages {
+		if msg.ID == messageID {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		return deleteMessageResult{}, fmt.Errorf("message not found")
+	}
+
+	if errUpdate := coord.UpdateState(func(wf *state.Workflow) {
+		for i, msg := range wf.Messages {
+			if msg.ID == messageID {
+				wf.Messages = append(wf.Messages[:i], wf.Messages[i+1:]...)
+				break
+			}
+		}
+	}); errUpdate != nil {
+		return deleteMessageResult{}, fmt.Errorf("failed to save workspace state: %w", errUpdate)
+	}
+
+	s.notifyStateChange()
+
+	return deleteMessageResult{Deleted: true, ID: messageID, Message: "message deleted successfully"}, nil
+}

--- a/docs/sgai-skills/README.md
+++ b/docs/sgai-skills/README.md
@@ -1,0 +1,53 @@
+# sgai Skills
+
+Skills for driving [sgai](https://github.com/sandgardenhq/sgai) (Software Garden AI) from any MCP-capable harness or AI agent.
+
+## Entrypoint
+
+Start here: **[using-sgai/SKILL.md](using-sgai/SKILL.md)**
+
+This skill explains the cyclical probe/poll/act workflow for orchestrating sgai from Claude Code, Codex, or any AI harness that supports skills or HTTP.
+
+## Sub-skills
+
+| Skill | Description |
+|-------|-------------|
+| [workspace-management](workspace-management/SKILL.md) | Create, fork, delete, rename workspaces |
+| [session-control](session-control/SKILL.md) | Start/stop sessions, steer agents |
+| [human-interaction](human-interaction/SKILL.md) | Respond to questions and work gates |
+| [monitoring](monitoring/SKILL.md) | List workspaces, get state, diffs, SVGs |
+| [knowledge](knowledge/SKILL.md) | Agents, skills, snippets, models |
+| [compose](compose/SKILL.md) | Compose wizard: state, save, preview, draft, templates |
+| [adhoc](adhoc/SKILL.md) | Ad-hoc prompt start/stop/status |
+
+## MCP Interface
+
+sgai also exposes a full MCP server at `/mcp/external` with 38 tools that mirror the HTTP API:
+
+```bash
+npx mcporter list --http-url http://127.0.0.1:PORT/mcp/external --allow-http
+```
+
+## Quick Start
+
+```bash
+# 1. Start sgai server
+sgai serve -listen-addr 127.0.0.1:PORT ./workspaces
+
+# 2. Create a workspace
+curl -X POST http://localhost:PORT/api/v1/workspaces -d '{"name": "my-project"}'
+
+# 3. Write a goal
+curl -X PUT http://localhost:PORT/api/v1/workspaces/my-project/goal \
+  -d '{"content": "- [ ] Build something great"}'
+
+# 4. Start in auto mode
+curl -X POST http://localhost:PORT/api/v1/workspaces/my-project/start -d '{"auto": true}'
+
+# 5. Monitor progress
+curl -s http://localhost:PORT/api/v1/state | jq '.workspaces[0].latestProgress'
+```
+
+## Specification
+
+These skills conform to the [agentskills.io specification](https://agentskills.io/specification).

--- a/docs/sgai-skills/adhoc/SKILL.md
+++ b/docs/sgai-skills/adhoc/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: adhoc
+description: Run and manage ad-hoc AI prompts in sgai workspaces without starting a full agentic session. Use when you need to run a one-off AI prompt against a workspace, check the status of a running ad-hoc prompt, or stop a running ad-hoc prompt.
+compatibility: Requires a running sgai server and opencode installed. The prompt runs as a non-interactive opencode command in the workspace directory.
+---
+
+# Ad-hoc Prompts
+
+Ad-hoc prompts let you run a single AI prompt against a workspace without starting a full agentic session. Useful for quick tasks, code reviews, or one-off questions.
+
+## Start an Ad-hoc Prompt
+
+**Endpoint:** `POST /api/v1/workspaces/{name}/adhoc`
+
+```bash
+curl -X POST $BASE_URL/api/v1/workspaces/my-project/adhoc \
+  -H "Content-Type: application/json" \
+  -d '{
+    "prompt": "Review the authentication code and identify any security issues",
+    "model": "anthropic/claude-opus-4-6"
+  }'
+```
+
+Request:
+```json
+{
+  "prompt": "Review the authentication code and identify any security issues",
+  "model": "anthropic/claude-opus-4-6"
+}
+```
+
+Response:
+```json
+{
+  "running": true,
+  "output": "",
+  "message": "ad-hoc prompt started"
+}
+```
+
+If already running:
+```json
+{
+  "running": true,
+  "output": "$ opencode run -m anthropic/claude-opus-4-6...\nprompt: Review the...",
+  "message": "ad-hoc prompt already running"
+}
+```
+
+### Model Format
+
+The model parameter accepts the same format as GOAL.md models:
+- `"anthropic/claude-opus-4-6"` — standard model
+- `"anthropic/claude-opus-4-6 (max)"` — model with variant
+- Use `GET /api/v1/models` to list available models
+
+### How Ad-hoc Works
+
+Ad-hoc prompts run `opencode run -m {model} --agent build --title "adhoc [{model}]"` with your prompt piped as stdin. The workspace directory is used as the working directory.
+
+## Get Ad-hoc Status
+
+Check if an ad-hoc prompt is running and get its current output.
+
+**Endpoint:** `GET /api/v1/workspaces/{name}/adhoc`
+
+```bash
+curl -s $BASE_URL/api/v1/workspaces/my-project/adhoc
+```
+
+Response (running):
+```json
+{
+  "running": true,
+  "output": "$ opencode run -m anthropic/claude-opus-4-6 --agent build --title \"adhoc [anthropic/claude-opus-4-6]\"\nprompt: Review the authentication code...\n\nAnalyzing the codebase...\n\nFound 3 potential issues:\n1. JWT tokens lack expiration...",
+  "message": "adhoc status"
+}
+```
+
+Response (not running):
+```json
+{
+  "running": false,
+  "output": "$ opencode run...\n...\n[completed successfully]",
+  "message": "adhoc status"
+}
+```
+
+### Polling for Completion
+
+```bash
+WORKSPACE="my-project"
+
+# Start the prompt
+curl -X POST $BASE_URL/api/v1/workspaces/$WORKSPACE/adhoc \
+  -H "Content-Type: application/json" \
+  -d '{"prompt": "Summarize the GOAL.md", "model": "anthropic/claude-sonnet-4-6"}'
+
+# Poll until done
+while true; do
+  STATUS=$(curl -s $BASE_URL/api/v1/workspaces/$WORKSPACE/adhoc)
+  RUNNING=$(echo $STATUS | jq '.running')
+  
+  if [ "$RUNNING" = "false" ]; then
+    echo "Ad-hoc complete!"
+    echo $STATUS | jq -r '.output'
+    break
+  fi
+  
+  echo "Still running..."
+  sleep 3
+done
+```
+
+## Stop an Ad-hoc Prompt
+
+Stop a running ad-hoc prompt.
+
+**Endpoint:** `DELETE /api/v1/workspaces/{name}/adhoc`
+
+```bash
+curl -X DELETE $BASE_URL/api/v1/workspaces/my-project/adhoc
+```
+
+Response:
+```json
+{
+  "running": false,
+  "output": "$ opencode run...\n...\n[process terminated]",
+  "message": "ad-hoc stopped"
+}
+```
+
+## Ad-hoc vs Full Session
+
+| Feature | Ad-hoc | Full Session |
+|---------|--------|--------------|
+| Single prompt | ✓ | ✗ (multi-agent flow) |
+| Multi-agent workflow | ✗ | ✓ |
+| Human interaction | ✗ | ✓ |
+| Progress tracking | Basic | Full (todos, events) |
+| Cost tracking | ✗ | ✓ |
+| Concurrent with session | No | N/A |
+| GOAL.md required | ✗ | ✓ |
+
+## Common Ad-hoc Use Cases
+
+```bash
+# Code review
+curl -X POST $BASE_URL/api/v1/workspaces/my-project/adhoc \
+  -d '{"prompt": "Review all Go files for potential race conditions", "model": "anthropic/claude-opus-4-6"}'
+
+# Documentation generation
+curl -X POST $BASE_URL/api/v1/workspaces/my-project/adhoc \
+  -d '{"prompt": "Generate a README.md for this project", "model": "anthropic/claude-sonnet-4-6"}'
+
+# Quick fix
+curl -X POST $BASE_URL/api/v1/workspaces/my-project/adhoc \
+  -d '{"prompt": "Fix the failing test in auth_test.go", "model": "anthropic/claude-sonnet-4-6"}'
+
+# Analysis
+curl -X POST $BASE_URL/api/v1/workspaces/my-project/adhoc \
+  -d '{"prompt": "List all TODO comments in the codebase", "model": "anthropic/claude-haiku-4-5"}'
+```

--- a/docs/sgai-skills/compose/SKILL.md
+++ b/docs/sgai-skills/compose/SKILL.md
@@ -1,0 +1,210 @@
+---
+name: compose
+description: Use the sgai compose wizard to create and manage GOAL.md files for workspaces. Supports reading compose state, updating wizard fields, saving drafts, previewing generated GOAL.md content, browsing workflow templates, and writing the final GOAL.md to the workspace.
+compatibility: Requires a running sgai server. The compose wizard maintains in-memory state per workspace session.
+---
+
+# Compose Wizard
+
+The compose wizard is a guided interface for creating GOAL.md files. It maintains state about the workflow configuration, agent assignments, tech stack, and goals.
+
+## Get Compose State
+
+**Endpoint:** `GET /api/v1/compose?workspace={name}`
+
+```bash
+curl -s "$BASE_URL/api/v1/compose?workspace=my-project"
+```
+
+Response:
+```json
+{
+  "workspace": "my-project",
+  "state": {
+    "flow": "\"coordinator\" -> \"backend-go-developer\" -> \"go-readability-reviewer\"",
+    "models": {
+      "coordinator": "anthropic/claude-opus-4-6",
+      "backend-go-developer": "anthropic/claude-sonnet-4-6"
+    },
+    "goals": "- [ ] Build a REST API for user management\n- [ ] Write tests with 80%+ coverage",
+    "completionGateScript": "make test"
+  },
+  "wizard": {
+    "currentStep": 3,
+    "fromTemplate": "go-backend",
+    "description": "User management REST API",
+    "techStack": ["go", "postgresql"],
+    "safetyAnalysis": false,
+    "completionGate": "make test"
+  },
+  "techStackItems": [
+    {"id": "go", "name": "Go", "selected": true},
+    {"id": "react", "name": "React", "selected": false},
+    {"id": "postgresql", "name": "PostgreSQL", "selected": true}
+  ],
+  "flowError": ""
+}
+```
+
+### Compose State Fields
+
+**`state`** — the raw GOAL.md configuration:
+- `flow` — agent flow definition (quoted agent names with `->`)
+- `models` — map of agent name to model ID
+- `goals` — markdown goal checklist
+- `completionGateScript` — shell command to verify completion
+
+**`wizard`** — user-facing wizard state:
+- `currentStep` — which step in the wizard (1-based)
+- `fromTemplate` — template ID if started from template
+- `description` — project description
+- `techStack` — selected technology stack items
+- `safetyAnalysis` — whether STPA analysis is included
+- `completionGate` — gate script for completion
+
+## Get Compose Templates
+
+**Endpoint:** `GET /api/v1/compose/templates`
+
+```bash
+curl -s "$BASE_URL/api/v1/compose/templates"
+```
+
+Response:
+```json
+{
+  "templates": [
+    {
+      "id": "go-backend",
+      "name": "Go Backend API",
+      "description": "REST API with Go, including code review and testing agents.",
+      "icon": "🔧",
+      "agents": [
+        {"name": "coordinator", "model": "anthropic/claude-opus-4-6"},
+        {"name": "backend-go-developer", "model": "anthropic/claude-sonnet-4-6"}
+      ],
+      "flow": "\"backend-go-developer\" -> \"go-readability-reviewer\""
+    }
+  ]
+}
+```
+
+## Preview Generated GOAL.md
+
+Preview what the GOAL.md would look like without saving.
+
+**Endpoint:** `GET /api/v1/compose/preview?workspace={name}`
+
+```bash
+curl -s "$BASE_URL/api/v1/compose/preview?workspace=my-project"
+```
+
+Response:
+```json
+{
+  "content": "---\nflow: |\n  \"backend-go-developer\" -> \"go-readability-reviewer\"\nmodels:\n  coordinator: anthropic/claude-opus-4-6\n  backend-go-developer: anthropic/claude-sonnet-4-6\ncompletionGateScript: make test\n---\n\n- [ ] Build a REST API\n",
+  "flowError": "",
+  "etag": "\"abc123def456\""
+}
+```
+
+- `content` — the full GOAL.md content that would be saved
+- `flowError` — non-empty if the flow definition has syntax errors
+- `etag` — current file ETag for optimistic concurrency
+
+## Save Draft (In-Memory)
+
+Save the compose state in memory without writing GOAL.md.
+
+**Endpoint:** `POST /api/v1/compose/draft?workspace={name}`
+
+```bash
+curl -X POST "$BASE_URL/api/v1/compose/draft?workspace=my-project" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "state": {
+      "flow": "\"coordinator\" -> \"backend-go-developer\"",
+      "models": {"coordinator": "anthropic/claude-opus-4-6"},
+      "goals": "- [ ] Build authentication\n",
+      "completionGateScript": ""
+    },
+    "wizard": {
+      "currentStep": 2,
+      "fromTemplate": "",
+      "description": "Auth system",
+      "techStack": ["go"],
+      "safetyAnalysis": false,
+      "completionGate": ""
+    }
+  }'
+```
+
+Response:
+```json
+{"saved": true}
+```
+
+Use this to update the wizard state incrementally as the user fills in fields.
+
+## Save Compose (Write GOAL.md)
+
+Write the current compose state to GOAL.md.
+
+**Endpoint:** `POST /api/v1/compose?workspace={name}`
+
+```bash
+# Simple save
+curl -X POST "$BASE_URL/api/v1/compose?workspace=my-project"
+
+# With optimistic concurrency (prevent overwriting concurrent changes)
+ETAG=$(curl -s "$BASE_URL/api/v1/compose/preview?workspace=my-project" | jq -r '.etag')
+curl -X POST "$BASE_URL/api/v1/compose?workspace=my-project" \
+  -H "If-Match: $ETAG"
+```
+
+Response (201 Created):
+```json
+{
+  "saved": true,
+  "workspace": "my-project"
+}
+```
+
+Errors:
+- `412 Precondition Failed` — GOAL.md was modified since the etag was fetched
+
+## Complete Compose Workflow
+
+```bash
+# 1. Start from a template
+curl -X POST "$BASE_URL/api/v1/compose/draft?workspace=my-project" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "state": {
+      "flow": "\"backend-go-developer\" -> \"go-readability-reviewer\"",
+      "models": {
+        "coordinator": "anthropic/claude-opus-4-6",
+        "backend-go-developer": "anthropic/claude-sonnet-4-6",
+        "go-readability-reviewer": "anthropic/claude-opus-4-6"
+      },
+      "goals": "- [ ] Build REST API\n- [ ] Add authentication\n- [ ] Write tests\n",
+      "completionGateScript": "make test"
+    },
+    "wizard": {
+      "currentStep": 4,
+      "description": "User management API",
+      "techStack": ["go", "postgresql"],
+      "safetyAnalysis": false,
+      "completionGate": "make test"
+    }
+  }'
+
+# 2. Preview to verify
+curl -s "$BASE_URL/api/v1/compose/preview?workspace=my-project" | jq '.content'
+
+# 3. Save to GOAL.md
+curl -X POST "$BASE_URL/api/v1/compose?workspace=my-project"
+
+# 4. Start the session
+curl -X POST $BASE_URL/api/v1/workspaces/my-project/start -d '{"auto": true}'
+```

--- a/docs/sgai-skills/human-interaction/SKILL.md
+++ b/docs/sgai-skills/human-interaction/SKILL.md
@@ -1,0 +1,226 @@
+---
+name: human-interaction
+description: Handle agent questions and work gates in sgai workspaces. Use when an agent is blocked waiting for human input, when you need to respond to multi-choice questions, approve work gates, or provide free-text answers to agent queries.
+compatibility: Requires a running sgai session with a pending question. Check workspace state for pendingQuestion field before calling respond endpoint.
+---
+
+# Human Interaction
+
+When sgai agents need human input, they set `needsInput: true` and populate `pendingQuestion` in the workspace state. Your harness must detect and respond to these to unblock the agent.
+
+## Detecting Pending Questions
+
+Poll `/api/v1/state` and check each workspace:
+
+```bash
+STATE=$(curl -s $BASE_URL/api/v1/state)
+
+# Check all workspaces for pending questions
+echo $STATE | jq '.workspaces[] | select(.needsInput == true) | {name, pendingQuestion}'
+```
+
+A workspace with a pending question looks like:
+
+```json
+{
+  "name": "my-project",
+  "needsInput": true,
+  "pendingQuestion": {
+    "questionId": "abc123def456ef78",
+    "type": "free-text",
+    "agentName": "coordinator",
+    "message": "Which database should we use for the project?",
+    "questions": []
+  }
+}
+```
+
+## Question Types
+
+### `free-text`
+
+Agent asks an open-ended question. Respond with `answer`.
+
+```json
+{
+  "pendingQuestion": {
+    "questionId": "abc123def456ef78",
+    "type": "free-text",
+    "agentName": "coordinator",
+    "message": "What is the primary use case for this application?",
+    "questions": []
+  }
+}
+```
+
+Response:
+```bash
+curl -X POST $BASE_URL/api/v1/workspaces/my-project/respond \
+  -H "Content-Type: application/json" \
+  -d '{
+    "questionId": "abc123def456ef78",
+    "answer": "This is a B2B SaaS platform for small businesses"
+  }'
+```
+
+### `multi-choice`
+
+Agent presents structured questions with predefined choices.
+
+```json
+{
+  "pendingQuestion": {
+    "questionId": "def456abc789ab12",
+    "type": "multi-choice",
+    "agentName": "coordinator",
+    "message": "Please answer the following questions:",
+    "questions": [
+      {
+        "question": "Which backend language?",
+        "choices": ["Go", "Python", "Node.js", "Rust"],
+        "multiSelect": false
+      },
+      {
+        "question": "Which features are required?",
+        "choices": ["Auth", "Payments", "Analytics", "Notifications"],
+        "multiSelect": true
+      }
+    ]
+  }
+}
+```
+
+Response (single select one choice, multi-select multiple):
+```bash
+curl -X POST $BASE_URL/api/v1/workspaces/my-project/respond \
+  -H "Content-Type: application/json" \
+  -d '{
+    "questionId": "def456abc789ab12",
+    "selectedChoices": ["Go", "Auth", "Analytics"],
+    "answer": "Also add OAuth2 integration"
+  }'
+```
+
+### `work-gate`
+
+A decision point requiring explicit approval to proceed. The agent stops until approved.
+
+```json
+{
+  "pendingQuestion": {
+    "questionId": "ghi789xyz123cd45",
+    "type": "work-gate",
+    "agentName": "coordinator",
+    "message": "Ready to begin implementation. Please review the plan and approve.",
+    "questions": [
+      {
+        "question": "Review complete?",
+        "choices": ["Approve and proceed", "Request changes", "Cancel"],
+        "multiSelect": false
+      }
+    ]
+  }
+}
+```
+
+To approve (select the approval choice):
+```bash
+curl -X POST $BASE_URL/api/v1/workspaces/my-project/respond \
+  -H "Content-Type: application/json" \
+  -d '{
+    "questionId": "ghi789xyz123cd45",
+    "selectedChoices": ["Approve and proceed"]
+  }'
+```
+
+## Respond Endpoint
+
+**Endpoint:** `POST /api/v1/workspaces/{name}/respond`
+
+```bash
+curl -X POST $BASE_URL/api/v1/workspaces/{name}/respond \
+  -H "Content-Type: application/json" \
+  -d '{
+    "questionId": "QUESTION_ID_FROM_STATE",
+    "answer": "optional free text",
+    "selectedChoices": ["optional", "choice", "selections"]
+  }'
+```
+
+Request fields:
+| Field | Required | Description |
+|-------|----------|-------------|
+| `questionId` | Yes | Must match the current `pendingQuestion.questionId` |
+| `answer` | No | Free-text answer (used for free-text and as additional context for multi-choice) |
+| `selectedChoices` | No | Array of selected choice strings for multi-choice/work-gate |
+
+Response:
+```json
+{
+  "success": true,
+  "message": "response submitted"
+}
+```
+
+Errors:
+- `409 Conflict` — no pending question, or question expired (stale questionId)
+- `400 Bad Request` — empty response (must provide answer or choices)
+
+## Question ID Handling
+
+The `questionId` is a SHA256 hash of the question content. It changes when the question changes. Always:
+1. Fetch fresh state before responding
+2. Use the `questionId` from the current state
+3. If you get a `409 "question expired"` error, re-fetch state and get the new ID
+
+## Delete a Message
+
+Remove a message from a workspace's message queue.
+
+**Endpoint:** `DELETE /api/v1/workspaces/{name}/messages/{id}`
+
+```bash
+curl -X DELETE $BASE_URL/api/v1/workspaces/my-project/messages/42
+```
+
+Response:
+```json
+{
+  "deleted": true,
+  "id": 42,
+  "message": "message deleted successfully"
+}
+```
+
+## Complete Interaction Loop Example
+
+```bash
+#!/bin/bash
+BASE_URL="http://127.0.0.1:PORT"
+WORKSPACE="my-project"
+
+while true; do
+  STATE=$(curl -s $BASE_URL/api/v1/state)
+  WS=$(echo $STATE | jq --arg name "$WORKSPACE" '.workspaces[] | select(.name == $name)')
+  
+  NEEDS_INPUT=$(echo $WS | jq '.needsInput')
+  RUNNING=$(echo $WS | jq '.running')
+  
+  if [ "$NEEDS_INPUT" = "true" ]; then
+    QUESTION_ID=$(echo $WS | jq -r '.pendingQuestion.questionId')
+    TYPE=$(echo $WS | jq -r '.pendingQuestion.type')
+    MESSAGE=$(echo $WS | jq -r '.pendingQuestion.message')
+    
+    echo "Question ($TYPE): $MESSAGE"
+    
+    # Your harness logic to determine the answer...
+    ANSWER="My response to this question"
+    
+    curl -X POST $BASE_URL/api/v1/workspaces/$WORKSPACE/respond \
+      -H "Content-Type: application/json" \
+      -d "{\"questionId\": \"$QUESTION_ID\", \"answer\": \"$ANSWER\"}"
+  fi
+  
+  sleep 5
+done
+```

--- a/docs/sgai-skills/knowledge/SKILL.md
+++ b/docs/sgai-skills/knowledge/SKILL.md
@@ -1,0 +1,250 @@
+---
+name: knowledge
+description: Access agents, skills, and code snippets available in sgai workspaces. Use when you need to discover what agents are defined in a workspace, browse available skills, get skill instructions, find code snippets by language, or retrieve snippet content for a specific task.
+compatibility: Requires a running sgai server. Knowledge is workspace-scoped (agents/skills/snippets from the workspace .sgai/ directory).
+---
+
+# Knowledge
+
+sgai workspaces contain agent definitions, skills, and code snippets in their `.sgai/` directory. Use these endpoints to discover and retrieve that knowledge.
+
+## List Available Agents
+
+**Endpoint:** `GET /api/v1/agents?workspace={name}`
+
+```bash
+curl -s "$BASE_URL/api/v1/agents?workspace=my-project"
+```
+
+Response:
+```json
+{
+  "agents": [
+    {
+      "name": "coordinator",
+      "description": "Coordinates the work flow between specialized agents."
+    },
+    {
+      "name": "backend-go-developer",
+      "description": "Expert Go backend developer for building production-quality APIs."
+    },
+    {
+      "name": "react-developer",
+      "description": "Frontend developer specializing in React components."
+    }
+  ]
+}
+```
+
+Agents are loaded from `.sgai/agent/*.md` files in the workspace.
+
+## List Available Skills
+
+Skills are organized into categories based on their directory structure.
+
+**Endpoint:** `GET /api/v1/skills?workspace={name}`
+
+```bash
+curl -s "$BASE_URL/api/v1/skills?workspace=my-project"
+```
+
+Response:
+```json
+{
+  "categories": [
+    {
+      "name": "coding-practices",
+      "skills": [
+        {
+          "name": "go-code-review",
+          "fullPath": "coding-practices/go-code-review",
+          "description": "Go code review checklist based on official Go style guides."
+        },
+        {
+          "name": "react-best-practices",
+          "fullPath": "coding-practices/react-best-practices",
+          "description": "React and Next.js performance optimization guidelines."
+        }
+      ]
+    },
+    {
+      "name": "General",
+      "skills": [
+        {
+          "name": "test-driven-development",
+          "fullPath": "test-driven-development",
+          "description": "Write tests first, watch them fail, then implement."
+        }
+      ]
+    }
+  ]
+}
+```
+
+Skills are loaded from `.sgai/skills/*/SKILL.md` files.
+
+## Get Skill Detail
+
+**Endpoint:** `GET /api/v1/skills/{path...}?workspace={name}`
+
+```bash
+# Get a skill at a specific path
+curl -s "$BASE_URL/api/v1/skills/coding-practices/go-code-review?workspace=my-project"
+
+# Get a top-level skill
+curl -s "$BASE_URL/api/v1/skills/test-driven-development?workspace=my-project"
+```
+
+Response:
+```json
+{
+  "name": "go-code-review",
+  "fullPath": "coding-practices/go-code-review",
+  "content": "<rendered HTML of skill content>",
+  "rawContent": "# Go Code Review\n\n## When to Use\n..."
+}
+```
+
+- `content` — HTML-rendered markdown
+- `rawContent` — raw markdown without frontmatter
+
+## List Code Snippets
+
+**Endpoint:** `GET /api/v1/snippets?workspace={name}`
+
+```bash
+curl -s "$BASE_URL/api/v1/snippets?workspace=my-project"
+```
+
+Response:
+```json
+{
+  "languages": [
+    {
+      "name": "go",
+      "snippets": [
+        {
+          "name": "HTTP Server with Routes",
+          "fileName": "http-server-routes",
+          "fullPath": "go/http-server-routes",
+          "description": "Set up an HTTP server with Go 1.22+ enhanced routing.",
+          "language": "go"
+        }
+      ]
+    },
+    {
+      "name": "typescript",
+      "snippets": [
+        {
+          "name": "SSE Client Hook",
+          "fileName": "sse-client",
+          "fullPath": "typescript/sse-client",
+          "description": "React hook for Server-Sent Events with reconnection.",
+          "language": "typescript"
+        }
+      ]
+    }
+  ]
+}
+```
+
+## List Snippets by Language
+
+**Endpoint:** `GET /api/v1/snippets/{lang}?workspace={name}`
+
+```bash
+curl -s "$BASE_URL/api/v1/snippets/go?workspace=my-project"
+```
+
+Response:
+```json
+{
+  "language": "go",
+  "snippets": [
+    {
+      "name": "HTTP Server with Routes",
+      "fileName": "http-server-routes",
+      "fullPath": "go/http-server-routes",
+      "description": "Set up an HTTP server with Go 1.22+ enhanced routing.",
+      "language": "go"
+    }
+  ]
+}
+```
+
+## Get Snippet Detail
+
+**Endpoint:** `GET /api/v1/snippets/{lang}/{fileName}?workspace={name}`
+
+```bash
+curl -s "$BASE_URL/api/v1/snippets/go/http-server-routes?workspace=my-project"
+```
+
+Response:
+```json
+{
+  "name": "HTTP Server with Routes",
+  "fileName": "http-server-routes",
+  "language": "go",
+  "description": "Set up an HTTP server with Go 1.22+ enhanced routing.",
+  "whenToUse": "When defining HTTP routes using net/http ServeMux in Go 1.22+",
+  "content": "package main\n\nimport \"net/http\"\n\nfunc main() {\n..."
+}
+```
+
+## List Available Models
+
+**Endpoint:** `GET /api/v1/models?workspace={name}`
+
+```bash
+curl -s "$BASE_URL/api/v1/models?workspace=my-project"
+```
+
+Response:
+```json
+{
+  "models": [
+    {"id": "anthropic/claude-opus-4-6", "name": "anthropic/claude-opus-4-6"},
+    {"id": "anthropic/claude-sonnet-4-6", "name": "anthropic/claude-sonnet-4-6"},
+    {"id": "openai/gpt-4o", "name": "openai/gpt-4o"}
+  ],
+  "defaultModel": "anthropic/claude-opus-4-6"
+}
+```
+
+The `defaultModel` is the coordinator's model as defined in GOAL.md frontmatter.
+
+## Workspace Query Parameter
+
+All knowledge endpoints accept an optional `?workspace=name` query parameter:
+- If omitted, uses the first workspace found
+- If provided, scopes results to that workspace's `.sgai/` directory
+
+```bash
+# Explicit workspace
+curl -s "$BASE_URL/api/v1/agents?workspace=my-project"
+
+# First workspace (implicit)
+curl -s "$BASE_URL/api/v1/agents"
+```
+
+## Knowledge Directory Structure
+
+The workspace's `.sgai/` directory layout:
+```
+.sgai/
+  agent/
+    coordinator.md       # agent definition files
+    backend-go-developer.md
+  skills/
+    test-driven-development/
+      SKILL.md           # skill definition
+    coding-practices/
+      go-code-review/
+        SKILL.md
+  snippets/
+    go/
+      http-server-routes.go  # code snippets
+    typescript/
+      sse-client.ts
+```

--- a/docs/sgai-skills/monitoring/SKILL.md
+++ b/docs/sgai-skills/monitoring/SKILL.md
@@ -1,0 +1,294 @@
+---
+name: monitoring
+description: Monitor sgai workspace status, events, progress, diffs, and workflow diagrams. Use when you need to observe what agents are doing, track progress, get the current state of all workspaces, subscribe to real-time updates via SSE, or inspect code changes.
+compatibility: Requires a running sgai server. SSE streaming requires a client that supports Server-Sent Events.
+---
+
+# Monitoring
+
+Monitor the sgai factory to understand what agents are doing and track their progress.
+
+## Get Full Factory State
+
+Returns all workspaces and their complete state.
+
+**Endpoint:** `GET /api/v1/state`
+
+```bash
+curl -s $BASE_URL/api/v1/state | jq .
+```
+
+Response:
+```json
+{
+  "workspaces": [
+    {
+      "name": "my-project",
+      "dir": "/path/to/workspaces/my-project",
+      "running": true,
+      "needsInput": false,
+      "inProgress": true,
+      "pinned": false,
+      "isRoot": false,
+      "isFork": false,
+      "hasSgai": true,
+      "status": "working",
+      "badgeClass": "badge-running",
+      "badgeText": "Running",
+      "currentAgent": "backend-go-developer",
+      "currentModel": "anthropic/claude-sonnet-4-6",
+      "task": "Writing authentication endpoints",
+      "latestProgress": "Created JWT middleware",
+      "cost": {
+        "inputTokens": 45000,
+        "outputTokens": 12000,
+        "cacheCreationInputTokens": 8000,
+        "cacheReadInputTokens": 32000
+      },
+      "events": [...],
+      "messages": [...],
+      "projectTodos": [...],
+      "agentTodos": [...],
+      "commits": [...],
+      "log": [...],
+      "pendingQuestion": null,
+      "forks": []
+    }
+  ]
+}
+```
+
+### Key State Fields
+
+| Field | Description |
+|-------|-------------|
+| `running` | Session is active |
+| `needsInput` | Blocked waiting for human response |
+| `inProgress` | Work is actively happening |
+| `status` | Workflow status: "working", "agent-done", "complete", etc. |
+| `currentAgent` | Currently executing agent |
+| `task` | Current task being worked on |
+| `latestProgress` | Most recent progress note |
+| `pendingQuestion` | Non-null when human input needed |
+| `badgeText` | Human-readable status badge |
+
+### Cost Tracking
+
+```json
+"cost": {
+  "inputTokens": 45000,
+  "outputTokens": 12000,
+  "cacheCreationInputTokens": 8000,
+  "cacheReadInputTokens": 32000
+}
+```
+
+### Event Timeline
+
+```json
+"events": [
+  {
+    "timestamp": "2026-02-27T17:00:00Z",
+    "formattedTime": "5:00 PM",
+    "agent": "coordinator",
+    "description": "Planning implementation",
+    "showDateDivider": false,
+    "dateDivider": ""
+  }
+]
+```
+
+### Agent Messages
+
+```json
+"messages": [
+  {
+    "id": 42,
+    "fromAgent": "coordinator",
+    "toAgent": "backend-go-developer",
+    "body": "Please implement the authentication module",
+    "subject": "Implement auth",
+    "read": true,
+    "readAt": "2026-02-27T17:00:01Z",
+    "createdAt": "2026-02-27T17:00:00Z"
+  }
+]
+```
+
+## Get Single Workspace State
+
+Equivalent to filtering state by workspace name:
+
+```bash
+curl -s $BASE_URL/api/v1/state | jq '.workspaces[] | select(.name == "my-project")'
+```
+
+Or use the MCP tool `get_workspace_state`:
+```
+get_workspace_state(workspace: "my-project")
+```
+
+## Real-Time Updates via SSE
+
+Subscribe to state change notifications.
+
+**Endpoint:** `GET /api/v1/signal`
+
+```bash
+curl -s -N $BASE_URL/api/v1/signal
+```
+
+Events emitted:
+```
+event: reload
+data: {}
+
+event: reload
+data: {}
+```
+
+Each `reload` event means state has changed. Fetch `/api/v1/state` after receiving one.
+
+### SSE with Reconnection
+
+```bash
+#!/bin/bash
+while true; do
+  curl -s -N "$BASE_URL/api/v1/signal" | while IFS= read -r line; do
+    if [[ "$line" == "event: reload" ]]; then
+      echo "State changed, fetching..."
+      curl -s $BASE_URL/api/v1/state > /tmp/latest-state.json
+    fi
+  done
+  echo "SSE disconnected, reconnecting..."
+  sleep 2
+done
+```
+
+## Get Workspace Diff
+
+Get the current code changes (jj diff) for a workspace.
+
+**Endpoint:** `GET /api/v1/workspaces/{name}/diff`
+
+```bash
+curl -s $BASE_URL/api/v1/workspaces/my-project/diff
+```
+
+Response:
+```json
+{
+  "diff": "diff --git a/cmd/api/auth.go b/cmd/api/auth.go\nnew file mode 100644\n..."
+}
+```
+
+## Get Workflow SVG Diagram
+
+Get a visual diagram of the agent workflow.
+
+**Endpoint:** `GET /api/v1/workspaces/{name}/workflow.svg`
+
+```bash
+# Save to file
+curl -s $BASE_URL/api/v1/workspaces/my-project/workflow.svg > workflow.svg
+
+# Or open directly in browser
+open $BASE_URL/api/v1/workspaces/my-project/workflow.svg
+```
+
+Returns SVG with the agent flow graph. The current agent is highlighted.
+
+## Monitor Agent Sequence
+
+The `agentSequence` field shows the execution history:
+
+```bash
+curl -s $BASE_URL/api/v1/state | jq '.workspaces[0].agentSequence'
+```
+
+Response:
+```json
+[
+  {
+    "agent": "coordinator",
+    "model": "anthropic/claude-opus-4-6",
+    "elapsedTime": "2m 15s",
+    "isCurrent": false
+  },
+  {
+    "agent": "backend-go-developer",
+    "model": "anthropic/claude-sonnet-4-6",
+    "elapsedTime": "8m 42s",
+    "isCurrent": true
+  }
+]
+```
+
+## Monitor Todos
+
+Check what the agent has planned:
+
+```bash
+# Project-level todos (from TodoWrite)
+curl -s $BASE_URL/api/v1/state | jq '.workspaces[0].projectTodos'
+
+# Agent-level todos (current agent's todo list)
+curl -s $BASE_URL/api/v1/state | jq '.workspaces[0].agentTodos'
+```
+
+Todo format:
+```json
+[
+  {
+    "id": "todo-1",
+    "content": "Implement JWT authentication",
+    "status": "in_progress",
+    "priority": "high"
+  }
+]
+```
+
+## Monitor Commit History
+
+```bash
+curl -s $BASE_URL/api/v1/state | jq '.workspaces[0].commits'
+```
+
+Response:
+```json
+[
+  {
+    "changeId": "abc123",
+    "commitId": "def456",
+    "timestamp": "2026-02-27T17:00:00Z",
+    "bookmarks": ["main"],
+    "description": "cmd/api: add authentication endpoints",
+    "graphChar": "◆"
+  }
+]
+```
+
+## Monitor Fork Status
+
+For root workspaces, check their forks:
+
+```bash
+curl -s $BASE_URL/api/v1/state | jq '.workspaces[] | select(.isRoot) | .forks'
+```
+
+Fork entry:
+```json
+[
+  {
+    "name": "feature-auth",
+    "dir": "/path/to/workspaces/feature-auth",
+    "running": true,
+    "needsInput": false,
+    "inProgress": true,
+    "pinned": false,
+    "commitAhead": 3,
+    "commits": [...],
+    "summary": "Implementing auth"
+  }
+]
+```

--- a/docs/sgai-skills/session-control/SKILL.md
+++ b/docs/sgai-skills/session-control/SKILL.md
@@ -1,0 +1,190 @@
+---
+name: session-control
+description: Start, stop, and steer agentic sessions in sgai workspaces. Use when you need to launch AI agent sessions, halt running sessions, or inject steering instructions to guide the agent mid-execution without stopping it.
+compatibility: Requires a running sgai server with workspaces that have a GOAL.md configured.
+---
+
+# Session Control
+
+Sessions are the running instances of AI agents working on a workspace. Each workspace can have at most one running session.
+
+## Start a Session
+
+**Endpoint:** `POST /api/v1/workspaces/{name}/start`
+
+```bash
+# Brainstorming mode (interactive, pauses for human input)
+curl -X POST $BASE_URL/api/v1/workspaces/my-project/start \
+  -H "Content-Type: application/json" \
+  -d '{"auto": false}'
+
+# Self-drive mode (fully autonomous, no pausing)
+curl -X POST $BASE_URL/api/v1/workspaces/my-project/start \
+  -H "Content-Type: application/json" \
+  -d '{"auto": true}'
+```
+
+Request:
+```json
+{"auto": true}
+```
+
+Response:
+```json
+{
+  "name": "my-project",
+  "status": "running",
+  "running": true,
+  "message": "session started"
+}
+```
+
+### Session Modes
+
+| Mode | `auto` | Description |
+|------|--------|-------------|
+| Brainstorming | `false` | Pauses at key decision points to ask for input |
+| Self-drive | `true` | Runs fully autonomously without interruption |
+| Continuous | (auto-detected) | If workspace has a `continuous.md` prompt, uses continuous mode |
+
+Notes:
+- Root workspaces cannot start agentic work (only forks/standalone can)
+- If already running, returns `"message": "session already running"`
+
+## Stop a Session
+
+**Endpoint:** `POST /api/v1/workspaces/{name}/stop`
+
+```bash
+curl -X POST $BASE_URL/api/v1/workspaces/my-project/stop
+```
+
+Response:
+```json
+{
+  "name": "my-project",
+  "status": "stopped",
+  "running": false,
+  "message": "session stopped"
+}
+```
+
+If already stopped: `"message": "session already stopped"`
+
+## Steer an Agent
+
+Inject a steering instruction into a running session without stopping it. The message is delivered to the coordinator agent via the message queue.
+
+**Endpoint:** `POST /api/v1/workspaces/{name}/steer`
+
+```bash
+curl -X POST $BASE_URL/api/v1/workspaces/my-project/steer \
+  -H "Content-Type: application/json" \
+  -d '{"message": "Focus on the authentication module first, skip the dashboard for now"}'
+```
+
+Request:
+```json
+{"message": "Focus on the authentication module first, skip the dashboard for now"}
+```
+
+Response:
+```json
+{
+  "success": true,
+  "message": "steering instruction added"
+}
+```
+
+Notes:
+- The steering message is prefixed with "Re-steering instruction: " internally
+- Messages are inserted at the front of the unread message queue so they are processed next
+- This works while a session is running or even when stopped (message queued for next run)
+
+## Get Workflow SVG
+
+Get the workflow diagram showing agent flow and current position.
+
+**Endpoint:** `GET /api/v1/workspaces/{name}/workflow.svg`
+
+```bash
+curl -s $BASE_URL/api/v1/workspaces/my-project/workflow.svg > workflow.svg
+```
+
+Response: SVG image (`Content-Type: image/svg+xml`)
+
+Returns 404 if workflow SVG is not available.
+
+## Check Running Status
+
+Use the full state endpoint to check session status:
+
+```bash
+STATE=$(curl -s $BASE_URL/api/v1/state)
+RUNNING=$(echo $STATE | jq '.workspaces[] | select(.name=="my-project") | .running')
+AGENT=$(echo $STATE | jq -r '.workspaces[] | select(.name=="my-project") | .currentAgent')
+TASK=$(echo $STATE | jq -r '.workspaces[] | select(.name=="my-project") | .task')
+```
+
+Key workspace state fields for session monitoring:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `running` | bool | Is session active? |
+| `inProgress` | bool | Is work actively happening? |
+| `currentAgent` | string | Which agent is currently running |
+| `currentModel` | string | Which model is being used |
+| `task` | string | Current task description |
+| `status` | string | Workflow status string |
+| `latestProgress` | string | Most recent progress note |
+
+## Open in OpenCode (Local Only)
+
+Open the workspace in OpenCode terminal (localhost connections only).
+
+**Endpoint:** `POST /api/v1/workspaces/{name}/open-opencode`
+
+```bash
+curl -X POST http://localhost:PORT/api/v1/workspaces/my-project/open-opencode
+```
+
+Response:
+```json
+{
+  "opened": true,
+  "message": "opened in opencode"
+}
+```
+
+Errors:
+- `403` — remote connections not allowed (localhost only)
+- `409` — session not running
+
+## Open in Editor
+
+Open the workspace directory in the configured editor (VS Code, etc.).
+
+**Endpoint:** `POST /api/v1/workspaces/{name}/open-editor`
+
+```bash
+curl -X POST $BASE_URL/api/v1/workspaces/my-project/open-editor
+```
+
+Response:
+```json
+{
+  "opened": true,
+  "editor": "code",
+  "message": "opened in editor"
+}
+```
+
+### Open Specific Files
+
+```bash
+# Open GOAL.md in editor
+curl -X POST $BASE_URL/api/v1/workspaces/my-project/open-editor/goal
+
+# Open PROJECT_MANAGEMENT.md in editor
+curl -X POST $BASE_URL/api/v1/workspaces/my-project/open-editor/project-management
+```

--- a/docs/sgai-skills/using-sgai/SKILL.md
+++ b/docs/sgai-skills/using-sgai/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: using-sgai
+description: Drive sgai (Software Garden AI) from any MCP-capable harness or AI agent. Covers the cyclical probe/poll/act workflow for managing AI software factory workspaces, sessions, and human interaction. Use this as the entrypoint when orchestrating sgai from Claude Code, Codex, or any AI harness.
+compatibility: Requires a running sgai server (sgai serve). Works with any HTTP client or MCP-capable harness.
+---
+
+# Using sgai from an AI Harness
+
+sgai is a software factory system that runs AI agents in workspaces. This skill teaches you to drive it via the HTTP API or MCP tools.
+
+## Quick Start: Base URL
+
+All examples assume `BASE_URL=http://127.0.0.1:PORT` where PORT is shown in the server startup log:
+```
+sgai serve listening on http://127.0.0.1:PORT
+```
+
+The MCP endpoint is at `/mcp/external` on the same server (e.g. `http://127.0.0.1:PORT/mcp/external`).
+
+## The Cyclical Probe/Poll/Act Loop
+
+The core pattern for driving sgai is a continuous loop:
+
+```
+LOOP:
+  1. PROBE  → GET /api/v1/state          # Discover all workspaces + status
+  2. CHECK  → pendingQuestion != null?   # Does any workspace need human input?
+  3. ACT    → based on workspace status  # Start, steer, respond, or wait
+  4. WAIT   → poll again after delay     # Repeat
+```
+
+### Step 1: Probe — Get Factory State
+
+```bash
+curl -s $BASE_URL/api/v1/state
+```
+
+Response shape:
+```json
+{
+  "workspaces": [
+    {
+      "name": "my-project",
+      "running": false,
+      "needsInput": false,
+      "inProgress": false,
+      "status": "agent-done",
+      "currentAgent": "coordinator",
+      "task": "Planning implementation",
+      "pendingQuestion": null
+    }
+  ]
+}
+```
+
+Key fields to check per workspace:
+- `running` — is a session active?
+- `needsInput` — does the agent need a human response?
+- `pendingQuestion` — non-null when human input is required
+- `status` — current workflow status string
+- `inProgress` — is work actively happening?
+
+### Step 2: Check for Pending Questions
+
+When `workspace.pendingQuestion != null`, the agent is blocked waiting for human input.
+
+```json
+{
+  "pendingQuestion": {
+    "questionId": "abc123def456",
+    "type": "free-text",
+    "agentName": "coordinator",
+    "message": "Which approach should we take?",
+    "questions": []
+  }
+}
+```
+
+Question types:
+- `"free-text"` — respond with a text answer
+- `"multi-choice"` — select from provided choices
+- `"work-gate"` — approve to proceed (select approval text)
+
+### Step 3: Act Based on Status
+
+| Workspace State | Action |
+|----------------|--------|
+| `needsInput: true` | Call respond endpoint with answer |
+| `running: false` and has goal | Start session |
+| `running: true` | Monitor / optionally steer |
+| Session complete | Check results, start next task |
+
+### Step 4: Respond to Questions
+
+```bash
+# Free-text response
+curl -s -X POST $BASE_URL/api/v1/workspaces/{name}/respond \
+  -H "Content-Type: application/json" \
+  -d '{"questionId": "abc123def456", "answer": "Use the microservice approach"}'
+
+# Multi-choice response
+curl -s -X POST $BASE_URL/api/v1/workspaces/{name}/respond \
+  -H "Content-Type: application/json" \
+  -d '{"questionId": "abc123def456", "selectedChoices": ["Option A"]}'
+```
+
+## Sub-skills
+
+For detailed documentation on specific operations:
+
+- [workspace-management](../workspace-management/SKILL.md) — Create, fork, delete, rename workspaces
+- [session-control](../session-control/SKILL.md) — Start/stop sessions, steer agents
+- [human-interaction](../human-interaction/SKILL.md) — Respond to questions and work gates
+- [monitoring](../monitoring/SKILL.md) — List workspaces, get state, diffs, SVGs
+- [knowledge](../knowledge/SKILL.md) — Agents, skills, snippets
+- [compose](../compose/SKILL.md) — Compose wizard: state, save, preview, draft, templates
+- [adhoc](../adhoc/SKILL.md) — Ad-hoc prompt start/stop/status
+
+## MCP Interface
+
+If using the MCP interface instead of HTTP, all tools are available at `/mcp/external`:
+
+```bash
+# List all 38 tools
+npx mcporter list --http-url http://HOST:PORT/mcp/external --allow-http
+```
+
+Key MCP tools mirror the HTTP API:
+- `list_workspaces` → GET /api/v1/state
+- `start_session` → POST /api/v1/workspaces/{name}/start
+- `respond_to_question` → POST /api/v1/workspaces/{name}/respond
+- `wait_for_question` → polls + elicitation (MCP only)
+
+## Real-Time Updates via SSE
+
+Subscribe to state changes instead of polling:
+
+```bash
+curl -s -N $BASE_URL/api/v1/signal
+# Emits: event: reload\ndata: {}\n\n
+```
+
+When you receive a `reload` event, re-fetch `/api/v1/state`.
+
+## Common Workflow: Start a Project End-to-End
+
+```bash
+# 1. Create workspace
+curl -X POST $BASE_URL/api/v1/workspaces \
+  -d '{"name": "my-project"}'
+
+# 2. Write a GOAL.md
+curl -X PUT $BASE_URL/api/v1/workspaces/my-project/goal \
+  -d '{"content": "# My Goal\n- [ ] Build the feature"}'
+
+# 3. Start session in auto (self-drive) mode
+curl -X POST $BASE_URL/api/v1/workspaces/my-project/start \
+  -d '{"auto": true}'
+
+# 4. Poll for completion
+while true; do
+  STATE=$(curl -s $BASE_URL/api/v1/state)
+  NEEDS_INPUT=$(echo $STATE | jq '.workspaces[0].needsInput')
+  if [ "$NEEDS_INPUT" = "true" ]; then
+    # Handle question...
+  fi
+  sleep 5
+done
+```

--- a/docs/sgai-skills/workspace-management/SKILL.md
+++ b/docs/sgai-skills/workspace-management/SKILL.md
@@ -1,0 +1,249 @@
+---
+name: workspace-management
+description: Create, fork, delete, and rename sgai workspaces via the HTTP API. Use when you need to set up new project workspaces, create parallel forks for concurrent development, clean up finished forks, or rename existing fork workspaces.
+compatibility: Requires a running sgai server. Workspace names must use lowercase letters, numbers, and dashes only.
+---
+
+# Workspace Management
+
+Workspaces are directories managed by sgai. There are three kinds:
+- **Standalone** — independent workspace, not part of a fork tree
+- **Root** — has one or more fork children (displayed in dashboard/fork mode)
+- **Fork** — child of a root workspace, shares the jj VCS repository
+
+## Create a Workspace
+
+**Endpoint:** `POST /api/v1/workspaces`
+
+```bash
+curl -X POST $BASE_URL/api/v1/workspaces \
+  -H "Content-Type: application/json" \
+  -d '{"name": "my-project"}'
+```
+
+Request:
+```json
+{"name": "my-project"}
+```
+
+Response (201 Created):
+```json
+{
+  "name": "my-project",
+  "dir": "/path/to/workspaces/my-project"
+}
+```
+
+Errors:
+- `400` — invalid name (must be lowercase letters, numbers, dashes)
+- `409` — directory already exists
+
+### Name Validation Rules
+- Only lowercase letters (a-z), numbers (0-9), and dashes (-)
+- Cannot start or end with a dash
+- No spaces or special characters
+
+## Fork a Workspace
+
+Create a jj workspace fork for parallel development.
+
+**Endpoint:** `POST /api/v1/workspaces/{name}/fork`
+
+```bash
+curl -X POST $BASE_URL/api/v1/workspaces/my-project/fork \
+  -H "Content-Type: application/json" \
+  -d '{"name": "feature-branch"}'
+```
+
+Request:
+```json
+{"name": "feature-branch"}
+```
+
+Response (201 Created):
+```json
+{
+  "name": "feature-branch",
+  "dir": "/path/to/workspaces/feature-branch",
+  "parent": "my-project",
+  "createdAt": ""
+}
+```
+
+Notes:
+- Only standalone or root workspaces can be forked (forks cannot fork)
+- Fork names are normalized (spaces become dashes, etc.)
+- The fork shares the jj repository with the root via `jj workspace add`
+
+## Delete a Fork
+
+**Endpoint:** `POST /api/v1/workspaces/{name}/delete-fork`
+
+Where `{name}` is the **root** workspace name.
+
+```bash
+curl -X POST $BASE_URL/api/v1/workspaces/my-project/delete-fork \
+  -H "Content-Type: application/json" \
+  -d '{"forkDir": "/full/path/to/fork", "confirm": true}'
+```
+
+Request:
+```json
+{
+  "forkDir": "/full/path/to/workspaces/feature-branch",
+  "confirm": true
+}
+```
+
+Response:
+```json
+{
+  "deleted": true,
+  "message": "fork deleted successfully"
+}
+```
+
+Notes:
+- `confirm: true` is required (safety guard)
+- The running session is stopped before deletion
+- Uses `jj workspace forget` then removes the directory
+- When a root workspace runs out of forks, it reverts from Fork Mode to Repository Mode
+
+## Rename a Fork
+
+Only fork workspaces can be renamed (not standalone or root).
+
+**Endpoint:** `POST /api/v1/workspaces/{name}/rename`
+
+```bash
+curl -X POST $BASE_URL/api/v1/workspaces/feature-branch/rename \
+  -H "Content-Type: application/json" \
+  -d '{"name": "new-feature-name"}'
+```
+
+Request:
+```json
+{"name": "new-feature-name"}
+```
+
+Response:
+```json
+{
+  "name": "new-feature-name",
+  "oldName": "feature-branch",
+  "dir": "/path/to/workspaces/new-feature-name"
+}
+```
+
+Errors:
+- `400` — workspace is not a fork
+- `409` — session is running (stop first) or name conflict
+
+## Toggle Pin
+
+Pin workspaces to keep them prioritized at the top of the list.
+
+**Endpoint:** `POST /api/v1/workspaces/{name}/pin`
+
+```bash
+curl -X POST $BASE_URL/api/v1/workspaces/my-project/pin
+```
+
+Response:
+```json
+{
+  "pinned": true,
+  "message": "pin toggled"
+}
+```
+
+## Update Workspace Summary
+
+Set a human-readable summary for a workspace (shown in the UI).
+
+**Endpoint:** `PUT /api/v1/workspaces/{name}/summary`
+
+```bash
+curl -X PUT $BASE_URL/api/v1/workspaces/my-project/summary \
+  -H "Content-Type: application/json" \
+  -d '{"summary": "Implementing authentication module"}'
+```
+
+Response:
+```json
+{
+  "updated": true,
+  "summary": "Implementing authentication module",
+  "workspace": "my-project"
+}
+```
+
+## Update Commit Description
+
+Update the jj commit description for the current working copy.
+
+**Endpoint:** `POST /api/v1/workspaces/{name}/description`
+
+```bash
+curl -X POST $BASE_URL/api/v1/workspaces/my-project/description \
+  -H "Content-Type: application/json" \
+  -d '{"description": "feat: add authentication endpoints"}'
+```
+
+Response:
+```json
+{
+  "updated": true,
+  "description": "feat: add authentication endpoints"
+}
+```
+
+## Get GOAL.md
+
+**Endpoint:** `GET /api/v1/workspaces/{name}/goal`
+
+```bash
+curl -s $BASE_URL/api/v1/workspaces/my-project/goal
+```
+
+Response:
+```json
+{
+  "content": "---\nflow: ...\n---\n\n- [ ] Task 1\n"
+}
+```
+
+## Update GOAL.md
+
+**Endpoint:** `PUT /api/v1/workspaces/{name}/goal`
+
+```bash
+curl -X PUT $BASE_URL/api/v1/workspaces/my-project/goal \
+  -H "Content-Type: application/json" \
+  -d '{"content": "- [ ] Build the auth system\n- [ ] Write tests\n"}'
+```
+
+Response:
+```json
+{
+  "updated": true,
+  "workspace": "my-project"
+}
+```
+
+## Get Workspace Diff
+
+Get the current jj diff for a workspace.
+
+**Endpoint:** `GET /api/v1/workspaces/{name}/diff`
+
+```bash
+curl -s $BASE_URL/api/v1/workspaces/my-project/diff
+```
+
+Response:
+```json
+{
+  "diff": "diff --git a/file.go b/file.go\n..."
+}
+```

--- a/opencode.json
+++ b/opencode.json
@@ -17,6 +17,11 @@
         "-y",
         "@upstash/context7-mcp"
       ]
+    },
+    "sgai": {
+      "type": "remote",
+      "url": "http://127.0.0.1:8080/mcp/external",
+      "enabled": true
     }
   }
 }


### PR DESCRIPTION
## Summary

- Add `/mcp/external` streamable HTTP endpoint with 38 tools providing full parity to web UI HTTP API
- Service layer refactor: extract business logic into `service_*.go` files
- MCP elicitation support: `wait_for_question` tool with proactive question delivery
- Add `docs/sgai-skills/` with 8 agentskills.io-compliant SKILL.md files for HTTP-capable harnesses
- Validate MCP server with mcporter: all 38 tools listed successfully
- Update README.md with MCP and skills integration instructions including OpenCode configuration example
- Archive GOAL.md into `GOALS/2026_02_27_add_external_mcp_server_and_skills.md`