### PR TITLE
cmd/sgai/webapp: compact fork rows with collapsible commits and icon action buttons

### DIFF
--- a/GOALS/2026_02_26_compact_fork_rows_with_collapsible_commits.md
+++ b/GOALS/2026_02_26_compact_fork_rows_with_collapsible_commits.md
@@ -1,0 +1,32 @@
+---
+flow: |
+  "backend-go-developer" -> "go-readability-reviewer"
+  "react-developer" -> "react-reviewer"
+  "general-purpose" 
+  "go-readability-reviewer" 
+  "project-critic-council"
+  "skill-writer"
+  "stpa-analyst"
+models:
+  "coordinator": "anthropic/claude-opus-4-6 (max)"
+  "backend-go-developer": "anthropic/claude-sonnet-4-6"
+  "go-readability-reviewer": "anthropic/claude-opus-4-6"
+  "general-purpose": "anthropic/claude-sonnet-4-6"
+  "react-developer": "anthropic/claude-sonnet-4-6"
+  "react-reviewer": "anthropic/claude-opus-4-6"
+  "stpa-analyst": "anthropic/claude-opus-4-6 (max)"
+  "project-critic-council": ["anthropic/claude-opus-4-6 (max)"]
+  "skill-writer": "anthropic/claude-opus-4-6 (max)"
+completionGateScript: make test
+---
+
+The Root Repository in Forked Mode is still very slow.
+
+Let's make it faster by simplifying it.
+
+- [x] Instead of having multiple cards, make it a compact interface;
+- [x] add the button bar buttons into the list (the ones from sgai.json / actions)
+
+in the new cards:
+- [x] drop the internal title: "commits"
+- [x] drop the pill with `# ahead`

--- a/cmd/sgai/webapp/src/components/ui/collapsible.tsx
+++ b/cmd/sgai/webapp/src/components/ui/collapsible.tsx
@@ -1,0 +1,32 @@
+import * as React from "react"
+import { Collapsible as CollapsiblePrimitive } from "radix-ui"
+
+function Collapsible({
+  ...props
+}: React.ComponentProps<typeof CollapsiblePrimitive.Root>) {
+  return <CollapsiblePrimitive.Root data-slot="collapsible" {...props} />
+}
+
+function CollapsibleTrigger({
+  ...props
+}: React.ComponentProps<typeof CollapsiblePrimitive.Trigger>) {
+  return (
+    <CollapsiblePrimitive.CollapsibleTrigger
+      data-slot="collapsible-trigger"
+      {...props}
+    />
+  )
+}
+
+function CollapsibleContent({
+  ...props
+}: React.ComponentProps<typeof CollapsiblePrimitive.Content>) {
+  return (
+    <CollapsiblePrimitive.CollapsibleContent
+      data-slot="collapsible-content"
+      {...props}
+    />
+  )
+}
+
+export { Collapsible, CollapsibleTrigger, CollapsibleContent }

--- a/cmd/sgai/webapp/src/pages/tabs/ForksTab.tsx
+++ b/cmd/sgai/webapp/src/pages/tabs/ForksTab.tsx
@@ -1,6 +1,6 @@
-import { useState, useTransition, useMemo, type MouseEvent } from "react";
+import { useState, useTransition, useMemo, useCallback, type MouseEvent } from "react";
 import { useNavigate } from "react-router";
-import { Square } from "lucide-react";
+import { ChevronRight, ChevronDown, Mail, SquarePen, ExternalLink, Trash2, Square } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
@@ -11,23 +11,49 @@ import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Separator } from "@/components/ui/separator";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
 import { PromptHistory } from "@/components/PromptHistory";
 import { api } from "@/lib/api";
 import { useFactoryState } from "@/lib/factory-state";
 import { useAdhocRun } from "@/hooks/useAdhocRun";
