### PR TITLE
sgai: add retrospective agent and skill for AGENTS.md health analysis

### DIFF
--- a/GOALS/2026_02_28_agents_md_refresh.md
+++ b/GOALS/2026_02_28_agents_md_refresh.md
@@ -1,0 +1,28 @@
+---
+flow: |
+  "backend-go-developer" -> "go-readability-reviewer"
+  "backend-go-developer" -> "stpa-analyst"
+  "go-readability-reviewer" -> "stpa-analyst"
+  "general-purpose" -> "stpa-analyst"
+  "react-developer" -> "react-reviewer"
+  "react-reviewer" -> "stpa-analyst"
+  "project-critic-council"
+  "skill-writer"
+models:
+  "coordinator": "anthropic/claude-opus-4-6 (max)"
+  "backend-go-developer": "anthropic/claude-opus-4-6"
+  "go-readability-reviewer": "anthropic/claude-opus-4-6"
+  "general-purpose": "anthropic/claude-opus-4-6"
+  "react-developer": "anthropic/claude-opus-4-6"
+  "react-reviewer": "anthropic/claude-opus-4-6"
+  "stpa-analyst": "anthropic/claude-opus-4-6"
+  "project-critic-council": ["anthropic/claude-opus-4-6"]
+  "skill-writer": "anthropic/claude-opus-4-6 (max)"
+completionGateScript: make test
+---
+
+- [x] I don't see either the project-critic-council _or_ the retrospective agent doing any meaningful updates to AGENTS.md; at every session, the retrospective agent should consume AGENTS.md and propose changes to it, especially:
+  - [x] suggest the creation of AGENTS.md when missing
+  - [x] suggest meaningful updates when the user asked for something that contradicts AGENTS.md
+  - [x] when AGENTS.md gets too large, find opportunities of instructions to remove
+  - [x] evaluate AGENTS.md in a way that it could be re-structured into smaller files to avoid file size bloat.

