### PR TITLE
cmd/sgai: fix diff tab with dedicated workspace diff API endpoint

### DIFF
--- a/GOALS/2026_02_27_fix_diff_tab.md
+++ b/GOALS/2026_02_27_fix_diff_tab.md
@@ -1,0 +1,25 @@
+---
+flow: |
+  "backend-go-developer" -> "go-readability-reviewer"
+  "react-developer" -> "react-reviewer"
+  "general-purpose"
+  "go-readability-reviewer"
+  "project-critic-council"
+  "skill-writer"
+  "stpa-analyst"
+models:
+  "coordinator": "anthropic/claude-opus-4-6 (max)"
+  "backend-go-developer": "anthropic/claude-sonnet-4-6"
+  "go-readability-reviewer": "anthropic/claude-opus-4-6"
+  "general-purpose": "anthropic/claude-sonnet-4-6"
+  "react-developer": "anthropic/claude-sonnet-4-6"
+  "react-reviewer": "anthropic/claude-opus-4-6"
+  "stpa-analyst": "anthropic/claude-opus-4-6 (max)"
+  "project-critic-council": ["anthropic/claude-opus-4-6 (max)", "anthropic/claude-opus-4-5", "anthropic/claude-sonnet-4-6"]
+  "skill-writer": "anthropic/claude-opus-4-6 (max)"
+completionGateScript: make test
+---
+
+
+- [x] Fix the Diff Tab (the view full diff is broken)
+  - [x] It used to work, check the previous changes to figure out why


### PR DESCRIPTION
## Summary

- Add dedicated `GET /api/v1/workspaces/{name}/diff` endpoint that returns the full `jj diff --git` output for a workspace
- Fix the broken "view full diff" functionality in the diff tab by providing a proper API backend