-import type { ApiForkEntry, ApiForkCommit } from "@/types";
+import type { ApiForkEntry, ApiForkCommit, ApiActionEntry } from "@/types";
 
 interface ForksTabProps {
   workspaceName: string;
+  actions?: ApiActionEntry[];
+  onActionClick?: (action: ApiActionEntry, forkName: string) => void;
 }
 
 function ForksTabSkeleton() {
   return (
-    <div className="space-y-4">
+    <div className="space-y-2">
       {Array.from({ length: 3 }, (_, i) => (
-        <Skeleton key={i} className="h-24 w-full rounded-xl" />
+        <Skeleton key={i} className="h-10 w-full rounded" />
       ))}
     </div>
+  );
+}
+
+function StatusDot({ running, needsInput }: { running: boolean; needsInput: boolean }) {
+  let colorClass = "bg-gray-400";
+  let label = "idle";
+  if (running) {
+    colorClass = "bg-green-500";
+    label = "running";
+  } else if (needsInput) {
+    colorClass = "bg-amber-400";
+    label = "needs input";
+  }
+  return (
+    <span
+      className={`inline-block w-2 h-2 rounded-full shrink-0 ${colorClass}`}
+      aria-label={label}
+      title={label}
+    />
   );
 }
 
@@ -79,13 +105,21 @@ function ForkCommitList({ commits }: { commits: ApiForkCommit[] }) {
   );
 }
 
