### PR TITLE
cmd/sgai: add interactive chat assistant to web dashboard

### DIFF
--- a/GOALS/2026_02_28_add_interactive_chat_assistant.md
+++ b/GOALS/2026_02_28_add_interactive_chat_assistant.md
@@ -1,0 +1,20 @@
+---
+flow: |
+  "backend-go-developer" -> "go-readability-reviewer"
+  "backend-go-developer" -> "stpa-analyst"
+  "go-readability-reviewer" -> "stpa-analyst"
+  "general-purpose" -> "stpa-analyst"
+  "htmx-picocss-frontend-developer" -> "htmx-picocss-frontend-reviewer"
+  "htmx-picocss-frontend-reviewer" -> "stpa-analyst"
+models:
+  "coordinator": "anthropic/claude-opus-4-5 (max)"
+  "backend-go-developer": "anthropic/claude-opus-4-5"
+  "go-readability-reviewer": "anthropic/claude-opus-4-5"
+  "general-purpose": "anthropic/claude-opus-4-5"
+  "htmx-picocss-frontend-developer": "anthropic/claude-sonnet-4-5"
+  "htmx-picocss-frontend-reviewer": "anthropic/claude-opus-4-5"
+  "stpa-analyst": "anthropic/claude-opus-4-5"
+interactive: yes
+---
+I want to add an interactive chat assistant to every page of SGAI that can help the user better understand SGAI and explain how it works.
+

--- a/cmd/sgai/chat.go
+++ b/cmd/sgai/chat.go
@@ -1,0 +1,185 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/sandgardenhq/sgai/pkg/state"
+)
+
+// chatContext contains contextual information about the current page and workspace.
+type chatContext struct {
+	Route        string `json:"route"`
+	WorkspaceDir string `json:"workspaceDir"`
+}
+
+// apiChatRequest is the request body for the chat endpoint.
+type apiChatRequest struct {
+	Message             string        `json:"message"`
+	ConversationHistory []chatMessage `json:"conversationHistory"`
+	Context             chatContext   `json:"context"`
+}
+
+// apiChatConfigResponse returns the configuration status for the chat assistant.
+type apiChatConfigResponse struct {
+	Configured bool   `json:"configured"`
+	Provider   string `json:"provider,omitempty"`
+	Model      string `json:"model,omitempty"`
+}
+
+func (s *Server) handleAPIChatConfig(w http.ResponseWriter, _ *http.Request) {
+	config := detectLLMConfig()
+	writeJSON(w, apiChatConfigResponse{
+		Configured: config.APIKey != "",
+		Provider:   string(config.Provider),
+		Model:      config.Model,
+	})
+}
+
+func (s *Server) handleAPIChat(w http.ResponseWriter, r *http.Request) {
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming not supported", http.StatusInternalServerError)
+		return
+	}
+
+	var req apiChatRequest
+	if errDecode := json.NewDecoder(r.Body).Decode(&req); errDecode != nil {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	if strings.TrimSpace(req.Message) == "" {
+		http.Error(w, "message cannot be empty", http.StatusBadRequest)
+		return
+	}
+
+	config := detectLLMConfig()
+	if config.APIKey == "" {
+		http.Error(w, "no LLM API key configured (set ANTHROPIC_API_KEY or OPENAI_API_KEY)", http.StatusServiceUnavailable)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no")
+
+	systemPrompt := buildChatSystemPrompt(req.Context, s.rootDir)
+	relevantDocs := retrieveRelevantChunks(req.Message, 5)
+
+	fullSystemPrompt := systemPrompt
+	if docsContent := formatRetrievedDocs(relevantDocs); docsContent != "" {
+		fullSystemPrompt += "\n\n## RELEVANT DOCUMENTATION\n\n" + docsContent
+	}
+
+	messages := buildChatMessages(req.ConversationHistory, req.Message)
+
+	errStream := streamChatCompletion(r.Context(), messages, fullSystemPrompt, func(chunk string) {
+		data, errMarshal := json.Marshal(map[string]string{"content": chunk})
+		if errMarshal != nil {
+			return
+		}
+		_, errWrite := fmt.Fprintf(w, "data: %s\n\n", data)
+		if errWrite != nil {
+			return
+		}
+		flusher.Flush()
+	})
+
+	if errStream != nil {
+		log.Println("chat streaming error:", errStream)
+		data, _ := json.Marshal(map[string]string{"error": errStream.Error()})
+		if _, errWrite := fmt.Fprintf(w, "data: %s\n\n", data); errWrite != nil {
+			return
+		}
+		flusher.Flush()
+	}
+
+	if _, errWrite := fmt.Fprintf(w, "data: [DONE]\n\n"); errWrite != nil {
+		return
+	}
+	flusher.Flush()
+}
+
+func buildChatSystemPrompt(ctx chatContext, rootDir string) string {
+	var sb strings.Builder
+
+	sb.WriteString("You are an SGAI assistant helping users understand SGAI (Software Generation AI).\n")
+	sb.WriteString("SGAI is an AI-powered software factory that uses specialized agents to accomplish development tasks.\n\n")
+	sb.WriteString("Key concepts:\n")
+	sb.WriteString("- GOAL.md: Defines the project goal and workflow configuration in YAML frontmatter\n")
+	sb.WriteString("- Agents: Specialized AI agents (coordinator, backend-go-developer, etc.)\n")
+	sb.WriteString("- Flow: Defines how agents connect and pass work to each other\n")
+	sb.WriteString("- State: Workflow state is stored in .sgai/state.json\n")
+	sb.WriteString("- Skills: Reusable prompt templates that guide agent behavior\n")
+	sb.WriteString("- Snippets: Reusable code templates\n\n")
+	sb.WriteString("Be helpful, concise, and accurate. If you don't know something, say so.\n")
+	sb.WriteString("Reference the documentation when applicable.\n")
+
+	if ctx.WorkspaceDir != "" {
+		workspacePath := filepath.Join(rootDir, ctx.WorkspaceDir)
+		sb.WriteString("\n## CURRENT CONTEXT\n\n")
+		sb.WriteString(fmt.Sprintf("- Current Page: %s\n", ctx.Route))
+		sb.WriteString(fmt.Sprintf("- Workspace: %s\n", ctx.WorkspaceDir))
+
+		if goalContent := readWorkspaceFile(workspacePath, "GOAL.md"); goalContent != "" {
+			sb.WriteString("\n### GOAL.md Content:\n")
+			sb.WriteString("```\n")
+			sb.WriteString(truncateContent(goalContent, 2000))
+			sb.WriteString("\n```\n")
+		}
+
+		if wfState := readWorkspaceState(workspacePath); wfState != nil {
+			sb.WriteString(fmt.Sprintf("\n### Workflow Status: %s\n", wfState.Status))
+			if wfState.CurrentAgent != "" {
+				sb.WriteString(fmt.Sprintf("### Current Agent: %s\n", wfState.CurrentAgent))
+			}
+			if wfState.Task != "" {
+				sb.WriteString(fmt.Sprintf("### Current Task: %s\n", wfState.Task))
+			}
+		}
+	}
+
+	return sb.String()
+}
+
+func buildChatMessages(history []chatMessage, currentMessage string) []chatMessage {
+	messages := make([]chatMessage, 0, len(history)+1)
+	messages = append(messages, history...)
+	messages = append(messages, chatMessage{
+		Role:    "user",
+		Content: currentMessage,
+	})
+	return messages
+}
+
+func readWorkspaceFile(workspacePath, filename string) string {
+	filePath := filepath.Join(workspacePath, filename)
+	content, errRead := os.ReadFile(filePath)
+	if errRead != nil {
+		return ""
+	}
+	return string(content)
+}
+
+func readWorkspaceState(workspacePath string) *state.Workflow {
+	stateJSONPath := filepath.Join(workspacePath, ".sgai", "state.json")
+	wfState, errLoad := state.Load(stateJSONPath)
+	if errLoad != nil {
+		return nil
+	}
+	return &wfState
+}
+
+func truncateContent(content string, maxLen int) string {
+	if len(content) <= maxLen {
+		return content
+	}
+	return content[:maxLen] + "\n... (truncated)"
+}

--- a/cmd/sgai/chat_embed.go
+++ b/cmd/sgai/chat_embed.go
@@ -1,0 +1,6 @@
+package main
+
+import "embed"
+
+//go:embed docs
+var chatDocsFS embed.FS

--- a/cmd/sgai/chat_llm.go
+++ b/cmd/sgai/chat_llm.go
@@ -1,0 +1,224 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+)
+
+// chatMessage represents a message in a chat conversation.
+type chatMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type llmProvider string
+
+const (
+	llmProviderClaude llmProvider = "claude"
+	llmProviderOpenAI llmProvider = "openai"
+)
+
+// llmConfig holds configuration for LLM API calls.
+type llmConfig struct {
+	Provider llmProvider
+	Model    string
+	APIKey   string
+}
+
+func detectLLMConfig() llmConfig {
+	if key := os.Getenv("ANTHROPIC_API_KEY"); key != "" {
+		model := os.Getenv("CHAT_MODEL")
+		if model == "" {
+			model = "claude-sonnet-4-20250514"
+		}
+		return llmConfig{
+			Provider: llmProviderClaude,
+			Model:    model,
+			APIKey:   key,
+		}
+	}
+
+	if key := os.Getenv("OPENAI_API_KEY"); key != "" {
+		model := os.Getenv("CHAT_MODEL")
+		if model == "" {
+			model = "gpt-4o"
+		}
+		return llmConfig{
+			Provider: llmProviderOpenAI,
+			Model:    model,
+			APIKey:   key,
+		}
+	}
+
+	return llmConfig{}
+}
+
+// streamChatCompletion streams a chat completion response from the configured LLM provider.
+// The onChunk callback receives each text chunk as it arrives.
+// Returns an error if the API call fails.
+func streamChatCompletion(ctx context.Context, messages []chatMessage, systemPrompt string, onChunk func(string)) error {
+	config := detectLLMConfig()
+	if config.APIKey == "" {
+		return fmt.Errorf("no LLM API key configured (set ANTHROPIC_API_KEY or OPENAI_API_KEY)")
+	}
+
+	switch config.Provider {
+	case llmProviderClaude:
+		return streamClaudeCompletion(ctx, config, messages, systemPrompt, onChunk)
+	case llmProviderOpenAI:
+		return streamOpenAICompletion(ctx, config, messages, systemPrompt, onChunk)
+	default:
+		return fmt.Errorf("unknown LLM provider")
+	}
+}
+
+func streamClaudeCompletion(ctx context.Context, config llmConfig, messages []chatMessage, systemPrompt string, onChunk func(string)) error {
+	reqBody := map[string]any{
+		"model":      config.Model,
+		"max_tokens": 4096,
+		"stream":     true,
+		"messages":   messages,
+	}
+	if systemPrompt != "" {
+		reqBody["system"] = systemPrompt
+	}
+
+	body, errMarshal := json.Marshal(reqBody)
+	if errMarshal != nil {
+		return fmt.Errorf("marshaling request: %w", errMarshal)
+	}
+
+	req, errReq := http.NewRequestWithContext(ctx, http.MethodPost, "https://api.anthropic.com/v1/messages", bytes.NewReader(body))
+	if errReq != nil {
+		return fmt.Errorf("creating request: %w", errReq)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Api-Key", config.APIKey)
+	req.Header.Set("Anthropic-Version", "2023-06-01")
+
+	resp, errDo := http.DefaultClient.Do(req)
+	if errDo != nil {
+		return fmt.Errorf("sending request: %w", errDo)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("claude API error (status %d): %s", resp.StatusCode, string(respBody))
+	}
+
+	return parseClaudeSSE(resp.Body, onChunk)
+}
+
+func parseClaudeSSE(body io.Reader, onChunk func(string)) error {
+	scanner := bufio.NewScanner(body)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+
+		data := strings.TrimPrefix(line, "data: ")
+		if data == "[DONE]" {
+			break
+		}
+
+		var event struct {
+			Type  string `json:"type"`
+			Delta struct {
+				Type string `json:"type"`
+				Text string `json:"text"`
+			} `json:"delta"`
+		}
+
+		if errUnmarshal := json.Unmarshal([]byte(data), &event); errUnmarshal != nil {
+			continue
+		}
+
+		if event.Type == "content_block_delta" && event.Delta.Type == "text_delta" {
+			onChunk(event.Delta.Text)
+		}
+	}
+
+	return scanner.Err()
+}
+
+func streamOpenAICompletion(ctx context.Context, config llmConfig, messages []chatMessage, systemPrompt string, onChunk func(string)) error {
+	allMessages := messages
+	if systemPrompt != "" {
+		allMessages = append([]chatMessage{{Role: "system", Content: systemPrompt}}, messages...)
+	}
+
+	reqBody := map[string]any{
+		"model":    config.Model,
+		"stream":   true,
+		"messages": allMessages,
+	}
+
+	body, errMarshal := json.Marshal(reqBody)
+	if errMarshal != nil {
+		return fmt.Errorf("marshaling request: %w", errMarshal)
+	}
+
+	req, errReq := http.NewRequestWithContext(ctx, http.MethodPost, "https://api.openai.com/v1/chat/completions", bytes.NewReader(body))
+	if errReq != nil {
+		return fmt.Errorf("creating request: %w", errReq)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+config.APIKey)
+
+	resp, errDo := http.DefaultClient.Do(req)
+	if errDo != nil {
+		return fmt.Errorf("sending request: %w", errDo)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("openai API error (status %d): %s", resp.StatusCode, string(respBody))
+	}
+
+	return parseOpenAISSE(resp.Body, onChunk)
+}
+
+func parseOpenAISSE(body io.Reader, onChunk func(string)) error {
+	scanner := bufio.NewScanner(body)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+
+		data := strings.TrimPrefix(line, "data: ")
+		if data == "[DONE]" {
+			break
+		}
+
+		var event struct {
+			Choices []struct {
+				Delta struct {
+					Content string `json:"content"`
+				} `json:"delta"`
+			} `json:"choices"`
+		}
+
+		if errUnmarshal := json.Unmarshal([]byte(data), &event); errUnmarshal != nil {
+			continue
+		}
+
+		if len(event.Choices) > 0 && event.Choices[0].Delta.Content != "" {
+			onChunk(event.Choices[0].Delta.Content)
+		}
+	}
+
+	return scanner.Err()
+}

