### PR TITLE
cmd/sgai: fix duplicate workspace in left nav after rename

### DIFF
--- a/GOALS/2026_02_28_fix_duplicate_workspace_after_rename.md
+++ b/GOALS/2026_02_28_fix_duplicate_workspace_after_rename.md
@@ -1,0 +1,23 @@
+---
+flow: |
+  "backend-go-developer" -> "go-readability-reviewer"
+  "react-developer" -> "react-reviewer"
+  "general-purpose" -> "stpa-analyst"
+  "go-readability-reviewer" -> "stpa-analyst"
+  "backend-go-developer" -> "stpa-analyst"
+  "react-reviewer" -> "stpa-analyst"
+models:
+  "backend-go-developer": "anthropic/claude-opus-4-6"
+  "coordinator": "anthropic/claude-opus-4-6"
+  "general-purpose": "anthropic/claude-opus-4-6"
+  "go-readability-reviewer": "anthropic/claude-opus-4-6"
+  "react-developer": "anthropic/claude-opus-4-6"
+  "react-reviewer": "anthropic/claude-opus-4-6"
+  "stpa-analyst": "anthropic/claude-opus-4-6"
+---
+
+There is a bug in SGAI where when you rename a workspace, it appears twice in the left navigation. It appears once as its renamed name and another time as its original name.
+
+- [x] after renaming the workspace it should only appear once in the left nav. 
+I have a screenshot that I will attach.
+


### PR DESCRIPTION
## Summary

After renaming a workspace, it appeared twice in the left navigation — once under the new name and once under the old name.

**Root cause:** the rename handler only updated the filesystem path and `everStartedDirs`, but left stale entries in `pinnedDirs`, `adhocStates`, `composerSessions`, and `classifyCache`/`bookmarkCache`. The SSE-driven left-nav tree rebuilt from these caches, producing the ghost duplicate.

**Fix:** re-key all in-memory maps (`pinnedDirs`, `adhocStates`, `composerSessions`) from old path → new path during rename, invalidate both old and new entries in `classifyCache`/`bookmarkCache`, and persist re-keyed pins to disk. Applied to both `serve_api.go` and `service_workspace.go`.