-function ForkRow({ fork, rootName, needsInput }: { fork: ApiForkEntry; rootName: string; needsInput: boolean }) {
+interface CompactForkRowProps {
+  fork: ApiForkEntry;
+  rootName: string;
+  needsInput: boolean;
+  actions?: ApiActionEntry[];
+  onActionClick?: (action: ApiActionEntry, forkName: string) => void;
+}
+
+function CompactForkRow({ fork, rootName, needsInput, actions, onActionClick }: CompactForkRowProps) {
   const navigate = useNavigate();
+  const [isOpen, setIsOpen] = useState(false);
   const [actionError, setActionError] = useState<string | null>(null);
   const [isActionPending, startActionTransition] = useTransition();
-  const respondVariant = needsInput ? "default" : "outline";
 
-  const handleOpenEditor = (event: MouseEvent<HTMLButtonElement>) => {
+  const handleOpenEditor = useCallback((event: MouseEvent<HTMLButtonElement>) => {
     event.preventDefault();
     event.stopPropagation();
     if (isActionPending) return;
@@ -97,9 +131,9 @@ function ForkRow({ fork, rootName, needsInput }: { fork: ApiForkEntry; rootName:
         setActionError(err instanceof Error ? err.message : "Failed to open editor");
       }
     });
-  };
+  }, [fork.name, isActionPending]);
 
-  const handleDelete = (event: MouseEvent<HTMLButtonElement>) => {
+  const handleDelete = useCallback((event: MouseEvent<HTMLButtonElement>) => {
     event.preventDefault();
     event.stopPropagation();
     if (isActionPending) return;
@@ -113,98 +147,178 @@ function ForkRow({ fork, rootName, needsInput }: { fork: ApiForkEntry; rootName:
         setActionError(err instanceof Error ? err.message : "Failed to delete fork");
       }
     });
-  };
+  }, [fork.name, fork.dir, rootName, isActionPending]);
+
+  const handleRespond = useCallback((event: MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+    navigate(`/workspaces/${encodeURIComponent(fork.name)}/respond`);
+  }, [fork.name, navigate]);
+
+  const handleOpenInSgai = useCallback((event: MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+    navigate(`/workspaces/${encodeURIComponent(fork.name)}/progress`);
+  }, [fork.name, navigate]);
+
+  const hasCommits = fork.commits && fork.commits.length > 0;
 
   return (
-    <div className="border rounded-lg overflow-hidden">
-      <div className="flex items-center gap-4 p-4 bg-muted/20">
-        <div className="flex flex-col min-w-0 max-w-[300px]">
+    <Collapsible open={isOpen} onOpenChange={setIsOpen}>
+      <div className="border rounded-md overflow-hidden">
+        <div className="flex items-center gap-2 px-3 py-2 bg-muted/10 hover:bg-muted/20 transition-colors">
+          <CollapsibleTrigger asChild>
+            <button
+              type="button"
+              className="shrink-0 p-0.5 rounded hover:bg-muted transition-colors"
+              aria-label={isOpen ? "Collapse commits" : "Expand commits"}
+              disabled={!hasCommits}
+            >
+              {isOpen
+                ? <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
+                : <ChevronRight className="h-3.5 w-3.5 text-muted-foreground" />
+              }
+            </button>
+          </CollapsibleTrigger>
+
+          <StatusDot running={fork.running} needsInput={needsInput} />
+
           <Tooltip>
             <TooltipTrigger asChild>
-              <span className="font-medium text-sm truncate cursor-help">
+              <span className="font-medium text-sm truncate max-w-[180px] cursor-default shrink-0">
                 {fork.name}
               </span>
             </TooltipTrigger>
             <TooltipContent>{fork.name}</TooltipContent>
           </Tooltip>
-          {fork.summary && (
+
+          {fork.summary ? (
             <Tooltip>
               <TooltipTrigger asChild>
-                <span className="text-xs text-muted-foreground truncate cursor-help">
+                <span className="text-xs text-muted-foreground truncate flex-1 min-w-0 cursor-default">
                   {fork.summary}
                 </span>
               </TooltipTrigger>
               <TooltipContent className="max-w-xs">{fork.summary}</TooltipContent>
             </Tooltip>
+          ) : (
+            <span className="flex-1 min-w-0" />
+          )}
+
+          <div className="flex items-center gap-1 shrink-0">
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  type="button"
+                  size="icon"
+                  variant={needsInput ? "default" : "ghost"}
+                  className="h-7 w-7"
+                  onClick={handleRespond}
+                  disabled={isActionPending || !needsInput}
+                  aria-label="Respond"
+                >
+                  <Mail className="h-3.5 w-3.5" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Respond</TooltipContent>
+            </Tooltip>
+
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  type="button"
+                  size="icon"
+                  variant="ghost"
+                  className="h-7 w-7"
+                  onClick={handleOpenEditor}
+                  disabled={isActionPending}
+                  aria-label="Open in Editor"
+                >
+                  <SquarePen className="h-3.5 w-3.5" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Open in Editor</TooltipContent>
+            </Tooltip>
+
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  type="button"
+                  size="icon"
+                  variant="ghost"
+                  className="h-7 w-7"
+                  onClick={handleOpenInSgai}
+                  disabled={isActionPending}
+                  aria-label="Open in sgai"
+                >
+                  <ExternalLink className="h-3.5 w-3.5" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Open in sgai</TooltipContent>
+            </Tooltip>
+
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  type="button"
+                  size="icon"
+                  variant="ghost"
+                  className="h-7 w-7 text-destructive hover:text-destructive"
+                  onClick={handleDelete}
+                  disabled={isActionPending}
+                  aria-label="Delete fork"
+                >
+                  <Trash2 className="h-3.5 w-3.5" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Delete fork</TooltipContent>
+            </Tooltip>
+          </div>
+
+          {actions && actions.length > 0 && (
+            <div className="flex items-center gap-1 shrink-0 border-l pl-2 ml-1">
+              {actions.map((action) => (
+                <Tooltip key={`${action.name}-${action.model}`}>
+                  <TooltipTrigger asChild>
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="outline"
+                      className="h-7 text-xs px-2"
+                      disabled={isActionPending}
+                      onClick={(e) => {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        onActionClick?.(action, fork.name);
+                      }}
+                    >
+                      {action.name}
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>{action.description || action.model}</TooltipContent>
+                </Tooltip>
+              ))}
+            </div>
           )}
         </div>
 
-        <span className="text-xs text-muted-foreground shrink-0">
-          {fork.commitAhead} commits ahead
-        </span>
-
-        <div className="ml-auto flex flex-wrap items-center gap-2">
-          <Button
-            type="button"
-            size="sm"
-            variant={respondVariant}
-            className="min-w-[110px]"
-            onClick={() => navigate(`/workspaces/${encodeURIComponent(fork.name)}/respond`)}
-            disabled={isActionPending || !needsInput}
-          >
-            Respond
-          </Button>
-          <Button
-            type="button"
-            size="sm"
-            variant="outline"
-            className="min-w-[110px]"
-            onClick={handleOpenEditor}
-            disabled={isActionPending}
-          >
-            Open in Editor
-          </Button>
-          <Button
-            type="button"
-            size="sm"
-            variant="outline"
-            className="min-w-[110px]"
-            onClick={() => navigate(`/workspaces/${encodeURIComponent(fork.name)}/progress`)}
-            disabled={isActionPending}
-          >
-            Open in sgai
-          </Button>
-          <Button
-            type="button"
-            size="sm"
-            variant="destructive"
-            className="min-w-[110px]"
-            onClick={handleDelete}
-            disabled={isActionPending}
-          >
-            Delete
-          </Button>
-        </div>
-      </div>
-
-      {actionError && (
-        <div className="px-4 pb-3">
-          <p className="text-xs text-destructive" role="alert">{actionError}</p>
-        </div>
-      )}
-
-      {fork.commits && fork.commits.length > 0 && (
-        <div className="p-4 border-t">
-          <div className="flex items-center justify-between mb-2">
-            <span className="text-xs font-medium">Commits</span>
-            <span className="text-xs text-muted-foreground">{fork.commitAhead} ahead</span>
+        {actionError && (
+          <div className="px-3 py-1.5 border-t bg-destructive/5">
+            <p className="text-xs text-destructive" role="alert">{actionError}</p>
           </div>
-          <ScrollArea className="max-h-[200px]">
-            <ForkCommitList commits={fork.commits} />
-          </ScrollArea>
-        </div>
-      )}
-    </div>
+        )}
+
+        <CollapsibleContent>
+          {hasCommits && (
+            <div className="px-4 py-3 border-t bg-muted/5">
+              <ScrollArea className="max-h-[150px]">
+                <ForkCommitList commits={fork.commits} />
+              </ScrollArea>
+            </div>
+          )}
+        </CollapsibleContent>
+      </div>
+    </Collapsible>
   );
 }
 
@@ -339,7 +453,7 @@ function InlineRunBox({ workspaceName }: { workspaceName: string }) {
   );
 }
 
