### PR TITLE
cmd/sgai: remove spurious button bar from internal tab and fix empty actions override

### DIFF
--- a/GOALS/2026_02_27_fix_internal_tab.md
+++ b/GOALS/2026_02_27_fix_internal_tab.md
@@ -1,0 +1,30 @@
+---
+flow: |
+  "backend-go-developer" -> "go-readability-reviewer"
+  "react-developer" -> "react-reviewer"
+  "general-purpose"
+  "go-readability-reviewer"
+  "project-critic-council"
+  "skill-writer"
+  "stpa-analyst"
+models:
+  "coordinator": "anthropic/claude-opus-4-6 (max)"
+  "backend-go-developer": "anthropic/claude-sonnet-4-6"
+  "go-readability-reviewer": "anthropic/claude-opus-4-6"
+  "general-purpose": "anthropic/claude-sonnet-4-6"
+  "react-developer": "anthropic/claude-sonnet-4-6"
+  "react-reviewer": "anthropic/claude-opus-4-6"
+  "stpa-analyst": "anthropic/claude-opus-4-6 (max)"
+  "project-critic-council": ["anthropic/claude-opus-4-6 (max)", "anthropic/claude-opus-4-5", "anthropic/claude-sonnet-4-6"]
+  "skill-writer": "anthropic/claude-opus-4-6 (max)"
+completionGateScript: make test
+---
+
+- [x] In the Internal tab there is a button bar that shouldn't be there. Not sure why it's there. The only button bars that should exist are:
+  - [x] In the standalone / forked repository, button bar in the progress tab
+  - [x] In the root repository in forked mode
+    - [x] button bar in each forked repository
+    - [x] button bar at the top, below the forks tab - that applies to the root repository itself.
+
+- [x] The button bar has an internal default
+  - [x] it is fully overwritten (full replacement) by the value in sgai.json

--- a/cmd/sgai/config_test.go
+++ b/cmd/sgai/config_test.go
@@ -474,7 +474,7 @@ func TestLoadActionsForAPI(t *testing.T) {
 		assertDefaultActions(t, actions)
 	})
 
-	t.Run("emptyActionsReturnsDefaults", func(t *testing.T) {
+	t.Run("emptyActionsReturnsEmpty", func(t *testing.T) {
 		dir := t.TempDir()
 		configPath := filepath.Join(dir, configFileName)
 		content := `{"actions": []}`
@@ -483,7 +483,9 @@ func TestLoadActionsForAPI(t *testing.T) {
 		}
 
 		actions := loadActionsForAPI(dir)
-		assertDefaultActions(t, actions)
+		if len(actions) != 0 {
+			t.Errorf("len(actions) = %d; want 0 (empty sgai.json actions should fully replace defaults)", len(actions))
+		}
 	})
 
 	t.Run("configWithoutActionsReturnsDefaults", func(t *testing.T) {

--- a/cmd/sgai/serve_api.go
+++ b/cmd/sgai/serve_api.go
@@ -850,7 +850,7 @@ type apiAgentSequenceEntry struct {
 
 func loadActionsForAPI(workspacePath string) []apiActionEntry {
 	config, errLoad := loadProjectConfig(workspacePath)
-	if errLoad != nil || config == nil || len(config.Actions) == 0 {
+	if errLoad != nil || config == nil || config.Actions == nil {
 		return convertActionsForAPI(defaultActionConfigs())
 	}
 	return convertActionsForAPI(config.Actions)

--- a/cmd/sgai/webapp/src/pages/tabs/SessionTab.test.tsx
+++ b/cmd/sgai/webapp/src/pages/tabs/SessionTab.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
-import { cleanup, render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
 import { SessionTab } from "./SessionTab";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -173,34 +173,4 @@ describe("SessionTab", () => {
     }
   });
 
-  it("renders Start Application button", async () => {
-    renderSessionTab();
-
-    await waitFor(() => {
-      expect(screen.getByRole("button", { name: "Start Application" })).toBeDefined();
-    });
-  });
-
-  it("calls start API when Start Application button is clicked", async () => {
-    mockFetch.mockImplementation((input: string | URL | Request) => {
-      const url = input.toString();
-      if (url.includes("/start")) {
-        return Promise.resolve(new Response(JSON.stringify({ running: true, status: "working", message: "Started" })));
-      }
-      return Promise.resolve(new Response(JSON.stringify({})));
-    });
-
-    renderSessionTab();
-
-    await waitFor(() => {
-      expect(screen.getByRole("button", { name: "Start Application" })).toBeDefined();
-    });
-
-    fireEvent.click(screen.getByRole("button", { name: "Start Application" }));
-
-    await waitFor(() => {
-      const calledUrls = mockFetch.mock.calls.map((call) => String(call[0]));
-      expect(calledUrls.some((url) => url.includes("/start"))).toBe(true);
-    });
-  });
 });

--- a/cmd/sgai/webapp/src/pages/tabs/SessionTab.tsx
+++ b/cmd/sgai/webapp/src/pages/tabs/SessionTab.tsx
@@ -222,8 +222,6 @@ export function SessionTab({ workspaceName, pmContent, hasProjectMgmt }: Session
   const [isSteering, startSteerTransition] = useTransition();
   const [pmOpenError, setPmOpenError] = useState<string | null>(null);
   const [isPmOpenPending, startPmOpenTransition] = useTransition();
-  const [startAppError, setStartAppError] = useState<string | null>(null);
-  const [isStartAppPending, startStartAppTransition] = useTransition();
 
   const { workspaces } = useFactoryState();
   const workspace = workspaces.find((ws) => ws.name === workspaceName);
@@ -233,20 +231,6 @@ export function SessionTab({ workspaceName, pmContent, hasProjectMgmt }: Session
   const modelStatuses = workspace?.modelStatuses;
   const projectTodos = workspace?.projectTodos ?? [];
   const agentTodos = workspace?.agentTodos ?? [];
-
-  const handleStartApplication = (event: MouseEvent<HTMLButtonElement>) => {
-    event.preventDefault();
-    event.stopPropagation();
-    if (!workspaceName || isStartAppPending) return;
-    setStartAppError(null);
-    startStartAppTransition(async () => {
-      try {
-        await api.workspaces.start(workspaceName, false);
-      } catch (err) {
-        setStartAppError(err instanceof Error ? err.message : "Failed to start application");
-      }
-    });
-  };
 
   const handleSteerSubmit = (event: React.FormEvent) => {
     event.preventDefault();
@@ -285,21 +269,6 @@ export function SessionTab({ workspaceName, pmContent, hasProjectMgmt }: Session
 
   return (
     <div className="space-y-4">
-      <div className="flex items-center gap-2">
-        <Button
-          type="button"
-          size="sm"
-          variant="outline"
-          onClick={handleStartApplication}
-          disabled={isStartAppPending}
-        >
-          Start Application
-        </Button>
-      </div>
-      {startAppError && (
-        <p className="text-sm text-destructive" role="alert">{startAppError}</p>
-      )}
-
       <Card>
         <CardHeader className="pb-3">
           <CardTitle className="text-base">Steer Next Turn</CardTitle>


### PR DESCRIPTION
## Summary

- Remove the "Start Application" button that was incorrectly rendered in the Internal/Session tab
- Fix `loadActionsForAPI` so that an empty `actions: []` in sgai.json fully replaces the defaults instead of falling back to them
- Update tests to reflect both changes