### PR TITLE
cmd/sgai: filter left tree directories to require .sgai or GOAL.md

### DIFF
--- a/GOALS/2026_02_25_improve_left_tree.md
+++ b/GOALS/2026_02_25_improve_left_tree.md
@@ -1,0 +1,26 @@
+---
+flow: |
+  "backend-go-developer" -> "go-readability-reviewer"
+  "react-developer" -> "react-reviewer"
+  "general-purpose"
+  "go-readability-reviewer"
+  "project-critic-council"
+  "skill-writer"
+  "stpa-analyst"
+models:
+  "coordinator": "opencode/kimi-k2.5"
+  "backend-go-developer": "opencode/kimi-k2.5"
+  "go-readability-reviewer": "opencode/kimi-k2.5"
+  "general-purpose": "opencode/kimi-k2.5"
+  "react-developer": "opencode/kimi-k2.5"
+  "react-reviewer": "opencode/kimi-k2.5"
+  "stpa-analyst": "opencode/kimi-k2.5"
+  "project-critic-council": ["opencode/kimi-k2.5"]
+  "skill-writer": "opencode/kimi-k2.5"
+completionGateScript: make test
+---
+
+The web interface needs some improvement on the directory list on the left.
+
+- [x] on the left tree, below the pinned repositories list, list only directories that has either .sgai or GOAL.md
+   - [x] if a directory has the GOAL.md present but `.sgai` directory is absent, then create an empty `.sgai` folder and show the workspace

--- a/cmd/sgai/serve.go
+++ b/cmd/sgai/serve.go
@@ -64,14 +64,25 @@ func scanForProjects(rootDir string) ([]project, error) {
 
 		dirPath := filepath.Join(rootDir, entry.Name())
 		sgaiDir := filepath.Join(dirPath, ".sgai")
+		goalPath := filepath.Join(dirPath, "GOAL.md")
 
-		hasWorkspace := false
+		sgaiInfo, errStatSGAI := os.Stat(sgaiDir)
+		hasWorkspace := errStatSGAI == nil && sgaiInfo.IsDir()
+
+		_, errStatGoal := os.Stat(goalPath)
+		hasGoalMD := errStatGoal == nil
+
+		if !hasWorkspace && !hasGoalMD {
+			continue
+		}
+
 		var modTime time.Time
-		sgaiInfo, errsgai := os.Stat(sgaiDir)
-		if errsgai == nil && sgaiInfo.IsDir() {
-			hasWorkspace = true
+		if hasWorkspace {
 			modTime = sgaiInfo.ModTime()
-		} else {
+		} else if hasGoalMD {
+			if errMkdir := os.MkdirAll(sgaiDir, 0755); errMkdir == nil {
+				hasWorkspace = true
+			}
 			entryInfo, errEntry := entry.Info()
 			if errEntry == nil {
 				modTime = entryInfo.ModTime()


### PR DESCRIPTION
## Summary

- Filter the left tree to only show directories that have `.sgai` or `GOAL.md`, hiding directories that have neither.
- Auto-create an empty `.sgai` directory for projects that only have `GOAL.md` so they appear as workspaces.
- Archive completed goal spec to `GOALS/2026_02_25_improve_left_tree.md`.