-export function ForksTab({ workspaceName }: ForksTabProps) {
+export function ForksTab({ workspaceName, actions, onActionClick }: ForksTabProps) {
   const { workspaces: allWorkspaces, fetchStatus } = useFactoryState();
 
   const workspace = allWorkspaces.find((ws) => ws.name === workspaceName);
@@ -374,14 +488,18 @@ export function ForksTab({ workspaceName }: ForksTabProps) {
           <p>No forks yet. Create a fork to start work.</p>
         </div>
       ) : (
-        forks.map((fork) => (
-          <ForkRow
-            key={fork.name}
-            fork={fork}
-            rootName={workspaceName}
-            needsInput={needsInputMap[fork.name] ?? false}
-          />
-        ))
+        <div className="space-y-1.5">
+          {forks.map((fork) => (
+            <CompactForkRow
+              key={fork.name}
+              fork={fork}
+              rootName={workspaceName}
+              needsInput={needsInputMap[fork.name] ?? false}
+              actions={actions}
+              onActionClick={onActionClick}
+            />
+          ))}
+        </div>
       )}
 
       <Separator className="my-6" />


### PR DESCRIPTION
## Summary

- Replace card-based fork layout with compact single-row design using collapsible commit sections
- Swap full-width text buttons for icon action buttons (Respond, Open in Editor, Open in sgai, Delete) with tooltips
- Surface sgai.json action buttons inline on each fork row with separator
- Add status dot indicator per fork (green=running, amber=needs input, gray=idle)
- Add shadcn/ui Collapsible component
- Drop internal "Commits" title and "N ahead" pill from fork cards