--- a/cmd/sgai/chat_rag.go
+++ b/cmd/sgai/chat_rag.go
@@ -1,0 +1,237 @@
+package main
+
+import (
+	"io/fs"
+	"math"
+	"slices"
+	"strings"
+	"sync"
+)
+
+// docChunk represents a searchable chunk of documentation.
+type docChunk struct {
+	Content  string
+	Source   string
+	Keywords []string
+}
+
+var (
+	chatDocsOnce   sync.Once
+	chatDocsChunks []docChunk
+)
+
+func loadChatDocumentation() []docChunk {
+	chatDocsOnce.Do(func() {
+		chatDocsChunks = parseChatDocs()
+	})
+	return chatDocsChunks
+}
+
+func parseChatDocs() []docChunk {
+	var chunks []docChunk
+
+	errWalk := fs.WalkDir(chatDocsFS, "docs", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(path, ".md") {
+			return nil
+		}
+
+		content, errRead := fs.ReadFile(chatDocsFS, path)
+		if errRead != nil {
+			return nil
+		}
+
+		stripped := stripFrontmatter(string(content))
+		docChunks := splitIntoChunks(stripped, path)
+		chunks = append(chunks, docChunks...)
+		return nil
+	})
+	if errWalk != nil {
+		return nil
+	}
+
+	return chunks
+}
+
+func splitIntoChunks(content, source string) []docChunk {
+	sections := splitByHeadings(content)
+	chunks := make([]docChunk, 0, len(sections))
+
+	for _, section := range sections {
+		if strings.TrimSpace(section) == "" {
+			continue
+		}
+		keywords := extractKeywords(section)
+		chunks = append(chunks, docChunk{
+			Content:  section,
+			Source:   source,
+			Keywords: keywords,
+		})
+	}
+
+	return chunks
+}
+
+func splitByHeadings(content string) []string {
+	var sections []string
+	var current strings.Builder
+	headingPrefix := "##"
+
+	for line := range strings.SplitSeq(content, "\n") {
+		if strings.HasPrefix(line, headingPrefix) && current.Len() > 0 {
+			sections = append(sections, current.String())
+			current.Reset()
+		}
+		current.WriteString(line)
+		current.WriteString("\n")
+	}
+
+	if current.Len() > 0 {
+		sections = append(sections, current.String())
+	}
+
+	return sections
+}
+
+func extractKeywords(text string) []string {
+	lower := strings.ToLower(text)
+	words := strings.FieldsFunc(lower, isNonAlphaNum)
+
+	keywordSet := make(map[string]struct{})
+	for _, word := range words {
+		if len(word) >= 3 && !isStopWord(word) {
+			keywordSet[word] = struct{}{}
+		}
+	}
+
+	keywords := make([]string, 0, len(keywordSet))
+	for kw := range keywordSet {
+		keywords = append(keywords, kw)
+	}
+	slices.Sort(keywords)
+	return keywords
+}
+
+func isNonAlphaNum(r rune) bool {
+	isLower := r >= 'a' && r <= 'z'
+	isUpper := r >= 'A' && r <= 'Z'
+	isDigit := r >= '0' && r <= '9'
+	return !isLower && !isUpper && !isDigit
+}
+
+var stopWords = map[string]bool{
+	"the": true, "and": true, "for": true, "are": true, "but": true,
+	"not": true, "you": true, "all": true, "can": true, "had": true,
+	"her": true, "was": true, "one": true, "our": true, "out": true,
+	"has": true, "his": true, "its": true, "this": true, "that": true,
+	"with": true, "from": true, "have": true, "they": true, "will": true,
+	"what": true, "when": true, "make": true, "like": true, "just": true,
+	"into": true, "year": true, "your": true, "than": true, "them": true,
+	"been": true, "would": true, "which": true, "their": true, "about": true,
+}
+
+func isStopWord(word string) bool {
+	return stopWords[word]
+}
+
+// retrieveRelevantChunks returns the topK most relevant documentation chunks for a query.
+func retrieveRelevantChunks(query string, topK int) []docChunk {
+	chunks := loadChatDocumentation()
+	if len(chunks) == 0 {
+		return nil
+	}
+
+	queryKeywords := extractKeywords(query)
+	if len(queryKeywords) == 0 {
+		return nil
+	}
+
+	type scoredChunk struct {
+		chunk docChunk
+		score float64
+	}
+
+	scored := make([]scoredChunk, 0, len(chunks))
+	for _, chunk := range chunks {
+		score := computeTFIDFScore(queryKeywords, chunk.Keywords, chunks)
+		if score > 0 {
+			scored = append(scored, scoredChunk{chunk: chunk, score: score})
+		}
+	}
+
+	slices.SortFunc(scored, func(a, b scoredChunk) int {
+		if a.score > b.score {
+			return -1
+		}
+		if a.score < b.score {
+			return 1
+		}
+		return 0
+	})
+
+	if len(scored) > topK {
+		scored = scored[:topK]
+	}
+
+	result := make([]docChunk, len(scored))
+	for i, sc := range scored {
+		result[i] = sc.chunk
+	}
+	return result
+}
+
+func computeTFIDFScore(queryKeywords, chunkKeywords []string, allChunks []docChunk) float64 {
+	chunkKeywordSet := make(map[string]bool)
+	for _, kw := range chunkKeywords {
+		chunkKeywordSet[kw] = true
+	}
+
+	var score float64
+	for _, qkw := range queryKeywords {
+		if !chunkKeywordSet[qkw] {
+			continue
+		}
+
+		docFreq := countDocumentFrequency(qkw, allChunks)
+		if docFreq == 0 {
+			continue
+		}
+
+		idf := math.Log(float64(len(allChunks)+1) / float64(docFreq+1))
+		score += idf
+	}
+
+	return score
+}
+
+func countDocumentFrequency(keyword string, chunks []docChunk) int {
+	count := 0
+	for _, chunk := range chunks {
+		if slices.Contains(chunk.Keywords, keyword) {
+			count++
+		}
+	}
+	return count
+}
+
+// formatRetrievedDocs formats retrieved chunks for inclusion in a prompt.
+func formatRetrievedDocs(chunks []docChunk) string {
+	if len(chunks) == 0 {
+		return ""
+	}
+
+	var sb strings.Builder
+	for i, chunk := range chunks {
+		if i > 0 {
+			sb.WriteString("\n---\n")
+		}
+		sb.WriteString("Source: ")
+		sb.WriteString(chunk.Source)
+		sb.WriteString("\n\n")
+		sb.WriteString(strings.TrimSpace(chunk.Content))
+		sb.WriteString("\n")
+	}
+	return sb.String()
+}

