### PR TITLE
Makefile: exclude README.md and .DS_Store from absorb-sgai target

### DIFF
--- a/GOALS/2026_02_28_fix_issue_322_absorb_sgai_excludes.md
+++ b/GOALS/2026_02_28_fix_issue_322_absorb_sgai_excludes.md
@@ -1,0 +1,27 @@
+---
+flow: |
+  "backend-go-developer" -> "go-readability-reviewer"
+  "react-developer" -> "react-reviewer"
+  "general-purpose"
+  "go-readability-reviewer"
+  "project-critic-council"
+  "skill-writer"
+  "stpa-analyst"
+models:
+  "coordinator": "anthropic/claude-opus-4-6 (max)"
+  "backend-go-developer": "anthropic/claude-sonnet-4-6"
+  "go-readability-reviewer": "anthropic/claude-opus-4-6"
+  "general-purpose": "anthropic/claude-sonnet-4-6"
+  "react-developer": "anthropic/claude-sonnet-4-6"
+  "react-reviewer": "anthropic/claude-opus-4-6"
+  "stpa-analyst": "anthropic/claude-opus-4-6"
+  "project-critic-council": ["anthropic/claude-opus-4-6"]
+  "skill-writer": "anthropic/claude-opus-4-6 (max)"
+completionGateScript: make test
+---
+
+- [ ] using gh, absorb and fix the issue https://github.com/sandgardenhq/sgai/issues/322
+- [ ] using gh, respond to https://github.com/sandgardenhq/sgai/issues/322 acknowledging it
+- [ ] using sgai.json as a reference create the PR
+  - [ ] using gh, merge the PR
+  - [ ] using gh, close the issue

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ deploy: build
 	killall -9 sgai-base
 
 absorb-sgai:
-	@find sgai/ -type f | grep -v 'sgai/README.md' | while read f; do \
+	@find sgai/ -type f ! -name 'README.md' ! -name '.DS_Store' | while read f; do \
 		mkdir -p "$$(dirname "cmd/sgai/skel/.sgai/$${f#sgai/}")" || true; \
 		mv -v "$$f" "cmd/sgai/skel/.sgai/$${f#sgai/}"; \
 	done


### PR DESCRIPTION
## Summary

Fixes #322 - The `absorb-sgai` Makefile target was using `grep -v 'sgai/README.md'` to exclude README.md from the overlay absorption, but it was not excluding `.DS_Store` files (macOS Finder metadata).

## Changes

Replace the `grep -v` pipe with `find`'s native `! -name` exclusion predicates:

```makefile
# Before:
@find sgai/ -type f | grep -v 'sgai/README.md' | while read f; do \

# After:
@find sgai/ -type f ! -name 'README.md' ! -name '.DS_Store' | while read f; do \
```

## Testing

Manually verified:
- `README.md` stays in `sgai/` (not moved to `cmd/sgai/skel/.sgai/`)
- `.DS_Store` stays in `sgai/` (not moved to `cmd/sgai/skel/.sgai/`)
- Regular overlay files are correctly moved to `cmd/sgai/skel/.sgai/`

All existing tests pass (`make test`) and lint is clean (`make lint`).