### PR TITLE
cmd/sgai: prune nonexistent directories from pinned.json on load

### DIFF
--- a/GOALS/2026_02_24_prune_nonexistent_pinned_directories.md
+++ b/GOALS/2026_02_24_prune_nonexistent_pinned_directories.md
@@ -1,0 +1,23 @@
+---
+flow: |
+  "backend-go-developer" -> "go-readability-reviewer"
+  "react-developer" -> "react-reviewer"
+  "general-purpose"
+  "go-readability-reviewer"
+  "project-critic-council"
+  "skill-writer"
+  "stpa-analyst"
+models:
+  "coordinator": "anthropic/claude-opus-4-6 (max)"
+  "backend-go-developer": "anthropic/claude-sonnet-4-6"
+  "go-readability-reviewer": "anthropic/claude-opus-4-6"
+  "general-purpose": "anthropic/claude-sonnet-4-6"
+  "react-developer": "anthropic/claude-sonnet-4-6"
+  "react-reviewer": "anthropic/claude-opus-4-6"
+  "stpa-analyst": "anthropic/claude-opus-4-6"
+  "project-critic-council": ["anthropic/claude-opus-4-6"]
+  "skill-writer": "anthropic/claude-opus-4-6 (max)"
+completionGateScript: make test
+---
+
+- [x] When a repository is deleted, the pinned repository stays stuck in the pinned list; the json file needs to be pruned as directories disappear.


### PR DESCRIPTION
## Summary

- Prune nonexistent directories from `pinned.json` on load so deleted repositories no longer stay stuck in the pinned list.
- Archive GOAL.md into `GOALS/2026_02_24_prune_nonexistent_pinned_directories.md`.