--- a/cmd/sgai/chat_rag_test.go
+++ b/cmd/sgai/chat_rag_test.go
@@ -1,0 +1,215 @@
+package main
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestExtractKeywords(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    string
+		contains []string
+	}{
+		{
+			name:     "simple text",
+			input:    "How do I create a new workspace?",
+			contains: []string{"create", "workspace"},
+		},
+		{
+			name:     "filters stop words",
+			input:    "What is the workflow and how does it work?",
+			contains: []string{"workflow"},
+		},
+		{
+			name:     "extracts technical terms",
+			input:    "GOAL.md agent coordinator SGAI",
+			contains: []string{"goal", "agent", "coordinator", "sgai"},
+		},
+		{
+			name:  "empty input",
+			input: "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := extractKeywords(tc.input)
+			if tc.input == "" && len(got) != 0 {
+				t.Errorf("extractKeywords(%q) returned %d keywords; want 0", tc.input, len(got))
+			}
+			for _, want := range tc.contains {
+				if !slices.Contains(got, want) {
+					t.Errorf("extractKeywords(%q) missing %q; got %v", tc.input, want, got)
+				}
+			}
+		})
+	}
+}
+
+func TestIsStopWord(t *testing.T) {
+	stopWordTests := []string{"the", "and", "for", "with", "from"}
+	for _, word := range stopWordTests {
+		if !isStopWord(word) {
+			t.Errorf("isStopWord(%q) = false; want true", word)
+		}
+	}
+
+	nonStopWordTests := []string{"agent", "workflow", "sgai", "coordinator"}
+	for _, word := range nonStopWordTests {
+		if isStopWord(word) {
+			t.Errorf("isStopWord(%q) = true; want false", word)
+		}
+	}
+}
+
+func TestSplitByHeadings(t *testing.T) {
+	content := `# Main Title
+
+Some intro text.
+
+## Section One
+
+Content of section one.
+
+## Section Two
+
+Content of section two.
+`
+
+	sections := splitByHeadings(content)
+	if len(sections) != 3 {
+		t.Errorf("splitByHeadings returned %d sections; want 3", len(sections))
+	}
+}
+
+func TestFormatRetrievedDocs(t *testing.T) {
+	chunks := []docChunk{
+		{
+			Content:  "This is chunk one.",
+			Source:   "docs/reference/cli.md",
+			Keywords: []string{"cli", "command"},
+		},
+		{
+			Content:  "This is chunk two.",
+			Source:   "docs/AGENTS.md",
+			Keywords: []string{"agent", "workflow"},
+		},
+	}
+
+	result := formatRetrievedDocs(chunks)
+	if result == "" {
+		t.Error("formatRetrievedDocs returned empty string")
+	}
+
+	if !contains(result, "docs/reference/cli.md") {
+		t.Error("formatRetrievedDocs missing source reference")
+	}
+
+	if !contains(result, "This is chunk one.") {
+		t.Error("formatRetrievedDocs missing content")
+	}
+
+	if !contains(result, "---") {
+		t.Error("formatRetrievedDocs missing separator")
+	}
+}
+
+func TestFormatRetrievedDocsEmpty(t *testing.T) {
+	result := formatRetrievedDocs(nil)
+	if result != "" {
+		t.Errorf("formatRetrievedDocs(nil) = %q; want empty string", result)
+	}
+
+	result = formatRetrievedDocs([]docChunk{})
+	if result != "" {
+		t.Errorf("formatRetrievedDocs([]) = %q; want empty string", result)
+	}
+}
+
+func TestComputeTFIDFScore(t *testing.T) {
+	allChunks := []docChunk{
+		{Keywords: []string{"agent", "workflow", "sgai"}},
+		{Keywords: []string{"agent", "coordinator"}},
+		{Keywords: []string{"workflow", "goal"}},
+	}
+
+	queryKeywords := []string{"agent"}
+	chunkKeywords := []string{"agent", "workflow", "sgai"}
+
+	score := computeTFIDFScore(queryKeywords, chunkKeywords, allChunks)
+	if score <= 0 {
+		t.Error("computeTFIDFScore returned non-positive score for matching keyword")
+	}
+
+	noMatchScore := computeTFIDFScore([]string{"nonexistent"}, chunkKeywords, allChunks)
+	if noMatchScore != 0 {
+		t.Errorf("computeTFIDFScore returned %f for non-matching keyword; want 0", noMatchScore)
+	}
+}
+
+func TestCountDocumentFrequency(t *testing.T) {
+	chunks := []docChunk{
+		{Keywords: []string{"agent", "workflow"}},
+		{Keywords: []string{"agent", "coordinator"}},
+		{Keywords: []string{"workflow", "goal"}},
+	}
+
+	agentFreq := countDocumentFrequency("agent", chunks)
+	if agentFreq != 2 {
+		t.Errorf("countDocumentFrequency(\"agent\") = %d; want 2", agentFreq)
+	}
+
+	unknownFreq := countDocumentFrequency("unknown", chunks)
+	if unknownFreq != 0 {
+		t.Errorf("countDocumentFrequency(\"unknown\") = %d; want 0", unknownFreq)
+	}
+}
+
+func TestLoadChatDocumentation(t *testing.T) {
+	chunks := loadChatDocumentation()
+	if len(chunks) == 0 {
+		t.Skip("no documentation chunks loaded (expected in test environment without embedded docs)")
+	}
+
+	for i, chunk := range chunks {
+		if chunk.Source == "" {
+			t.Errorf("chunk[%d] has empty source", i)
+		}
+		if chunk.Content == "" {
+			t.Errorf("chunk[%d] has empty content", i)
+		}
+	}
+}
+
+func TestRetrieveRelevantChunks(t *testing.T) {
+	chunks := retrieveRelevantChunks("agent workflow", 5)
+	if chunks == nil {
+		t.Log("retrieveRelevantChunks returned nil (may be expected without embedded docs)")
+		return
+	}
+
+	if len(chunks) > 5 {
+		t.Errorf("retrieveRelevantChunks returned %d chunks; want <= 5", len(chunks))
+	}
+}
+
+func TestRetrieveRelevantChunksEmptyQuery(t *testing.T) {
+	chunks := retrieveRelevantChunks("", 5)
+	if chunks != nil {
+		t.Errorf("retrieveRelevantChunks(\"\", 5) = %v; want nil", chunks)
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsSubstr(s, substr))
+}
+
+func containsSubstr(s, substr string) bool {
+	for i := 0; i+len(substr) <= len(s); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/sgai/docs/AGENTS.md
+++ b/cmd/sgai/docs/AGENTS.md
@@ -1,0 +1,159 @@
+# SGAI Agents Reference
+
+SGAI (Software Generation AI) uses specialized agents to accomplish different tasks in a software development workflow. Each agent has a specific role, expertise, and set of capabilities. Agents communicate with each other through a messaging system and can be coordinated by the coordinator agent to accomplish complex, multi-step goals.
+
+---
+
+## agent-sdk-verifier-py
+
+Verifies that Python Claude Agent SDK applications are properly configured, follow SDK best practices, and are ready for deployment or testing. This agent inspects Python Agent SDK apps for correct SDK usage, adherence to official documentation recommendations, proper environment setup, and security configurations. Use this agent after creating or modifying a Python Agent SDK application to ensure it meets all requirements before deployment.
+
+---
+
+## agent-sdk-verifier-ts
+
+Verifies that TypeScript Claude Agent SDK applications are properly configured, follow SDK best practices, and are ready for deployment or testing. This agent inspects TypeScript Agent SDK apps for correct SDK usage, proper TypeScript configuration, type checking compliance, and adherence to official documentation recommendations. Invoke this agent after creating or modifying a TypeScript Agent SDK application to validate configuration and catch issues before runtime.
+
+---
+
+## backend-go-developer
+
+Expert Go backend developer for building production-quality APIs, CLI tools, and services with idiomatic Go patterns. This agent writes, tests, and refactors Go code following official Go conventions and best practices from Effective Go. It handles HTTP/API development, database operations, testing, and uses modern Go features (Go 1.21+) including generics, the slices package, and iterators. The agent works closely with the go-readability-reviewer for code quality assurance and must address all review feedback before completing work.
+
+---
+
+## c4-code
+
+Expert C4 Code-level documentation specialist that analyzes code directories to create comprehensive C4 code-level documentation. This agent extracts function signatures, arguments, dependencies, and code structure at the most granular level of the C4 model. It supports multiple programming paradigms (OOP, functional, procedural) and generates Mermaid diagrams for code relationships. Use this agent when documenting code at the lowest C4 level for individual directories and code modules, forming the foundation for higher-level C4 documentation.
+
+---
+
+## c4-component
+
+Expert C4 Component-level documentation specialist that synthesizes C4 Code-level documentation into Component-level architecture. This agent identifies component boundaries, defines interfaces, maps relationships between components, and creates component diagrams. It groups related code files into logical components based on domain, technical, or organizational boundaries. Use this agent when synthesizing code-level documentation into logical components for architectural understanding.
+
+---
+
+## c4-container
+
+Expert C4 Container-level documentation specialist that synthesizes Component-level documentation into Container-level architecture. This agent maps components to deployment units (Docker, Kubernetes, cloud services), documents container interfaces as OpenAPI/Swagger specifications, and creates container diagrams showing high-level technology choices. Use this agent when synthesizing components into deployment containers and documenting system deployment architecture.
+
+---
+
+## c4-context
+
+Expert C4 Context-level documentation specialist that creates high-level system context diagrams and documentation. This agent identifies personas, maps user journeys, documents system features, and captures external dependencies. It synthesizes container and component documentation into stakeholder-friendly context diagrams that show the system, its users, and external systems. Use this agent when creating the highest-level C4 system context documentation that non-technical stakeholders can understand.
+
+---
+
+## cli-output-style-adjuster
+
+Adjusts source code CLI output style for minimal, plain-text output following Unix philosophy principles. This agent scans source code files and applies style transformations to ensure outputs are clean, lowercase, emoji-free, use plain ASCII characters, are silent on success, and properly direct errors to stderr. It works across multiple programming languages (Go, Python, JavaScript, Rust, etc.) and processes recently changed files based on version control diffs.
+
+---
+
+## coordinator
+
+The project manager of the SGAI Software Factory that orchestrates the entire workflow. This agent evaluates GOAL.md and PROJECT_MANAGEMENT.md, delegates tasks to specialized agents, manages checkbox completion in GOAL.md, and ensures the project progresses through brainstorming, work gate approval, and code cleanup phases. The coordinator is read-only for code - it never writes code itself but dispatches work to appropriate specialist agents. It is the sole agent that can communicate with the human partner via questions and the only agent that can mark the workflow as complete.
+
+---
+
+## general-purpose
+
+General-purpose agent for researching complex questions, searching for code, and executing multi-step tasks that no other specialized agent can handle. This agent has full access to read, write, edit, and manage code across any language, run shell commands, and use all development tools. It approaches problems systematically: analyzing requirements, exploring codebases, planning work, executing carefully, and verifying results. Use this agent for tasks that don't fit other specialized agents or require cross-domain expertise.
+
+---
+
+## go-readability-reviewer
+
+Reviews Go code for readability, idioms, and best practices following Go Code Review Comments and the Google Go Style Guide. This is a read-only reviewer that cannot modify files - it provides detailed feedback with line numbers and sends fix recommendations to the backend-go-developer agent via messaging. The agent uses a comprehensive checklist covering formatting, naming, error handling, concurrency, interfaces, documentation, type safety, and modern Go idioms. Every issue identified is mandatory and must be addressed before work can proceed.
+
+---
+
+## htmx-picocss-frontend-developer
+
+Frontend developer specializing in building modern, lightweight web interfaces using HTMX and PicoCSS without heavy JavaScript frameworks. This agent creates fast, accessible, and maintainable web applications with semantic HTML, partial page updates via HTMX attributes, and PicoCSS's classless styling approach. It enforces a strict no-custom-JavaScript policy (except for idiomorph extension setup), uses Playwright for visual verification, and ensures accessibility with proper contrast ratios. Use this agent for building interactive web UIs that need HTMX's AJAX capabilities.
+
+---
+
+## htmx-picocss-frontend-reviewer
+
+The "UI OCD Web Agent" - a hyper-perfectionist frontend reviewer for interfaces built with HTMX and PicoCSS. This agent obsessively reviews visual consistency, predictable interaction patterns, cohesive information architecture, and code readability. It verifies that every interactive element has proper hover/focus/loading/error states, layouts are responsive, accessibility requirements are met, and Playwright tests cover UI behavior. Any rough edge is considered a bug. Use this agent to review and polish HTMX/PicoCSS interfaces to production quality.
+
+---
+
+## openai-sdk-verifier-py
+
+Verifies that Python OpenAI Agents SDK applications are properly configured and follow best practices. This agent checks package installation, Python version compatibility, syntax errors, import statements, agent configuration, tool definitions, environment variables, and run configuration. It supports Basic Agents, Voice Agents (with audio pipeline verification), and Realtime Agents (with WebSocket configuration). Use this agent after creating or modifying a Python OpenAI Agents SDK application to ensure it's ready for deployment.
+
+---
+
+## openai-sdk-verifier-ts
+
+Verifies that TypeScript OpenAI Agents SDK applications are properly configured and follow best practices. This agent checks package installation, TypeScript configuration (tsconfig.json), type checking with `tsc --noEmit`, import statements, agent configuration, Zod-based tool definitions, and environment setup. It supports standard agents, voice agents, and realtime agents with WebSocket/WebRTC transports. Use this agent after creating or modifying a TypeScript OpenAI Agents SDK application.
+
+---
+
+## project-critic-council
+
+A multi-model council that strictly evaluates whether GOAL.md items are truly complete. Multiple models collaborate in a debate-style evaluation, examining checked items against actual evidence (test results, code review, file contents). The council reaches consensus through structured communication, then requests checkbox reverts through the coordinator if work was not genuinely complete. This agent enforces extremely strict standards - "mostly done" or "should work" does not count as complete. It is the last line of defense against incomplete work being marked complete.
+
+---
+
+## retrospective-applier
+
+Reads SUGGESTIONS.md (or IMPROVEMENTS.md) files and applies only the approved suggestions by delegating to appropriate agents. This agent parses approved suggestions, determines whether they are skills or snippets, then delegates creation to the skill-writer or snippet-writer agents respectively. It reports a summary of what was created after processing all approved items. Use this agent to apply retrospective improvements after human review and approval.
+
+---
+
+## retrospective-code-analyzer
+
+Mines code from session diffs to identify valuable code snippets that should be added to SGAI's snippet library. This agent reviews code produced during a session and identifies reusable infrastructure patterns (HTTP handlers, database connections, error handling, test helpers) that would benefit future SGAI users across ANY project - not patterns specific to the application being developed. It checks against existing snippets to avoid duplicates and outputs findings to IMPROVEMENTS.draft.md with priority rankings.
+
+---
+
+## retrospective-refiner
+
+Deduplicates, polishes, and formats IMPROVEMENTS.draft.md into the final IMPROVEMENTS.md with checkbox approval format for human review. This agent validates SGAI relevance (filtering out application-specific improvements), merges similar improvements, verifies uniqueness against existing skills/snippets/agents, prioritizes by impact, and produces a clean approval format with checkboxes. The final output is written to both the retrospective directory and project root for visibility.
+
+---
+
+## retrospective-session-analyzer
+
+Analyzes exported session JSON transcripts to identify skill gaps, struggle patterns, and improvement opportunities for SGAI itself. This agent looks for missing knowledge signals (failed skill searches, trial-and-error debugging), successful workarounds that could be formalized as skills, and agent behavior issues that suggest improvements. It performs deep verification against existing skills to prevent duplicate suggestions and focuses exclusively on improvements that benefit SGAI infrastructure, not the application being developed.
+
+---
+
+## shell-script-coder
+
+Expert shell script developer specializing in writing production-quality shell scripts. This agent creates POSIX-compliant scripts for maximum portability, uses bash-specific features when appropriate, implements proper argument parsing with edge case handling, and ensures robust error handling with appropriate exit codes. It follows best practices like quoting variables, using `"$@"` for arguments, and providing meaningful error messages. Use this agent when you need to create new shell scripts.
+
+---
+
+## shell-script-reviewer
+
+Reviews shell script quality for correctness, portability, security, and best practices. This is a read-only reviewer that cannot modify files or execute commands. It analyzes scripts against criteria including logical correctness, POSIX compatibility, proper variable quoting, input validation, command injection prevention, secure temporary file handling, and meaningful error messages. The agent provides structured feedback with specific line references and a PASS/NEEDS WORK verdict.
+
+---
+
+## skill-writer
+
+Creates new skills from approved suggestions with mandatory validation using the testing-skills-with-subagents process. This agent writes properly formatted SKILL.md files following conventions, then runs a RED-GREEN-REFACTOR testing cycle to ensure the skill works under pressure and resists rationalization. Skills are not considered complete until they pass testing - the agent iterates until the skill is bulletproof. Skills are created in the sgai overlay directory for distribution to all SGAI users.
+
+---
+
+## snippet-writer
+
+Creates new code snippets from approved suggestions following established conventions. This agent writes clean, reusable code snippets with proper header comments documenting purpose, usage, and examples. It uses TODO comments for customizable parts, ensures proper formatting for the target language, and follows language-specific idioms. Snippets are created in the sgai overlay directory for distribution and must pass quality checks including syntax validity and proper documentation.
+
+---
+
+## stpa-analyst
+
+STPA (System Theoretic Process Analysis) hazard analyst for software, physical, and AI systems. This agent treats safety as a control problem and guides users through the 4 STPA steps: defining purpose (losses, hazards, constraints), modeling control structures with Graphviz diagrams, identifying unsafe control actions (4 types), and tracing loss scenarios through causal pathways. It uses interactive questioning to gather system information and documents findings in PROJECT_MANAGEMENT.md. Use this agent for systematic hazard analysis of any system where safety is a concern.
+
+---
+
+## webmaster
+
+Website developer specializing in building marketing sites, landing pages, and institutional websites (not web applications). This agent creates simple Go backends with HTML templates, embedded assets, and Let's Encrypt HTTPS support. It is proficient in Bootstrap, Tailwind CSS, PicoCSS, and vanilla CSS, choosing the appropriate framework based on project needs. The agent emphasizes SEO best practices (meta tags, semantic HTML, Open Graph), mobile-first responsive design, and accessibility. Use this agent for content-driven websites that prioritize presentation and conversion, not complex interactive applications.

--- a/cmd/sgai/docs/reference/cli.md
+++ b/cmd/sgai/docs/reference/cli.md
@@ -1,0 +1,101 @@
+# CLI commands
+
+This page describes the `sgai` command-line interface.
+
+## Usage
+
+```sh
+sgai [--interactive] [--fresh] <target_directory>
+```
+
+`sgai` expects a `GOAL.md` file in the target directory.
+
+## Global options
+
+- `--interactive`
+
+  Interactive mode.
+
+  Accepted values:
+
+  - `yes` (open `$EDITOR` for human responses)
+  - `no`
+  - `auto` (self-driving)
+
+- `--fresh`
+
+  Force a fresh start (do not resume existing workflow).
+
+## Commands
+
+### `sgai serve`
+
+Start the web server for session management.
+
+```sh
+sgai serve [--listen-addr addr]
+```
+
+Options:
+
+- `--listen-addr`
+
+  HTTP server listen address.
+
+  Default: `127.0.0.1:8080`
+
+### `sgai sessions`
+
+List all sessions in `.sgai/retrospectives`.
+
+```sh
+sgai sessions
+```
+
+### `sgai status`
+
+Show workflow status summary.
+
+```sh
+sgai status [target_directory]
+```
+
+If `target_directory` is omitted, `sgai` uses the current directory.
+
+### `sgai retrospective`
+
+Work with retrospective sessions.
+
+#### `sgai retrospective analyze`
+
+Analyze a session.
+
+```sh
+sgai retrospective analyze [session-id]
+```
+
+If `session-id` is omitted, `sgai` analyzes the most recent session.
+
+#### `sgai retrospective apply`
+
+Apply improvements from a session.
+
+```sh
+sgai retrospective apply <session-id>
+```
+
+### `sgai list-agents`
+
+List available agents.
+
+```sh
+sgai list-agents [target_directory]
+```
+
+### `sgai mcp`
+
+Start the MCP server.
+
+```sh
+sgai mcp
+```

--- a/cmd/sgai/docs/reference/environment-variables.md
+++ b/cmd/sgai/docs/reference/environment-variables.md
@@ -1,0 +1,45 @@
+# Environment variables
+
+This page lists environment variables that `sgai` reads.
+
+## `EDITOR`
+
+If `EDITOR` is set, `sgai` uses it to choose the default for `--interactive`.
+
+- When `EDITOR` is set, the default interactive mode is `yes`.
+- When `EDITOR` is not set, the default interactive mode is `auto`.
+
+## `SGAI_MCP_EXECUTABLE`
+
+Used by the OpenCode plugin configuration to locate the `sgai` binary.
+
+In the skeleton plugin, the MCP server command is configured as:
+
+```ts
+command: [process.env.SGAI_MCP_EXECUTABLE || "sgai", "mcp"]
+```
+
+## `SGAI_MCP_INTERACTIVE`
+
+Controls the interactive mode used by the MCP integration.
+
+In the skeleton plugin, the environment is configured as:
+
+```ts
+environment: {
+  SGAI_MCP_WORKING_DIRECTORY: directory,
+  SGAI_MCP_INTERACTIVE: process.env.SGAI_MCP_INTERACTIVE || "yes",
+}
+```
+
+## `SGAI_MCP_WORKING_DIRECTORY`
+
+`sgai mcp` reads `SGAI_MCP_WORKING_DIRECTORY` to decide which directory contains `.sgai/state.json`.
+
+- If `SGAI_MCP_WORKING_DIRECTORY` is not set, the default working directory is `.`.
+- `sgai mcp` loads state from `<working-dir>/.sgai/state.json`.
+
+## `SGAI_NTFY`
+
+If `SGAI_NTFY` is set, `sgai` sends remote notifications by posting the message body to that URL.
+

--- a/cmd/sgai/docs/reference/index.md
+++ b/cmd/sgai/docs/reference/index.md
@@ -1,0 +1,17 @@
+# Sandgarden AI Software Factory Reference
+
+Reference pages for the `sgai` CLI and its workspace file formats.
+
+## Topics
+
+- [CLI commands](./cli.md)
+- [Environment variables](./environment-variables.md)
+- [Project configuration (`sgai.json`)](./project-configuration.md)
+- [Workflow state (`.sgai/state.json`)](./workflow-state.md)
+- [MCP server](./mcp.md)
+
+## Examples
+
+- [`GOAL.example.md`](../../GOAL.example.md)
+- [`sgai.example.json`](../../sgai.example.json)
+- [`opencode.json`](../../opencode.json)

--- a/cmd/sgai/docs/reference/mcp.md
+++ b/cmd/sgai/docs/reference/mcp.md
@@ -1,0 +1,104 @@
+# MCP server
+
+`sgai` provides an MCP server that exposes workflow-management tools over stdio.
+
+## Run
+
+```sh
+sgai mcp
+```
+
+## Working directory
+
+`sgai mcp` reads the working directory from `SGAI_MCP_WORKING_DIRECTORY`.
+
+If `SGAI_MCP_WORKING_DIRECTORY` is not set, the default working directory is `.`.
+
+## Tools
+
+### `skills`
+
+- Input: `{ "name": "..." }` (optional)
+- Behavior:
+  - When `name` is empty, lists available skills.
+  - When `name` matches a skill name, returns the skill content.
+
+### `find_snippets`
+
+- Input: `{ "language": "...", "query": "..." }` (both optional)
+- Behavior:
+  - When `language` and `query` are empty, lists available languages.
+  - When `language` is set and `query` is empty, lists snippets for that language.
+  - When `language` and `query` are set, returns the matching snippet content or matching snippet list.
+
+### `update_workflow_state`
+
+Update `.sgai/state.json`.
+
+Input fields:
+
+- `status`
+- `task`
+- `addProgress`
+
+#### Status values depend on the current agent
+
+`update_workflow_state.status` only allows:
+
+- `working`
+- `agent-done`
+
+When the current agent is `coordinator`, it also allows:
+
+- `complete`
+
+#### TODO guardrails
+
+Transitions to `agent-done` or `complete` fail if there are pending TODO items.
+
+### `send_message`
+
+Send a message to another agent.
+
+Input:
+
+```json
+{
+  "toAgent": "name-or-model-id",
+  "body": "message body"
+}
+```
+
+Notes:
+
+- The target must be an agent in the workflow.
+- When `currentModel` is set in state, `send_message` uses that as `fromAgent`.
+
+### `check_inbox`
+
+Return unread messages for the current agent (and current model, if set) and mark them as read.
+
+### `check_outbox`
+
+Return messages sent by the current agent (and current model, if set).
+
+### `peek_message_bus` (coordinator only)
+
+Return all messages in the system (pending and read), in reverse chronological order.
+
+### `project_todowrite` (coordinator only)
+
+Write the project todo list to state.
+
+### `project_todoread` (coordinator only)
+
+Read the project todo list from state.
+
+### `ask_user_question` (coordinator only)
+
+Present one or more multiple-choice questions to the human partner.
+
+Input:
+
+- `questions`: array of `{ "question": string, "choices": string[], "multiSelect": boolean }`
+

--- a/cmd/sgai/docs/reference/project-configuration.md
+++ b/cmd/sgai/docs/reference/project-configuration.md
@@ -1,0 +1,100 @@
+# Project configuration (`sgai.json`)
+
+`sgai` reads an optional `sgai.json` file from the project root (as a sibling to the `.sgai` directory).
+
+## File name and location
+
+- File name: `sgai.json`
+- Location: project root directory
+
+## Related examples
+
+The repository includes example configuration files you can use as starting points:
+
+- [`GOAL.example.md`](../../GOAL.example.md): Example `GOAL.md` frontmatter with a workflow graph and per-agent model selection.
+- [`sgai.example.json`](../../sgai.example.json): Example MCP configuration snippet for a project-level `sgai.json`.
+- [`opencode.json`](../../opencode.json): Example OpenCode configuration with a local MCP entry.
+
+## Schema
+
+### `defaultModel`
+
+Type: string
+
+If set, `defaultModel` becomes the default model for any agent in `GOAL.md` that does not already have a model configured.
+
+Notes:
+
+- `defaultModel` is validated using the base model name. If the value includes a variant in parentheses (for example, `provider/model (variant)`), only the base model is validated.
+
+### `disable_retrospective`
+
+Type: boolean
+
+If `true`, `sgai` does not create or resume a retrospective directory for the workflow run.
+
+### `editor`
+
+Type: string
+
+Configures the editor used for the "Open in Editor" button in the web interface.
+
+**Preset names:**
+
+| Preset | Command | Terminal? |
+|--------|---------|-----------|
+| `code` | `code {path}` | No |
+| `cursor` | `cursor {path}` | No |
+| `zed` | `zed {path}` | No |
+| `subl` | `subl {path}` | No |
+| `idea` | `idea {path}` | No |
+| `emacs` | `emacsclient -n {path}` | No |
+| `nvim` | `nvim {path}` | Yes |
+| `vim` | `vim {path}` | Yes |
+| `atom` | `atom {path}` | No |
+
+**Examples:**
+
+```json
+{"editor": "cursor"}
+```
+
+```json
+{"editor": "myeditor --open {path}"}
+```
+
+**Fallback chain:**
+
+When not set, `sgai` uses the following fallback chain:
+
+1. `$VISUAL` environment variable
+2. `$EDITOR` environment variable
+3. `code` (VS Code)
+
+**Custom commands:**
+
+- If your custom command contains `{path}`, it will be replaced with the file path.
+- If your custom command does not contain `{path}`, the path is appended to the end.
+- Environment variable values are treated as custom commands.
+- Custom commands are assumed to be GUI editors (not terminal editors).
+
+**Terminal editors:**
+
+Terminal-based editors (`vim`, `nvim`) cannot be opened from the web interface. When a terminal editor is configured, the "Open in Editor" button is hidden.
+
+### `mcp`
+
+Type: object (`map[string]json.RawMessage`)
+
+`mcp` allows defining additional MCP entries that are merged into `.sgai/opencode.jsonc`.
+
+Merge rules:
+
+- `sgai` only adds an MCP entry when the entry name does not already exist in `.sgai/opencode.jsonc`.
+- If `sgai.json` contains MCP entries but all of them already exist in `.sgai/opencode.jsonc`, `sgai` does not rewrite `.sgai/opencode.jsonc`.
+
+## Notes
+
+- If `sgai.json` does not exist, `sgai` proceeds without configuration.
+- If `sgai.json` exists but cannot be read due to permissions, `sgai` reports a "permission denied reading config file" error.
+- If `sgai.json` contains invalid JSON syntax or type mismatches, `sgai` reports an error that includes the file path and the failing offset or field.

--- a/cmd/sgai/docs/reference/workflow-state.md
+++ b/cmd/sgai/docs/reference/workflow-state.md
@@ -1,0 +1,73 @@
+# Workflow state (`.sgai/state.json`)
+
+`sgai` persists workflow state as JSON in `.sgai/state.json` inside the project directory.
+
+## File location
+
+- Path: `.sgai/state.json`
+
+## Status values
+
+The `status` field in `.sgai/state.json` uses these values:
+
+- `working`
+- `agent-done`
+- `complete`
+
+### Coordinator-only statuses in MCP
+
+The MCP tool `update_workflow_state` uses a per-agent JSON schema.
+
+- When the current agent is `coordinator`, the schema allows `complete`.
+- When the current agent is not `coordinator`, the schema only allows `working` and `agent-done`.
+
+## Human interaction
+
+`sgai` uses structured, multi-choice questions for human input.
+
+- The coordinator communicates with the human partner through `ask_user_question`.
+- The workflow state file stores the active question in `multiChoiceQuestion`.
+
+## Workflow object shape
+
+`state.json` stores a JSON object with fields used by the CLI, web UI, and MCP tools.
+
+Common fields include:
+
+- `status` (string)
+- `task` (string)
+- `progress` (array of objects with `timestamp`, `agent`, `description`)
+- `multiChoiceQuestion` (object with `questions`, each with `question`, `choices`, `multiSelect`)
+- `messages` (array of inter-agent messages)
+- `visitCounts` (object map of agent name to integer)
+- `currentAgent` (string)
+- `todos` (array of todo items)
+- `projectTodos` (array of todo items)
+- `agentSequence` (array with `agent`, `startTime`, `isCurrent`)
+- `sessionId` (string)
+- `cost` (object with `totalCost`, `totalTokens`, and `byAgent`)
+- `modelStatuses` (object map of model ID to status string)
+- `currentModel` (string, format `agentName:modelSpec`)
+
+## Messages
+
+A message entry includes:
+
+- `id` (number)
+- `fromAgent` (string)
+- `toAgent` (string)
+- `body` (string)
+- `read` (boolean)
+- `readAt` (string)
+- `readBy` (string)
+- `createdAt` (string)
+
+## TODO items
+
+A todo item includes:
+
+- `id` (string)
+- `content` (string)
+- `status` (string)
+- `priority` (string)
+

--- a/cmd/sgai/serve_api.go
+++ b/cmd/sgai/serve_api.go
@@ -126,6 +126,8 @@ func (s *Server) registerAPIRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/v1/compose/templates", s.handleAPIComposeTemplates)
 	mux.HandleFunc("GET /api/v1/compose/preview", s.handleAPIComposePreview)
 	mux.HandleFunc("POST /api/v1/compose/draft", s.handleAPIComposeDraft)
+	mux.HandleFunc("GET /api/v1/chat/config", s.handleAPIChatConfig)
+	mux.HandleFunc("POST /api/v1/chat", s.handleAPIChat)
 }
 
 func (s *Server) handleSSEStream(w http.ResponseWriter, r *http.Request) {

--- a/cmd/sgai/webapp/src/App.tsx
+++ b/cmd/sgai/webapp/src/App.tsx
@@ -2,6 +2,7 @@ import { Outlet } from "react-router";
 import { AppStateProvider } from "./contexts/AppStateProvider";
 import { ConnectionStatusBanner } from "./components/ConnectionStatusBanner";
 import { NotificationPermissionBar } from "./components/NotificationPermissionBar";
+import { ChatAssistant } from "./components/ChatAssistant";
 import { TooltipProvider } from "./components/ui/tooltip";
 import { useNotifications } from "./hooks/useNotifications";
 
@@ -18,6 +19,7 @@ export function App() {
             <Outlet />
           </main>
         </div>
+        <ChatAssistant />
       </TooltipProvider>
     </AppStateProvider>
   );

--- a/cmd/sgai/webapp/src/components/ChatAssistant/ChatButton.test.tsx
+++ b/cmd/sgai/webapp/src/components/ChatAssistant/ChatButton.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeEach } from "bun:test";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { ChatButton } from "./ChatButton";
+import { resetDefaultChatStore, getDefaultChatStore } from "@/lib/chat-store";
+
+describe("ChatButton", () => {
+  beforeEach(() => {
+    cleanup();
+    resetDefaultChatStore();
+  });
+
+  it("renders a button with chat icon", () => {
+    render(<ChatButton />);
+
+    const button = screen.getByRole("button", { name: /open chat assistant/i });
+    expect(button).toBeTruthy();
+  });
+
+  it("toggles chat open state when clicked", () => {
+    render(<ChatButton />);
+    const store = getDefaultChatStore();
+
+    expect(store.getSnapshot().isOpen).toBe(false);
+
+    const button = screen.getByRole("button");
+    fireEvent.click(button);
+
+    expect(store.getSnapshot().isOpen).toBe(true);
+
+    fireEvent.click(button);
+    expect(store.getSnapshot().isOpen).toBe(false);
+  });
+
+  it("has fixed positioning", () => {
+    const { container } = render(<ChatButton />);
+
+    const button = container.querySelector("button");
+    expect(button?.className).toContain("fixed");
+    expect(button?.className).toContain("bottom-4");
+    expect(button?.className).toContain("right-4");
+  });
+
+  it("updates aria-label based on open state", () => {
+    render(<ChatButton />);
+    const store = getDefaultChatStore();
+
+    let button = screen.getByRole("button", { name: /open chat assistant/i });
+    expect(button).toBeTruthy();
+
+    fireEvent.click(button);
+
+    button = screen.getByRole("button", { name: /close chat assistant/i });
+    expect(button).toBeTruthy();
+  });
+});

