### PR TITLE
INSTALLATION.md: add platform-specific instructions and pre-flight checks

### DIFF
--- a/GOALS/2026_02_28_improve_installation_instructions.md
+++ b/GOALS/2026_02_28_improve_installation_instructions.md
@@ -1,0 +1,30 @@
+---
+flow: |
+  "backend-go-developer" -> "go-readability-reviewer"
+  "backend-go-developer" -> "stpa-analyst"
+  "go-readability-reviewer" -> "stpa-analyst"
+  "general-purpose" -> "stpa-analyst"
+  "react-developer" -> "react-reviewer"
+  "react-reviewer" -> "stpa-analyst"
+  "project-critic-council"
+  "skill-writer"
+models:
+  "coordinator": "anthropic/claude-opus-4-6 (max)"
+  "backend-go-developer": "anthropic/claude-opus-4-6"
+  "go-readability-reviewer": "anthropic/claude-opus-4-6"
+  "general-purpose": "anthropic/claude-opus-4-6"
+  "react-developer": "anthropic/claude-opus-4-6"
+  "react-reviewer": "anthropic/claude-opus-4-6"
+  "stpa-analyst": "anthropic/claude-opus-4-6"
+  "project-critic-council": ["anthropic/claude-opus-4-6","anthropic/claude-sonnet-4-6", "anthropic/claude-opus-4-5"]
+  "skill-writer": "anthropic/claude-opus-4-6 (max)"
+completionGateScript: make test
+---
+
+We need to improve INSTALLATION.md
+
+- [ ] linux specific instructions
+  - [ ] you must test for sudo and whether the sudo is in passwordless mode;
+    - [ ] when sudo is not in passwordless mode, must INTERRUPT AND ALERT USER YOU CAN'T PROCEED WITH INSTALLATION
+- [ ] when installing, you must avoid hitting permission errors
+  - [ ] the most common problem is trying to access directories out of the current working directory, this is disabled. Refer to https://opencode.ai/docs/permissions#external-directories (you must keep the permission)


### PR DESCRIPTION
## Summary

- Add Step 0 pre-flight checks: OS detection, sudo availability and passwordless mode verification on Linux
- When sudo is unavailable or requires a password, interrupt with clear instructions listing manual package-install commands per detected package manager (apt, dnf, pacman, zypper, apk)
- Add platform-specific dependency installation instructions for macOS (Homebrew) and Linux (per package manager)
- Wrap clone/build commands in `bash -c` to avoid opencode external-directory permission errors
- Add GOALS/2026_02_28_improve_installation_instructions.md specification