### PR TITLE
cmd/sgai: fix needsInputCount double-counting by deduplicating workflow names

### DIFF
--- a/GOALS/2026_02_26_message_deletion_action_bar_and_start_app.md
+++ b/GOALS/2026_02_26_message_deletion_action_bar_and_start_app.md
@@ -24,4 +24,4 @@ completionGateScript: make test
 - [x] move the Internal's button bar into the Progress tab
 - [x] add a `Start Application` button in the internal definitions
   - [x] add a `Start Application` button in the sgai.example.json too
-- [x] pending messages counter seems to be incorrect, counting double.
+- [x] needsInputCount counter seems to be incorrect, counting double.

--- a/cmd/sgai/webapp/src/pages/Dashboard.tsx
+++ b/cmd/sgai/webapp/src/pages/Dashboard.tsx
@@ -257,7 +257,7 @@ function collectAllWorkspaces(workspaces: ApiWorkspaceEntry[]): ApiWorkspaceEntr
       }
     }
   }
-  return all;
+  return deduplicateByName(all);
 }
 
 interface SidebarHeaderIndicatorsProps {


### PR DESCRIPTION
Fixes a bug where the needsInputCount counter was double-counting workflows by deduplicating workflow names in the collectAllWorkspaces function.