--- a/cmd/sgai/webapp/src/components/ChatAssistant/ChatButton.tsx
+++ b/cmd/sgai/webapp/src/components/ChatAssistant/ChatButton.tsx
@@ -1,0 +1,24 @@
+import { MessageCircleIcon } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { useChatActions, useChatIsOpen } from "@/hooks/useChatStore";
+import { cn } from "@/lib/utils";
+
+export function ChatButton() {
+  const { toggleOpen } = useChatActions();
+  const isOpen = useChatIsOpen();
+
+  return (
+    <Button
+      onClick={toggleOpen}
+      size="icon"
+      className={cn(
+        "fixed bottom-4 right-4 z-50 size-12 rounded-full shadow-lg",
+        "hover:scale-105 transition-transform",
+        isOpen && "bg-secondary text-secondary-foreground"
+      )}
+      aria-label={isOpen ? "Close chat assistant" : "Open chat assistant"}
+    >
+      <MessageCircleIcon className="size-6" />
+    </Button>
+  );
+}

--- a/cmd/sgai/webapp/src/components/ChatAssistant/ChatDrawer.tsx
+++ b/cmd/sgai/webapp/src/components/ChatAssistant/ChatDrawer.tsx
@@ -1,0 +1,133 @@
+import { useEffect, useRef, useCallback } from "react";
+import { useLocation } from "react-router";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
+} from "@/components/ui/sheet";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { ChatMessage } from "./ChatMessage";
+import { ChatInput } from "./ChatInput";
+import {
+  useChatMessages,
+  useChatIsOpen,
+  useChatIsStreaming,
+  useChatActions,
+} from "@/hooks/useChatStore";
+import { sendChatMessage, formatConversationHistory } from "@/lib/chat-api";
+
+export function ChatDrawer() {
+  const messages = useChatMessages();
+  const isOpen = useChatIsOpen();
+  const isStreaming = useChatIsStreaming();
+  const {
+    setOpen,
+    addUserMessage,
+    startStreaming,
+    appendStreamChunk,
+    finishStreaming,
+    setContext,
+  } = useChatActions();
+
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const location = useLocation();
+
+  useEffect(() => {
+    setContext({
+      currentPage: location.pathname,
+      workspaceName: extractWorkspaceName(location.pathname),
+    });
+  }, [location.pathname, setContext]);
+
+  useEffect(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+    }
+  }, [messages]);
+
+  const handleSendMessage = useCallback(
+    async (content: string) => {
+      addUserMessage(content);
+      startStreaming();
+
+      const conversationHistory = formatConversationHistory(messages);
+
+      await sendChatMessage(
+        {
+          message: content,
+          conversationHistory,
+          context: {
+            currentPage: location.pathname,
+            workspaceName: extractWorkspaceName(location.pathname),
+          },
+        },
+        {
+          onChunk: (chunk) => {
+            appendStreamChunk(chunk);
+          },
+          onComplete: () => {
+            finishStreaming();
+          },
+          onError: (error) => {
+            console.error("Chat error:", error);
+            appendStreamChunk(`\n\nError: ${error.message}`);
+            finishStreaming();
+          },
+        }
+      );
+    },
+    [messages, location.pathname, addUserMessage, startStreaming, appendStreamChunk, finishStreaming]
+  );
+
+  const handleOpenChange = useCallback(
+    (open: boolean) => {
+      setOpen(open);
+    },
+    [setOpen]
+  );
+
+  return (
+    <Sheet open={isOpen} onOpenChange={handleOpenChange}>
+      <SheetContent
+        side="right"
+        className="flex flex-col w-full sm:max-w-md p-0"
+        showCloseButton={true}
+      >
+        <SheetHeader className="px-4 pt-4 pb-2 border-b">
+          <SheetTitle>SGAI Assistant</SheetTitle>
+          <SheetDescription>
+            Ask questions about SGAI, your workspace, or get help.
+          </SheetDescription>
+        </SheetHeader>
+
+        <ScrollArea ref={scrollRef} className="flex-1 p-4">
+          <div className="flex flex-col gap-3">
+            {messages.length === 0 && (
+              <div className="text-center text-muted-foreground text-sm py-8">
+                <p>Welcome! I can help you understand SGAI.</p>
+                <p className="mt-2">Try asking:</p>
+                <ul className="mt-2 space-y-1">
+                  <li>&quot;What is SGAI?&quot;</li>
+                  <li>&quot;How do I create a workspace?&quot;</li>
+                  <li>&quot;What are skills?&quot;</li>
+                </ul>
+              </div>
+            )}
+            {messages.map((message) => (
+              <ChatMessage key={message.id} message={message} />
+            ))}
+          </div>
+        </ScrollArea>
+
+        <ChatInput onSend={handleSendMessage} disabled={isStreaming} />
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+function extractWorkspaceName(pathname: string): string | undefined {
+  const match = pathname.match(/^\/workspaces\/([^/]+)/);
+  return match ? decodeURIComponent(match[1]) : undefined;
+}

--- a/cmd/sgai/webapp/src/components/ChatAssistant/ChatInput.test.tsx
+++ b/cmd/sgai/webapp/src/components/ChatAssistant/ChatInput.test.tsx
@@ -1,0 +1,97 @@
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { ChatInput } from "./ChatInput";
+
+describe("ChatInput", () => {
+  const mockOnSend = mock(() => {});
+
+  beforeEach(() => {
+    cleanup();
+    mockOnSend.mockClear();
+  });
+
+  it("renders input and send button", () => {
+    render(<ChatInput onSend={mockOnSend} />);
+
+    expect(screen.getByRole("textbox")).toBeTruthy();
+    expect(screen.getByRole("button", { name: /send/i })).toBeTruthy();
+  });
+
+  it("uses custom placeholder", () => {
+    render(<ChatInput onSend={mockOnSend} placeholder="Type here..." />);
+
+    const input = screen.getByPlaceholderText("Type here...");
+    expect(input).toBeTruthy();
+  });
+
+  it("calls onSend when form is submitted", () => {
+    render(<ChatInput onSend={mockOnSend} />);
+
+    const input = screen.getByRole("textbox");
+    fireEvent.change(input, { target: { value: "Hello world" } });
+    fireEvent.submit(input.closest("form")!);
+
+    expect(mockOnSend).toHaveBeenCalledWith("Hello world");
+  });
+
+  it("calls onSend when Enter is pressed", () => {
+    render(<ChatInput onSend={mockOnSend} />);
+
+    const input = screen.getByRole("textbox");
+    fireEvent.change(input, { target: { value: "Test message" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(mockOnSend).toHaveBeenCalledWith("Test message");
+  });
+
+  it("does not send empty messages", () => {
+    render(<ChatInput onSend={mockOnSend} />);
+
+    const button = screen.getByRole("button", { name: /send/i });
+    fireEvent.click(button);
+
+    expect(mockOnSend).not.toHaveBeenCalled();
+  });
+
+  it("does not send whitespace-only messages", () => {
+    render(<ChatInput onSend={mockOnSend} />);
+
+    const input = screen.getByRole("textbox");
+    fireEvent.change(input, { target: { value: "   " } });
+
+    const button = screen.getByRole("button", { name: /send/i });
+    fireEvent.click(button);
+
+    expect(mockOnSend).not.toHaveBeenCalled();
+  });
+
+  it("clears input after sending", () => {
+    render(<ChatInput onSend={mockOnSend} />);
+
+    const input = screen.getByRole("textbox") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "Hello" } });
+    fireEvent.submit(input.closest("form")!);
+
+    expect(input.value).toBe("");
+  });
+
+  it("disables input and button when disabled prop is true", () => {
+    render(<ChatInput onSend={mockOnSend} disabled={true} />);
+
+    const input = screen.getByRole("textbox") as HTMLInputElement;
+    const button = screen.getByRole("button", { name: /send/i }) as HTMLButtonElement;
+
+    expect(input.disabled).toBe(true);
+    expect(button.disabled).toBe(true);
+  });
+
+  it("trims message before sending", () => {
+    render(<ChatInput onSend={mockOnSend} />);
+
+    const input = screen.getByRole("textbox");
+    fireEvent.change(input, { target: { value: "  Hello world  " } });
+    fireEvent.submit(input.closest("form")!);
+
+    expect(mockOnSend).toHaveBeenCalledWith("Hello world");
+  });
+});

--- a/cmd/sgai/webapp/src/components/ChatAssistant/ChatInput.tsx
+++ b/cmd/sgai/webapp/src/components/ChatAssistant/ChatInput.tsx
@@ -1,0 +1,57 @@
+import { useState, useCallback, type KeyboardEvent, type FormEvent } from "react";
+import { SendIcon } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+interface ChatInputProps {
+  onSend: (message: string) => void;
+  disabled?: boolean;
+  placeholder?: string;
+}
+
+export function ChatInput({ onSend, disabled = false, placeholder = "Ask about SGAI..." }: ChatInputProps) {
+  const [value, setValue] = useState("");
+
+  const handleSubmit = useCallback(
+    (e?: FormEvent) => {
+      e?.preventDefault();
+      const trimmed = value.trim();
+      if (!trimmed || disabled) return;
+      onSend(trimmed);
+      setValue("");
+    },
+    [value, disabled, onSend]
+  );
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === "Enter" && !e.shiftKey) {
+        e.preventDefault();
+        handleSubmit();
+      }
+    },
+    [handleSubmit]
+  );
+
+  return (
+    <form onSubmit={handleSubmit} className="flex gap-2 p-3 border-t bg-background">
+      <Input
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        onKeyDown={handleKeyDown}
+        placeholder={placeholder}
+        disabled={disabled}
+        className="flex-1"
+        aria-label="Chat message input"
+      />
+      <Button
+        type="submit"
+        size="icon"
+        disabled={disabled || !value.trim()}
+        aria-label="Send message"
+      >
+        <SendIcon className="size-4" />
+      </Button>
+    </form>
+  );
+}

