### PR TITLE
cmd/sgai: improve commit tab with tabled list and workspace-aware filtering

### DIFF
--- a/GOALS/2026_02_24_commit_tab_improvement.md
+++ b/GOALS/2026_02_24_commit_tab_improvement.md
@@ -1,0 +1,31 @@
+---
+flow: |
+  "backend-go-developer" -> "go-readability-reviewer"
+  "react-developer" -> "react-reviewer"
+  "general-purpose"
+  "go-readability-reviewer"
+  "project-critic-council"
+  "skill-writer"
+  "stpa-analyst"
+models:
+  "coordinator": "anthropic/claude-opus-4-6 (max)"
+  "backend-go-developer": "anthropic/claude-sonnet-4-6"
+  "go-readability-reviewer": "anthropic/claude-opus-4-6"
+  "general-purpose": "anthropic/claude-sonnet-4-6"
+  "react-developer": "anthropic/claude-sonnet-4-6"
+  "react-reviewer": "anthropic/claude-opus-4-6"
+  "stpa-analyst": "anthropic/claude-opus-4-6"
+  "project-critic-council": ["anthropic/claude-opus-4-6"]
+  "skill-writer": "anthropic/claude-opus-4-6 (max)"
+completionGateScript: make test
+---
+
+
+The commit tab needs improvement. 
+
+- [x] For all repositories, the list has to be a simple tabled list. 
+
+- [x] For standalone repositories the list should start from where the origin remote is
+
+- [x] For forked repositories the list should start from the root repository head
+

--- a/cmd/sgai/skel/.sgai/skills/coding-practices/go-code-review/SKILL.md
+++ b/cmd/sgai/skel/.sgai/skills/coding-practices/go-code-review/SKILL.md
@@ -288,6 +288,71 @@ func Lookup(key string) (value string, ok bool)
 func Lookup(key string) string  // returns "" on not found
 ```
 
+## Switch Statements
+
+### Direct Evaluation
+
+- [ ] Use switch with expressions for cleaner multi-way conditionals
+- [ ] Prefer switch over long if-else chains
+- [ ] Switch evaluates cases top-to-bottom, first match wins
+- [ ] No need for break statements (they're automatic)
+
+```go
+// GOOD - switch with direct evaluation
+switch status := getStatus(); status {
+case StatusPending:
+    return "pending"
+case StatusActive:
+    return "active"
+case StatusDone:
+    return "done"
+default:
+    return "unknown"
+}
+
+// BAD - long if-else chain
+if status := getStatus(); status == StatusPending {
+    return "pending"
+} else if status == StatusActive {
+    return "active"
+} else if status == StatusDone {
+    return "done"
+} else {
+    return "unknown"
+}
+```
+
+### Type Switches
+
+- [ ] Use type switches for interface type assertions
+- [ ] Use comma-ok idiom for safe type assertion
+
+```go
+// Type switch
+var i interface{} = "hello"
+switch v := i.(type) {
+case string:
+    fmt.Println("string:", v)
+case int:
+    fmt.Println("int:", v)
+default:
+    fmt.Println("unknown type")
+}
+```
+
+### Fallthrough
+
+- [ ] Avoid fallthrough unless intentional
+- [ ] Use comma-separated cases when multiple values need same handling
+
+```go
+// GOOD - comma-separated cases
+switch kind {
+case "admin", "owner", "superadmin":
+    grantFullAccess()
+}
+```
+
 ## Modern Go Idioms (Go 1.21+)
 
 ### Standard Library Preferences
@@ -387,6 +452,7 @@ For fast reviews, check these critical items:
 7. **Context** - First param when used
 8. **Interfaces** - At consumer, not producer
 9. **Modern idioms** - Uses slices/maps packages where applicable
+10. **Switch statements** - Use switch for multi-way conditionals
 
 ## Review Output Format
 

--- a/cmd/sgai/webapp/src/pages/tabs/CommitsTab.test.tsx
+++ b/cmd/sgai/webapp/src/pages/tabs/CommitsTab.test.tsx
@@ -106,4 +106,16 @@ describe("CommitsTab", () => {
     const calledUrl = (mockFetch.mock.calls[0] as unknown[])[0] as string;
     expect(calledUrl).toContain("/api/v1/workspaces/test-project/commits");
   });
+
+  it("renders table headers", async () => {
+    mockFetch.mockResolvedValue(new Response(JSON.stringify(commitsResponse)));
+    renderCommitsTab();
+
+    await waitFor(() => {
+      expect(screen.getByText("Change ID")).toBeDefined();
+    });
+
+    expect(screen.getByText("Time")).toBeDefined();
+    expect(screen.getByText("Description")).toBeDefined();
+  });
 });

--- a/sgai.json
+++ b/sgai.json
@@ -13,6 +13,12 @@
       "description": "Fetch and rebase against upstream main branch"
     },
     {
+      "name": "Absorb Overlay Directory",
+      "model": "anthropic/claude-opus-4-6 (max)",
+      "prompt": "run bash(`make absorb-sgai`)",
+      "description": "Absorb sgai/ into cmd/sgai/skel/.sgai/"
+    },
+    {
       "name": "Deploy",
       "model": "anthropic/claude-opus-4-6 (max)",
       "prompt": "run bash(`make deploy`)",


### PR DESCRIPTION
## Summary

- Refactor commit list from card-based layout to a proper table using shadcn/ui Table component with columns for Change ID, Commit ID, Time, Bookmarks, and Description
- Add workspace-aware commit filtering: standalone repositories show commits from remote bookmarks to HEAD, forked repositories show commits from root repository base bookmark
- Add go-code-review skill with comprehensive checklist based on official Go style guides
