### PR TITLE
cmd/sgai/webapp: add workspace name and summary to response multi-choice card

### DIFF
--- a/GOALS/2026_02_25_workspace_name_in_respond_page.md
+++ b/GOALS/2026_02_25_workspace_name_in_respond_page.md
@@ -1,0 +1,32 @@
+---
+flow: |
+  "backend-go-developer" -> "go-readability-reviewer"
+  "react-developer" -> "react-reviewer"
+  "general-purpose"
+  "project-critic-council"
+  "skill-writer"
+  "stpa-analyst"
+  "c4-code"
+  "c4-component"
+  "c4-container"
+  "c4-context"
+models:
+  "coordinator": "anthropic/claude-opus-4-6 (max)"
+  "backend-go-developer": "anthropic/claude-opus-4-6"
+  "c4-code": "anthropic/claude-sonnet-4-6"
+  "c4-component": "anthropic/claude-sonnet-4-6"
+  "c4-container": "anthropic/claude-sonnet-4-6"
+  "c4-context": "anthropic/claude-sonnet-4-6"
+  "general-purpose": "anthropic/claude-opus-4-6"
+  "go-readability-reviewer": "anthropic/claude-opus-4-6"
+  "project-critic-council": ["anthropic/claude-opus-4-6"]
+  "react-developer": "anthropic/claude-opus-4-6"
+  "react-reviewer": "anthropic/claude-opus-4-6"
+  "skill-writer": "anthropic/claude-opus-4-6 (max)"
+  "stpa-analyst": "anthropic/claude-opus-4-6 (max)"
+completionGateScript: make test
+---
+
+Consider this route: `/workspaces/$workspace/respond`
+
+- [x] I want you to add the Workspace name and the workspace brief summary at the top so that I can more easily know what I am responding to.

--- a/cmd/sgai/webapp/src/pages/ResponseMultiChoice.tsx
+++ b/cmd/sgai/webapp/src/pages/ResponseMultiChoice.tsx
@@ -127,6 +127,18 @@ export function ResponseMultiChoice() {
             </Link>
             <CardTitle className="text-lg">Response Required</CardTitle>
           </div>
+          {workspaceDetail?.name && (
+            <div>
+              <p className="text-base font-semibold" data-testid="workspace-name">
+                {workspaceDetail.name}
+              </p>
+              {workspaceDetail.summary && (
+                <p className="text-sm text-muted-foreground" data-testid="workspace-summary">
+                  {workspaceDetail.summary}
+                </p>
+              )}
+            </div>
+          )}
           <Badge variant="secondary" className="w-fit">
             Agent: {question.agentName}
           </Badge>


### PR DESCRIPTION
## Summary

- Add workspace name and brief summary display at the top of the response multi-choice page so users can easily identify what workspace they are responding to
- Archive GOAL.md into GOALS/2026_02_25_workspace_name_in_respond_page.md