--- a/cmd/sgai/webapp/src/components/ChatAssistant/ChatMessage.test.tsx
+++ b/cmd/sgai/webapp/src/components/ChatAssistant/ChatMessage.test.tsx
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "bun:test";
+import { render, screen } from "@testing-library/react";
+import { ChatMessage } from "./ChatMessage";
+import type { ChatMessage as ChatMessageType } from "@/lib/chat-store";
+
+function createMessage(overrides: Partial<ChatMessageType> = {}): ChatMessageType {
+  return {
+    id: "test-id",
+    role: "user",
+    content: "Test message",
+    timestamp: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+describe("ChatMessage", () => {
+  it("renders user message with correct styling", () => {
+    const message = createMessage({ role: "user", content: "Hello!" });
+    render(<ChatMessage message={message} />);
+
+    const text = screen.getByText("Hello!");
+    expect(text).toBeTruthy();
+
+    const container = text.closest("div[class*='bg-primary']");
+    expect(container).toBeTruthy();
+  });
+
+  it("renders assistant message with correct styling", () => {
+    const message = createMessage({ role: "assistant", content: "Hi there!" });
+    render(<ChatMessage message={message} />);
+
+    const text = screen.getByText("Hi there!");
+    expect(text).toBeTruthy();
+
+    const container = text.closest("div[class*='bg-muted']");
+    expect(container).toBeTruthy();
+  });
+
+  it("shows thinking indicator for empty streaming message", () => {
+    const message = createMessage({
+      role: "assistant",
+      content: "",
+      isStreaming: true,
+    });
+    render(<ChatMessage message={message} />);
+
+    expect(screen.getByText("Thinking...")).toBeTruthy();
+  });
+
+  it("renders markdown content for assistant messages", () => {
+    const message = createMessage({
+      role: "assistant",
+      content: "**Bold text**",
+    });
+    render(<ChatMessage message={message} />);
+
+    const boldElement = screen.getByText("Bold text");
+    expect(boldElement).toBeTruthy();
+  });
+
+  it("applies animation class when streaming", () => {
+    const message = createMessage({
+      role: "assistant",
+      content: "Streaming...",
+      isStreaming: true,
+    });
+    const { container } = render(<ChatMessage message={message} />);
+
+    const animatedElement = container.querySelector(".animate-pulse");
+    expect(animatedElement).toBeTruthy();
+  });
+});

--- a/cmd/sgai/webapp/src/components/ChatAssistant/ChatMessage.tsx
+++ b/cmd/sgai/webapp/src/components/ChatAssistant/ChatMessage.tsx
@@ -1,0 +1,42 @@
+import { cn } from "@/lib/utils";
+import { MarkdownContent } from "../MarkdownContent";
+import type { ChatMessage as ChatMessageType } from "@/lib/chat-store";
+
+interface ChatMessageProps {
+  message: ChatMessageType;
+}
+
+export function ChatMessage({ message }: ChatMessageProps) {
+  const isUser = message.role === "user";
+
+  return (
+    <div
+      className={cn(
+        "flex w-full",
+        isUser ? "justify-end" : "justify-start"
+      )}
+    >
+      <div
+        className={cn(
+          "max-w-[85%] rounded-lg px-3 py-2",
+          isUser
+            ? "bg-primary text-primary-foreground"
+            : "bg-muted text-foreground",
+          message.isStreaming && "animate-pulse"
+        )}
+      >
+        {isUser ? (
+          <p className="text-sm whitespace-pre-wrap">{message.content}</p>
+        ) : (
+          <div className="text-sm">
+            {message.content ? (
+              <MarkdownContent content={message.content} />
+            ) : (
+              <span className="text-muted-foreground italic">Thinking...</span>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/cmd/sgai/webapp/src/components/ChatAssistant/index.tsx
+++ b/cmd/sgai/webapp/src/components/ChatAssistant/index.tsx
@@ -1,0 +1,16 @@
+import { ChatButton } from "./ChatButton";
+import { ChatDrawer } from "./ChatDrawer";
+
+export function ChatAssistant() {
+  return (
+    <>
+      <ChatButton />
+      <ChatDrawer />
+    </>
+  );
+}
+
+export { ChatButton } from "./ChatButton";
+export { ChatDrawer } from "./ChatDrawer";
+export { ChatInput } from "./ChatInput";
+export { ChatMessage } from "./ChatMessage";

--- a/cmd/sgai/webapp/src/hooks/useChatStore.test.ts
+++ b/cmd/sgai/webapp/src/hooks/useChatStore.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, beforeEach } from "bun:test";
+import { renderHook, act } from "@testing-library/react";
+import {
+  useChatStore,
+  useChatMessages,
+  useChatIsOpen,
+  useChatIsStreaming,
+  useChatActions,
+} from "./useChatStore";
+import { resetDefaultChatStore, getDefaultChatStore } from "../lib/chat-store";
+
+describe("useChatStore hooks", () => {
+  beforeEach(() => {
+    resetDefaultChatStore();
+  });
+
+  describe("useChatStore", () => {
+    it("returns the full store snapshot", () => {
+      const { result } = renderHook(() => useChatStore());
+
+      expect(result.current).toHaveProperty("messages");
+      expect(result.current).toHaveProperty("isOpen");
+      expect(result.current).toHaveProperty("isStreaming");
+      expect(result.current).toHaveProperty("context");
+    });
+
+    it("updates when store changes", () => {
+      const { result } = renderHook(() => useChatStore());
+      const store = getDefaultChatStore();
+
+      expect(result.current.messages).toHaveLength(0);
+
+      act(() => {
+        store.addUserMessage("Test");
+      });
+
+      expect(result.current.messages).toHaveLength(1);
+    });
+  });
+
+  describe("useChatMessages", () => {
+    it("returns messages array", () => {
+      const { result } = renderHook(() => useChatMessages());
+      expect(result.current).toEqual([]);
+    });
+
+    it("updates when messages change", () => {
+      const { result } = renderHook(() => useChatMessages());
+      const store = getDefaultChatStore();
+
+      act(() => {
+        store.addUserMessage("Hello");
+      });
+
+      expect(result.current).toHaveLength(1);
+      expect(result.current[0].content).toBe("Hello");
+    });
+  });
+
+  describe("useChatIsOpen", () => {
+    it("returns isOpen state", () => {
+      const { result } = renderHook(() => useChatIsOpen());
+      expect(result.current).toBe(false);
+    });
+
+    it("updates when open state changes", () => {
+      const { result } = renderHook(() => useChatIsOpen());
+      const store = getDefaultChatStore();
+
+      act(() => {
+        store.setOpen(true);
+      });
+
+      expect(result.current).toBe(true);
+    });
+  });
+
+  describe("useChatIsStreaming", () => {
+    it("returns isStreaming state", () => {
+      const { result } = renderHook(() => useChatIsStreaming());
+      expect(result.current).toBe(false);
+    });
+
+    it("updates when streaming state changes", () => {
+      const { result } = renderHook(() => useChatIsStreaming());
+      const store = getDefaultChatStore();
+
+      act(() => {
+        store.startStreaming();
+      });
+
+      expect(result.current).toBe(true);
+
+      act(() => {
+        store.finishStreaming();
+      });
+
+      expect(result.current).toBe(false);
+    });
+  });
+
+  describe("useChatActions", () => {
+    it("returns action functions", () => {
+      const { result } = renderHook(() => useChatActions());
+
+      expect(typeof result.current.addUserMessage).toBe("function");
+      expect(typeof result.current.addAssistantMessage).toBe("function");
+      expect(typeof result.current.startStreaming).toBe("function");
+      expect(typeof result.current.appendStreamChunk).toBe("function");
+      expect(typeof result.current.finishStreaming).toBe("function");
+      expect(typeof result.current.setOpen).toBe("function");
+      expect(typeof result.current.toggleOpen).toBe("function");
+      expect(typeof result.current.setContext).toBe("function");
+      expect(typeof result.current.clearMessages).toBe("function");
+    });
+
+    it("actions work correctly", () => {
+      const { result: actionsResult } = renderHook(() => useChatActions());
+      const { result: messagesResult } = renderHook(() => useChatMessages());
+
+      act(() => {
+        actionsResult.current.addUserMessage("Test message");
+      });
+
+      expect(messagesResult.current).toHaveLength(1);
+      expect(messagesResult.current[0].content).toBe("Test message");
+    });
+  });
+});

--- a/cmd/sgai/webapp/src/hooks/useChatStore.ts
+++ b/cmd/sgai/webapp/src/hooks/useChatStore.ts
@@ -1,0 +1,108 @@
+import { useSyncExternalStore, useCallback } from "react";
+import { getDefaultChatStore } from "../lib/chat-store";
+import type { ChatStoreSnapshot, ChatMessage, ChatContext } from "../lib/chat-store";
+
+export function useChatStore(): ChatStoreSnapshot {
+  const store = getDefaultChatStore();
+  return useSyncExternalStore(
+    store.subscribe,
+    store.getSnapshot,
+    store.getServerSnapshot,
+  );
+}
+
+export function useChatMessages(): ChatMessage[] {
+  const store = getDefaultChatStore();
+
+  const getSnapshot = useCallback(
+    () => store.getSnapshot().messages,
+    [store],
+  );
+
+  const getServerSnapshot = useCallback(
+    () => [] as ChatMessage[],
+    [],
+  );
+
+  return useSyncExternalStore(
+    store.subscribe,
+    getSnapshot,
+    getServerSnapshot,
+  );
+}
+
+export function useChatIsOpen(): boolean {
+  const store = getDefaultChatStore();
+
+  const getSnapshot = useCallback(
+    () => store.getSnapshot().isOpen,
+    [store],
+  );
+
+  const getServerSnapshot = useCallback(
+    () => false,
+    [],
+  );
+
+  return useSyncExternalStore(
+    store.subscribe,
+    getSnapshot,
+    getServerSnapshot,
+  );
+}
+
+export function useChatIsStreaming(): boolean {
+  const store = getDefaultChatStore();
+
+  const getSnapshot = useCallback(
+    () => store.getSnapshot().isStreaming,
+    [store],
+  );
+
+  const getServerSnapshot = useCallback(
+    () => false,
+    [],
+  );
+
+  return useSyncExternalStore(
+    store.subscribe,
+    getSnapshot,
+    getServerSnapshot,
+  );
+}
+
+export function useChatContext(): ChatContext {
+  const store = getDefaultChatStore();
+
+  const getSnapshot = useCallback(
+    () => store.getSnapshot().context,
+    [store],
+  );
+
+  const getServerSnapshot = useCallback(
+    () => ({ currentPage: "/" }) as ChatContext,
+    [],
+  );
+
+  return useSyncExternalStore(
+    store.subscribe,
+    getSnapshot,
+    getServerSnapshot,
+  );
+}
+
+export function useChatActions() {
+  const store = getDefaultChatStore();
+
+  return {
+    addUserMessage: store.addUserMessage,
+    addAssistantMessage: store.addAssistantMessage,
+    startStreaming: store.startStreaming,
+    appendStreamChunk: store.appendStreamChunk,
+    finishStreaming: store.finishStreaming,
+    setOpen: store.setOpen,
+    toggleOpen: store.toggleOpen,
+    setContext: store.setContext,
+    clearMessages: store.clearMessages,
+  };
+}

--- a/cmd/sgai/webapp/src/lib/chat-api.ts
+++ b/cmd/sgai/webapp/src/lib/chat-api.ts
@@ -1,0 +1,100 @@
+import type { ChatMessage, ChatContext } from "./chat-store";
+
+export interface ChatRequest {
+  message: string;
+  conversationHistory: { role: "user" | "assistant"; content: string }[];
+  context: ChatContext;
+}
+
+export interface ChatStreamCallbacks {
+  onChunk: (chunk: string) => void;
+  onComplete: () => void;
+  onError: (error: Error) => void;
+}
+
+export async function sendChatMessage(
+  request: ChatRequest,
+  callbacks: ChatStreamCallbacks,
+): Promise<void> {
+  const response = await fetch("/api/v1/chat", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(request),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => "Unknown error");
+    callbacks.onError(new Error(`Chat request failed: ${errorText}`));
+    return;
+  }
+
+  if (!response.body) {
+    callbacks.onError(new Error("No response body"));
+    return;
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+
+  try {
+    let buffer = "";
+    while (true) {
+      const { done, value } = await reader.read();
+
+      if (done) {
+        if (buffer.trim()) {
+          processSSELine(buffer, callbacks);
+        }
+        callbacks.onComplete();
+        break;
+      }
+
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split("\n");
+      buffer = lines.pop() || "";
+
+      for (const line of lines) {
+        processSSELine(line, callbacks);
+      }
+    }
+  } catch (error) {
+    callbacks.onError(error instanceof Error ? error : new Error(String(error)));
+  }
+}
+
+function processSSELine(line: string, callbacks: ChatStreamCallbacks): void {
+  const trimmedLine = line.trim();
+  if (!trimmedLine || trimmedLine.startsWith(":")) {
+    return;
+  }
+
+  if (trimmedLine.startsWith("data: ")) {
+    const data = trimmedLine.slice(6);
+    if (data === "[DONE]") {
+      return;
+    }
+    try {
+      const parsed = JSON.parse(data);
+      if (parsed.content) {
+        callbacks.onChunk(parsed.content);
+      } else if (parsed.error) {
+        callbacks.onError(new Error(parsed.error));
+      }
+    } catch {
+      callbacks.onChunk(data);
+    }
+  }
+}
+
+export function formatConversationHistory(
+  messages: ChatMessage[],
+): { role: "user" | "assistant"; content: string }[] {
+  return messages
+    .filter((msg) => !msg.isStreaming)
+    .map((msg) => ({
+      role: msg.role,
+      content: msg.content,
+    }));
+}

--- a/cmd/sgai/webapp/src/lib/chat-store.test.ts
+++ b/cmd/sgai/webapp/src/lib/chat-store.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, beforeEach } from "bun:test";
+import { createChatStore, resetDefaultChatStore, getDefaultChatStore } from "./chat-store";
+
+describe("createChatStore", () => {
+  let store: ReturnType<typeof createChatStore>;
+
+  beforeEach(() => {
+    store = createChatStore();
+  });
+
+  describe("initial state", () => {
+    it("starts with empty messages", () => {
+      expect(store.getSnapshot().messages).toEqual([]);
+    });
+
+    it("starts with isOpen false", () => {
+      expect(store.getSnapshot().isOpen).toBe(false);
+    });
+
+    it("starts with isStreaming false", () => {
+      expect(store.getSnapshot().isStreaming).toBe(false);
+    });
+
+    it("starts with default context", () => {
+      expect(store.getSnapshot().context).toEqual({ currentPage: "/" });
+    });
+  });
+
+  describe("addUserMessage", () => {
+    it("adds a user message to the store", () => {
+      const message = store.addUserMessage("Hello");
+
+      expect(message.role).toBe("user");
+      expect(message.content).toBe("Hello");
+      expect(store.getSnapshot().messages).toHaveLength(1);
+      expect(store.getSnapshot().messages[0]).toEqual(message);
+    });
+
+    it("generates unique IDs for messages", () => {
+      const msg1 = store.addUserMessage("First");
+      const msg2 = store.addUserMessage("Second");
+
+      expect(msg1.id).not.toBe(msg2.id);
+    });
+  });
+
+  describe("addAssistantMessage", () => {
+    it("adds an assistant message to the store", () => {
+      const message = store.addAssistantMessage("Hello, how can I help?");
+
+      expect(message.role).toBe("assistant");
+      expect(message.content).toBe("Hello, how can I help?");
+      expect(store.getSnapshot().messages).toHaveLength(1);
+    });
+  });
+
+  describe("streaming", () => {
+    it("startStreaming creates an empty assistant message", () => {
+      const messageId = store.startStreaming();
+
+      expect(store.getSnapshot().isStreaming).toBe(true);
+      expect(store.getSnapshot().streamingMessageId).toBe(messageId);
+      expect(store.getSnapshot().messages).toHaveLength(1);
+      expect(store.getSnapshot().messages[0].content).toBe("");
+      expect(store.getSnapshot().messages[0].isStreaming).toBe(true);
+    });
+
+    it("appendStreamChunk adds content to streaming message", () => {
+      store.startStreaming();
+      store.appendStreamChunk("Hello");
+      store.appendStreamChunk(" world");
+
+      expect(store.getSnapshot().messages[0].content).toBe("Hello world");
+    });
+
+    it("finishStreaming completes the streaming message", () => {
+      store.startStreaming();
+      store.appendStreamChunk("Hello");
+      store.finishStreaming();
+
+      expect(store.getSnapshot().isStreaming).toBe(false);
+      expect(store.getSnapshot().streamingMessageId).toBeNull();
+      expect(store.getSnapshot().messages[0].isStreaming).toBe(false);
+    });
+  });
+
+  describe("open state", () => {
+    it("setOpen changes isOpen state", () => {
+      store.setOpen(true);
+      expect(store.getSnapshot().isOpen).toBe(true);
+
+      store.setOpen(false);
+      expect(store.getSnapshot().isOpen).toBe(false);
+    });
+
+    it("toggleOpen toggles isOpen state", () => {
+      expect(store.getSnapshot().isOpen).toBe(false);
+
+      store.toggleOpen();
+      expect(store.getSnapshot().isOpen).toBe(true);
+
+      store.toggleOpen();
+      expect(store.getSnapshot().isOpen).toBe(false);
+    });
+  });
+
+  describe("context", () => {
+    it("setContext updates the context", () => {
+      store.setContext({ currentPage: "/workspaces/test", workspaceName: "test" });
+
+      expect(store.getSnapshot().context).toEqual({
+        currentPage: "/workspaces/test",
+        workspaceName: "test",
+      });
+    });
+  });
+
+  describe("clearMessages", () => {
+    it("removes all messages", () => {
+      store.addUserMessage("First");
+      store.addAssistantMessage("Second");
+      expect(store.getSnapshot().messages).toHaveLength(2);
+
+      store.clearMessages();
+      expect(store.getSnapshot().messages).toEqual([]);
+    });
+  });
+
+  describe("subscribe", () => {
+    it("notifies listeners on state change", () => {
+      let callCount = 0;
+      const unsubscribe = store.subscribe(() => {
+        callCount++;
+      });
+
+      store.addUserMessage("Test");
+      expect(callCount).toBe(1);
+
+      store.setOpen(true);
+      expect(callCount).toBe(2);
+
+      unsubscribe();
+      store.addUserMessage("Another");
+      expect(callCount).toBe(2);
+    });
+  });
+});
+
+describe("getDefaultChatStore", () => {
+  beforeEach(() => {
+    resetDefaultChatStore();
+  });
+
+  it("returns the same instance on multiple calls", () => {
+    const store1 = getDefaultChatStore();
+    const store2 = getDefaultChatStore();
+
+    expect(store1).toBe(store2);
+  });
+
+  it("resetDefaultChatStore creates a new instance", () => {
+    const store1 = getDefaultChatStore();
+    store1.addUserMessage("Test");
+
+    resetDefaultChatStore();
+    const store2 = getDefaultChatStore();
+
+    expect(store2.getSnapshot().messages).toEqual([]);
+  });
+});

--- a/cmd/sgai/webapp/src/lib/chat-store.ts
+++ b/cmd/sgai/webapp/src/lib/chat-store.ts
@@ -1,0 +1,180 @@
+type Listener = () => void;
+
+export interface ChatMessage {
+  id: string;
+  role: "user" | "assistant";
+  content: string;
+  timestamp: string;
+  isStreaming?: boolean;
+}
+
+export interface ChatContext {
+  currentPage: string;
+  workspaceName?: string;
+}
+
+export interface ChatStoreSnapshot {
+  messages: ChatMessage[];
+  isOpen: boolean;
+  isStreaming: boolean;
+  streamingMessageId: string | null;
+  context: ChatContext;
+}
+
+function createInitialSnapshot(): ChatStoreSnapshot {
+  return {
+    messages: [],
+    isOpen: false,
+    isStreaming: false,
+    streamingMessageId: null,
+    context: { currentPage: "/" },
+  };
+}
+
+export function createChatStore() {
+  let snapshot = createInitialSnapshot();
+  const listeners: Set<Listener> = new Set();
+
+  function emitChange() {
+    for (const listener of listeners) {
+      listener();
+    }
+  }
+
+  function updateSnapshot(partial: Partial<ChatStoreSnapshot>) {
+    snapshot = { ...snapshot, ...partial };
+    emitChange();
+  }
+
+  function generateId(): string {
+    return `msg-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+  }
+
+  function addUserMessage(content: string): ChatMessage {
+    const message: ChatMessage = {
+      id: generateId(),
+      role: "user",
+      content,
+      timestamp: new Date().toISOString(),
+    };
+    updateSnapshot({ messages: [...snapshot.messages, message] });
+    return message;
+  }
+
+  function addAssistantMessage(content: string): ChatMessage {
+    const message: ChatMessage = {
+      id: generateId(),
+      role: "assistant",
+      content,
+      timestamp: new Date().toISOString(),
+    };
+    updateSnapshot({ messages: [...snapshot.messages, message] });
+    return message;
+  }
+
+  function startStreaming(): string {
+    const messageId = generateId();
+    const message: ChatMessage = {
+      id: messageId,
+      role: "assistant",
+      content: "",
+      timestamp: new Date().toISOString(),
+      isStreaming: true,
+    };
+    updateSnapshot({
+      messages: [...snapshot.messages, message],
+      isStreaming: true,
+      streamingMessageId: messageId,
+    });
+    return messageId;
+  }
+
+  function appendStreamChunk(chunk: string): void {
+    if (!snapshot.streamingMessageId) return;
+
+    const updatedMessages = snapshot.messages.map((msg) => {
+      if (msg.id === snapshot.streamingMessageId) {
+        return { ...msg, content: msg.content + chunk };
+      }
+      return msg;
+    });
+    updateSnapshot({ messages: updatedMessages });
+  }
+
+  function finishStreaming(): void {
+    if (!snapshot.streamingMessageId) return;
+
+    const updatedMessages = snapshot.messages.map((msg) => {
+      if (msg.id === snapshot.streamingMessageId) {
+        return { ...msg, isStreaming: false };
+      }
+      return msg;
+    });
+    updateSnapshot({
+      messages: updatedMessages,
+      isStreaming: false,
+      streamingMessageId: null,
+    });
+  }
+
+  function setOpen(isOpen: boolean): void {
+    updateSnapshot({ isOpen });
+  }
+
+  function toggleOpen(): void {
+    updateSnapshot({ isOpen: !snapshot.isOpen });
+  }
+
+  function setContext(context: ChatContext): void {
+    updateSnapshot({ context });
+  }
+
+  function clearMessages(): void {
+    updateSnapshot({ messages: [] });
+  }
+
+  function subscribe(listener: Listener): () => void {
+    listeners.add(listener);
+    return () => {
+      listeners.delete(listener);
+    };
+  }
+
+  function getSnapshot(): ChatStoreSnapshot {
+    return snapshot;
+  }
+
+  function getServerSnapshot(): ChatStoreSnapshot {
+    return createInitialSnapshot();
+  }
+
+  return {
+    subscribe,
+    getSnapshot,
+    getServerSnapshot,
+    addUserMessage,
+    addAssistantMessage,
+    startStreaming,
+    appendStreamChunk,
+    finishStreaming,
+    setOpen,
+    toggleOpen,
+    setContext,
+    clearMessages,
+  };
+}
+
+export type ChatStore = ReturnType<typeof createChatStore>;
+
+let defaultChatStore: ChatStore | null = null;
+
+export function getDefaultChatStore(): ChatStore {
+  if (!defaultChatStore) {
+    defaultChatStore = createChatStore();
+  }
+  return defaultChatStore;
+}
+
+export function resetDefaultChatStore(): void {
+  defaultChatStore = null;
+}


### PR DESCRIPTION
## Summary

- Add RAG-powered chat assistant accessible from every page of the web dashboard
- Go backend: streaming chat endpoint with embedded documentation for context-aware responses
- React frontend: floating chat button, slide-out drawer with message history and markdown rendering
- Add GOALS/2026_02_28_add_interactive_chat_assistant.md specification