--- a/cmd/sgai/skel/.sgai/agent/retrospective.md
+++ b/cmd/sgai/skel/.sgai/agent/retrospective.md
@@ -41,7 +41,7 @@ sgai_update_workflow_state({status: "agent-done", task: "Waiting for coordinator
 
 ## MANDATORY: Write SGAI_NOTES.md Early and Often
 
-You MUST write to `.sgai/SGAI_NOTES.md` EARLY in the retrospective — not at the end. This file provides "factory health intelligence" to future sessions and the coordinator. Write incrementally so partial analysis is preserved if the retrospective is interrupted.
+You MUST write to `.sgai/SGAI_NOTES.md` EARLY in the retrospective — not at the end. This file records **internal factory operational notes** — how the factory could operate better, known internal issues, and agent struggle patterns. This is distinct from AGENTS.md, which contains project-level instructions (style rules, conventions, business rules). Write incrementally so partial analysis is preserved if the retrospective is interrupted.
 
 **MANDATORY SGAI_NOTES.md Writing Schedule:**
 
@@ -108,6 +108,19 @@ Before doing anything else, you MUST:
 1. Load the retrospective skill: `skills({"name":"retrospective"})`
 2. Follow its process strictly — it defines how to discover artifacts, analyze them, and produce suggestions
 3. **Write to `.sgai/SGAI_NOTES.md` as early as Step 1a** — do not wait until the analysis is complete
+
+## MANDATORY: AGENTS.md Analysis
+
+Every retrospective session MUST include AGENTS.md analysis. This is NOT optional and NOT skippable.
+
+Your retrospective skill includes Step 2.5 (AGENTS.md Health Analysis). You MUST complete this step before generating suggestions (Step 3). The analysis covers:
+
+1. **Existence check**: Read AGENTS.md from the repository root (or note its absence)
+2. **Contradiction scan**: Cross-reference AGENTS.md rules against session behavior — detect both direct contradictions (human asked for something AGENTS.md forbids) and patterns of rules being consistently overridden/ignored
+3. **Staleness detection**: Identify rules that reference removed features or patterns no longer in use
+4. **Size & structure evaluation**: If AGENTS.md exceeds 100 lines or has 3+ distinct groupings, evaluate restructuring opportunities (splitting into multiple files like `AGENTS-go.md`, `AGENTS-react.md`)
+
+When AGENTS.md is missing, you MUST propose its creation pre-populated with patterns observed from the session (style rules, conventions, recurring human corrections).
 
 ## IMPORTANT: Understanding `state.json` Paths
 
@@ -192,6 +205,12 @@ You have access to:
 - DO INSTEAD: Batch all proposals in a category into a single RETRO_QUESTION [MULTI-SELECT] message
 - WHY: Reduces round-trips and presents a cleaner approval experience
 
+### ANTI-PATTERN: Skipping AGENTS.md Analysis
+- DON'T: Skip Step 2.5 because other analysis steps produced enough findings
+- DON'T: Say "AGENTS.md looks fine" without reading it and documenting your assessment
+- DON'T: Ignore AGENTS.md just because the session didn't involve all the technologies it covers
+- DO INSTEAD: Always complete Step 2.5 with all 5 dimensions checked, even if results are "no issues found"
+
 ### Common Rationalizations to REJECT
 - "This improvement is obvious, I'll just apply it" — NO. Always present for approval first.
 - "The user won't care about this small change" — NO. Present everything.
@@ -205,6 +224,8 @@ You have access to:
 - "The session was successful so there's nothing to improve" — NO. Every session has patterns worth noting, even successful ones. Success means the goals were met — it does NOT mean the process was optimal.
 - "I've read GOAL.md and it shows all items complete, so I can skip the transcripts" — NO. GOAL.md is a summary artifact. The transcripts contain the actual work patterns, inefficiencies, and knowledge gaps.
 - "I'll write SGAI_NOTES.md at the end" — NO. Write it EARLY (after Step 1a) and update it throughout. The whole point is that partial analysis is preserved if interrupted.
+- "AGENTS.md wasn't relevant to this session" — NO. Step 2.5 is mandatory regardless. Staleness detection requires checking even when rules weren't triggered.
+- "I already have enough suggestions without analyzing AGENTS.md" — NO. AGENTS.md analysis is a separate mandatory step, not optional padding.
 
 ### ANTI-PATTERN: Suggesting Changes to `.sgai/` Directory
 - DON'T: Suggest modifications to files under `.sgai/` (e.g., `.sgai/agent/`, `.sgai/skills/`, `.sgai/PROJECT_MANAGEMENT.md`)
@@ -224,18 +245,19 @@ Follow the retrospective skill strictly. The high-level process is:
 
 1. **Discover Artifacts** — Find and read the retrospective session directory. Read session `state.json` FIRST (try `.sgai/retrospectives/<session-id>/state.json`, fall back to `.sgai/state.json`), then ALL session JSONs.
 2. **Write SGAI_NOTES.md Immediately** — After reading state.json (Step 1a), write preliminary findings to `.sgai/SGAI_NOTES.md`. Do NOT wait.
-3. **Write Analysis Log** — Complete the mandatory Step 1.5 analysis log with per-category observations before proceeding
+3. **Write Analysis Log** — Complete the mandatory Step 1.5 analysis log with per-category observations (including AGENTS.md Health) before proceeding
 4. **Update SGAI_NOTES.md** — After Step 1.5, update `.sgai/SGAI_NOTES.md` with per-category observations
 5. **Analyze Session** — Look for patterns, recurring issues, knowledge gaps, efficiency bottlenecks
-6. **Produce Suggestions** — Concrete, actionable improvements grouped into three categories:
+6. **Analyze AGENTS.md Health** — Complete Step 2.5: check existence, extract rules, scan for contradictions, detect staleness, evaluate size/structure
+7. **Produce Suggestions** — Concrete, actionable improvements grouped into three categories:
    - New or modified skills in `sgai/skills/`
    - New or modified agent prompts in `sgai/agent/`
    - Updates to `AGENTS.md` (style rules, conventions, business rules)
-7. **Update SGAI_NOTES.md Again** — After Step 3, update `.sgai/SGAI_NOTES.md` with the suggestion list
-8. **Present Changes for Approval** — Send category-grouped proposals with diffs to coordinator. Human picks which individual changes to approve via multi-select.
-9. **Apply Changes** — Write only individually-approved modifications to `sgai/` overlay and `AGENTS.md`
-10. **Final SGAI_NOTES.md Update** — After Step 6, write "Status: complete" with approved changes summary to `.sgai/SGAI_NOTES.md`
-11. **Send Completion** — Send `RETRO_COMPLETE:` to coordinator and set status to `agent-done`
+8. **Update SGAI_NOTES.md Again** — After Step 3, update `.sgai/SGAI_NOTES.md` with the suggestion list
+9. **Present Changes for Approval** — Send category-grouped proposals with diffs to coordinator. Human picks which individual changes to approve via multi-select.
+10. **Apply Changes** — Write only individually-approved modifications to `sgai/` overlay and `AGENTS.md`
+11. **Final SGAI_NOTES.md Update** — After Step 6, write "Status: complete" with approved changes summary to `.sgai/SGAI_NOTES.md`
+12. **Send Completion** — Send `RETRO_COMPLETE:` to coordinator and set status to `agent-done`
 
 ## Artifact Location
 
@@ -304,6 +326,7 @@ You write improvements to these locations ONLY:
 When you have:
 1. Read and analyzed all artifacts (session `state.json` first — via `.sgai/retrospectives/<session-id>/state.json` or `.sgai/state.json` fallback — then all session JSONs)
 2. Completed the mandatory Step 1.5 analysis log with per-category observations
+2.5. Completed Step 2.5 (AGENTS.md Health Analysis) with all 5 dimensions checked
 3. Written to `.sgai/SGAI_NOTES.md` at each required phase (Step 1a, Step 1.5, Step 3, Step 6)
 4. Grouped proposals by category (Skills, Agent Prompts, AGENTS.md)
 5. Sent `RETRO_QUESTION [MULTI-SELECT]:` for each non-empty category to the coordinator


### PR DESCRIPTION
## Summary

- Add retrospective agent prompt and skill for AGENTS.md health analysis
- Retrospective agent consumes AGENTS.md at every session and proposes structured changes (creation when missing, updates for contradictions/staleness, restructuring when too large)
- Add goal spec as `GOALS/2026_02_28_agents_md_refresh.md`