### PR TITLE
cmd/sgai: fix retrospective and project-critic-council not running

### DIFF
--- a/GOALS/2026_02_28_retrospective_not_running.md
+++ b/GOALS/2026_02_28_retrospective_not_running.md
@@ -1,0 +1,25 @@
+---
+flow: |
+  "backend-go-developer" -> "go-readability-reviewer"
+  "react-developer" -> "react-reviewer"
+  "general-purpose"
+  "go-readability-reviewer"
+  "project-critic-council"
+  "skill-writer"
+  "stpa-analyst"
+models:
+  "coordinator": "anthropic/claude-opus-4-6 (max)"
+  "backend-go-developer": "anthropic/claude-sonnet-4-6"
+  "go-readability-reviewer": "anthropic/claude-opus-4-6"
+  "general-purpose": "anthropic/claude-sonnet-4-6"
+  "react-developer": "anthropic/claude-sonnet-4-6"
+  "react-reviewer": "anthropic/claude-opus-4-6"
+  "stpa-analyst": "anthropic/claude-opus-4-6"
+  "project-critic-council": ["anthropic/claude-opus-4-6"]
+  "skill-writer": "anthropic/claude-opus-4-6 (max)"
+completionGateScript: make test
+---
+
+- [x] retrospectives aren't running any more, sgai claims retrospective aren't declared in the flow
+
+- [x] project-critic-council doesn't seem to be running any more either 

--- a/cmd/sgai/mcp_external.go
+++ b/cmd/sgai/mcp_external.go
@@ -887,7 +887,7 @@ func elicitPendingQuestion(ctx context.Context, session *mcp.ServerSession, srv 
 	}
 }
 
-func buildPendingQuestionSchema(_ interface{}) *jsonschema.Schema {
+func buildPendingQuestionSchema(_ any) *jsonschema.Schema {
 	return &jsonschema.Schema{
 		Type: "object",
 		Properties: map[string]*jsonschema.Schema{

--- a/cmd/sgai/prompt_registry.go
+++ b/cmd/sgai/prompt_registry.go
@@ -66,8 +66,9 @@ You are running in Building mode. The brainstorming and work-gate phases are com
 - During the retrospective, the system will re-enable human interaction tools automatically
 `
 
-const flowSectionBuildingModeCoordinator = `- Your master plan: read GOAL.md → delegate to agents → verify → run retrospective → complete
-- When delegated work is done, send a message to the retrospective agent to start analysis
+const flowSectionBuildingModeCoordinator = `- Your master plan: read GOAL.md → delegate to agents → verify → ask project-critic-council → run retrospective → complete
+- When delegated work is done, send a message to project-critic-council to verify all GOAL.md checkboxes are genuinely complete
+- After project-critic-council approves, send a message to the retrospective agent to start analysis
 `
 
 const flowSectionPostSkillsCoordinator = `IMPORTANT: YOU COMMUNICATE WITH THE HUMAN ONLY VIA ask_user_question (structured multi-choice questions).`

--- a/cmd/sgai/prompt_registry_test.go
+++ b/cmd/sgai/prompt_registry_test.go
@@ -110,6 +110,18 @@ func TestComposePromptCoordinatorPlanOnlyForCoordinator(t *testing.T) {
 	}
 }
 
+func TestBuildingModeCoordinatorIncludesProjectCriticCouncil(t *testing.T) {
+	modeSection, coordPlan := modeSectionForMode(state.ModeBuilding)
+	msg := composePrompt(promptOptions{
+		agent:           "coordinator",
+		modeSection:     modeSection,
+		coordinatorPlan: coordPlan,
+	})
+	if !strings.Contains(msg, "project-critic-council") {
+		t.Error("building mode coordinator plan should instruct asking project-critic-council before completing")
+	}
+}
+
 func TestModeSectionForMode(t *testing.T) {
 	t.Run("selfDriveReturnsCorrectSections", func(t *testing.T) {
 		modeSection, coordPlan := modeSectionForMode(state.ModeSelfDrive)

--- a/cmd/sgai/serve.go
+++ b/cmd/sgai/serve.go
@@ -893,6 +893,9 @@ func workspaceDagAgents(workspacePath string) []string {
 	if errFlow != nil {
 		return nil
 	}
+	if retrospectiveEnabled(metadata) {
+		flowDag.injectRetrospectiveEdge()
+	}
 	return flowDag.allAgents()
 }
 

--- a/cmd/sgai/serve_test.go
+++ b/cmd/sgai/serve_test.go
@@ -1138,3 +1138,44 @@ func TestInjectCurrentAgentStyle(t *testing.T) {
 		})
 	}
 }
+
+func TestWorkspaceDagAgentsIncludesRetrospectiveWhenEnabled(t *testing.T) {
+	workspacePath := t.TempDir()
+	goalContent := `---
+flow: |
+  "backend-go-developer" -> "go-readability-reviewer"
+---
+
+- [ ] some task
+`
+	if err := os.WriteFile(filepath.Join(workspacePath, "GOAL.md"), []byte(goalContent), 0644); err != nil {
+		t.Fatalf("failed to write GOAL.md: %v", err)
+	}
+
+	agents := workspaceDagAgents(workspacePath)
+
+	if !slices.Contains(agents, "retrospective") {
+		t.Errorf("workspaceDagAgents should include retrospective when retrospective is enabled (default), got: %v", agents)
+	}
+}
+
+func TestWorkspaceDagAgentsExcludesRetrospectiveWhenDisabled(t *testing.T) {
+	workspacePath := t.TempDir()
+	goalContent := `---
+flow: |
+  "backend-go-developer" -> "go-readability-reviewer"
+retrospective: "no"
+---
+
+- [ ] some task
+`
+	if err := os.WriteFile(filepath.Join(workspacePath, "GOAL.md"), []byte(goalContent), 0644); err != nil {
+		t.Fatalf("failed to write GOAL.md: %v", err)
+	}
+
+	agents := workspaceDagAgents(workspacePath)
+
+	if slices.Contains(agents, "retrospective") {
+		t.Errorf("workspaceDagAgents should NOT include retrospective when retrospective is disabled, got: %v", agents)
+	}
+}


### PR DESCRIPTION
## Summary

- Fix retrospective not running by injecting retrospective edge into flow DAG when retrospective is enabled
- Fix project-critic-council not being triggered by adding explicit instruction to the building-mode coordinator plan
- Add GOAL file to GOALS/