### PR TITLE
cmd/sgai: add Monaco rich editor for markdown editing

### DIFF
--- a/GOALS/2026_02_28_rich_editor_monaco.md
+++ b/GOALS/2026_02_28_rich_editor_monaco.md
@@ -1,0 +1,36 @@
+---
+flow: |
+  "backend-go-developer" -> "go-readability-reviewer"
+  "react-developer" -> "react-reviewer"
+  "general-purpose"
+  "project-critic-council"
+  "skill-writer"
+  "stpa-analyst"
+models:
+  "coordinator": "anthropic/claude-opus-4-6 (max)"
+  "backend-go-developer": "anthropic/claude-opus-4-6"
+  "go-readability-reviewer": "anthropic/claude-opus-4-6"
+  "general-purpose": "anthropic/claude-opus-4-6"
+  "react-developer": "anthropic/claude-opus-4-6"
+  "react-reviewer": "anthropic/claude-opus-4-6"
+  "stpa-analyst": "anthropic/claude-opus-4-6"
+  "project-critic-council": ["anthropic/claude-opus-4-6", "anthropic/claude-sonnet-4-6", "anthropic/claude-opus-4-5"]
+  "skill-writer": "anthropic/claude-opus-4-6 (max)"
+---
+
+Refer to https://microsoft.github.io/monaco-editor/
+
+- [x] use rich editor for Edit GOAL (assume markdown)
+  - [x] ensure the rich editor always has word-wrap turned on by default
+  - [x] add basic markdown operations buttons
+- [x] use rich editor for Compose GOAL (assume markdown) wizard staged
+  - [x] ensure the rich editor always has word-wrap turned on by default
+  - [x] add basic markdown operations buttons
+- [x] use rich editor for Respond to Agent (assume markdown)
+  - [x] ensure the rich editor always has word-wrap turned on by default
+  - [x] add basic markdown operations buttons
+- [x] use rich editor for AdHoc Runs (assume markdown)
+  - [x] ensure the rich editor always has word-wrap turned on by default
+  - [x] add basic markdown operations buttons
+- [x] Fix the resize - in http://localhost:8080/workspaces/rich-editor-monaco/goal/edit, when I resized the editor to be taller, the container resized, but the embedded editor didn't.
+- [x] Close https://github.com/sandgardenhq/sgai/issues/72

--- a/cmd/sgai/webapp/bun.lock
+++ b/cmd/sgai/webapp/bun.lock
@@ -4,6 +4,7 @@
     "": {
       "name": "sgai-webapp",
       "dependencies": {
+        "@monaco-editor/react": "^4.7.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.575.0",
@@ -13,6 +14,7 @@
         "react-markdown": "^10.1.0",
         "react-router": "^7.6.2",
         "rehype-raw": "^7.0.0",
+        "remark-frontmatter": "^5.0.0",
         "remark-gfm": "^4.0.0",
         "tailwind-merge": "^3.4.0",
         "tw-animate-css": "^1.4.0",
@@ -62,6 +64,10 @@
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@monaco-editor/loader": ["@monaco-editor/loader@1.7.0", "", { "dependencies": { "state-local": "^1.0.6" } }, "sha512-gIwR1HrJrrx+vfyOhYmCZ0/JcWqG5kbfG7+d3f/C1LXk2EvzAbHSg3MQ5lO2sMlo9izoAZ04shohfKLVT6crVA=="],
+
+    "@monaco-editor/react": ["@monaco-editor/react@4.7.0", "", { "dependencies": { "@monaco-editor/loader": "^1.5.0" }, "peerDependencies": { "monaco-editor": ">= 0.25.0 < 1", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-cyzXQCtO47ydzxpQtCGSQGOC8Gk3ZUeBXFAxD+CWXYFo5OqZyZUonFl0DwUlTyAfRHntBfw2p3w4s9R6oe1eCA=="],
 
     "@parcel/watcher": ["@parcel/watcher@2.5.6", "", { "dependencies": { "detect-libc": "^2.0.3", "is-glob": "^4.0.3", "node-addon-api": "^7.0.0", "picomatch": "^4.0.3" }, "optionalDependencies": { "@parcel/watcher-android-arm64": "2.5.6", "@parcel/watcher-darwin-arm64": "2.5.6", "@parcel/watcher-darwin-x64": "2.5.6", "@parcel/watcher-freebsd-x64": "2.5.6", "@parcel/watcher-linux-arm-glibc": "2.5.6", "@parcel/watcher-linux-arm-musl": "2.5.6", "@parcel/watcher-linux-arm64-glibc": "2.5.6", "@parcel/watcher-linux-arm64-musl": "2.5.6", "@parcel/watcher-linux-x64-glibc": "2.5.6", "@parcel/watcher-linux-x64-musl": "2.5.6", "@parcel/watcher-win32-arm64": "2.5.6", "@parcel/watcher-win32-ia32": "2.5.6", "@parcel/watcher-win32-x64": "2.5.6" } }, "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ=="],
 
@@ -271,6 +277,8 @@
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
 
+    "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
+
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
     "@types/whatwg-mimetype": ["@types/whatwg-mimetype@3.0.2", "", {}, "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA=="],
@@ -325,6 +333,8 @@
 
     "dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
 
+    "dompurify": ["dompurify@3.2.7", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw=="],
+
     "enhanced-resolve": ["enhanced-resolve@5.19.0", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.0" } }, "sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg=="],
 
     "entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
@@ -334,6 +344,10 @@
     "estree-util-is-identifier-name": ["estree-util-is-identifier-name@3.0.0", "", {}, "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg=="],
 
     "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
+
+    "fault": ["fault@2.0.1", "", { "dependencies": { "format": "^0.2.0" } }, "sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ=="],
+
+    "format": ["format@0.2.2", "", {}, "sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww=="],
 
     "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
@@ -415,9 +429,13 @@
 
     "markdown-table": ["markdown-table@3.0.4", "", {}, "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw=="],
 
+    "marked": ["marked@14.0.0", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ=="],
+
     "mdast-util-find-and-replace": ["mdast-util-find-and-replace@3.0.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "escape-string-regexp": "^5.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg=="],
 
     "mdast-util-from-markdown": ["mdast-util-from-markdown@2.0.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "mdast-util-to-string": "^4.0.0", "micromark": "^4.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-decode-string": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA=="],
+
+    "mdast-util-frontmatter": ["mdast-util-frontmatter@2.0.1", "", { "dependencies": { "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "escape-string-regexp": "^5.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0", "micromark-extension-frontmatter": "^2.0.0" } }, "sha512-LRqI9+wdgC25P0URIJY9vwocIzCcksduHQ9OF2joxQoyTNVduwLAFUzjoopuRJbJAReaKrNQKAZKL3uCMugWJA=="],
 
     "mdast-util-gfm": ["mdast-util-gfm@3.1.0", "", { "dependencies": { "mdast-util-from-markdown": "^2.0.0", "mdast-util-gfm-autolink-literal": "^2.0.0", "mdast-util-gfm-footnote": "^2.0.0", "mdast-util-gfm-strikethrough": "^2.0.0", "mdast-util-gfm-table": "^2.0.0", "mdast-util-gfm-task-list-item": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ=="],
 
@@ -448,6 +466,8 @@
     "micromark": ["micromark@4.0.2", "", { "dependencies": { "@types/debug": "^4.0.0", "debug": "^4.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA=="],
 
     "micromark-core-commonmark": ["micromark-core-commonmark@2.0.3", "", { "dependencies": { "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-factory-destination": "^2.0.0", "micromark-factory-label": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-factory-title": "^2.0.0", "micromark-factory-whitespace": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-html-tag-name": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg=="],
+
+    "micromark-extension-frontmatter": ["micromark-extension-frontmatter@2.0.0", "", { "dependencies": { "fault": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-C4AkuM3dA58cgZha7zVnuVxBhDsbttIMiytjgsM2XbHAB2faRVaHRle40558FBN+DJcrLNCoqG5mlrpdU4cRtg=="],
 
     "micromark-extension-gfm": ["micromark-extension-gfm@3.0.0", "", { "dependencies": { "micromark-extension-gfm-autolink-literal": "^2.0.0", "micromark-extension-gfm-footnote": "^2.0.0", "micromark-extension-gfm-strikethrough": "^2.0.0", "micromark-extension-gfm-table": "^2.0.0", "micromark-extension-gfm-tagfilter": "^2.0.0", "micromark-extension-gfm-task-list-item": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w=="],
 
@@ -501,6 +521,8 @@
 
     "micromark-util-types": ["micromark-util-types@2.0.2", "", {}, "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA=="],
 
+    "monaco-editor": ["monaco-editor@0.55.1", "", { "dependencies": { "dompurify": "3.2.7", "marked": "14.0.0" } }, "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A=="],
+
     "mri": ["mri@1.2.0", "", {}, "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
@@ -547,6 +569,8 @@
 
     "rehype-raw": ["rehype-raw@7.0.0", "", { "dependencies": { "@types/hast": "^3.0.0", "hast-util-raw": "^9.0.0", "vfile": "^6.0.0" } }, "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww=="],
 
+    "remark-frontmatter": ["remark-frontmatter@5.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-frontmatter": "^2.0.0", "micromark-extension-frontmatter": "^2.0.0", "unified": "^11.0.0" } }, "sha512-XTFYvNASMe5iPN0719nPrdItC9aU0ssC4v14mH1BCi1u0n1gAocqcujWUrByftZTbLhRtiKRyjYTSIOcr69UVQ=="],
+
     "remark-gfm": ["remark-gfm@4.0.1", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-gfm": "^3.0.0", "micromark-extension-gfm": "^3.0.0", "remark-parse": "^11.0.0", "remark-stringify": "^11.0.0", "unified": "^11.0.0" } }, "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg=="],
 
     "remark-parse": ["remark-parse@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-from-markdown": "^2.0.0", "micromark-util-types": "^2.0.0", "unified": "^11.0.0" } }, "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA=="],
@@ -562,6 +586,8 @@
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
     "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
+
+    "state-local": ["state-local@1.0.7", "", {}, "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w=="],
 
     "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
 

--- a/cmd/sgai/webapp/package.json
+++ b/cmd/sgai/webapp/package.json
@@ -11,6 +11,7 @@
     "test:e2e:parity": "bunx playwright test e2e/parity/"
   },
   "dependencies": {
+    "@monaco-editor/react": "^4.7.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.575.0",
@@ -20,6 +21,7 @@
     "react-markdown": "^10.1.0",
     "react-router": "^7.6.2",
     "rehype-raw": "^7.0.0",
+    "remark-frontmatter": "^5.0.0",
     "remark-gfm": "^4.0.0",
     "tailwind-merge": "^3.4.0",
     "tw-animate-css": "^1.4.0"

--- a/cmd/sgai/webapp/src/components/MarkdownContent.tsx
+++ b/cmd/sgai/webapp/src/components/MarkdownContent.tsx
@@ -8,6 +8,7 @@ import type {
 } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import remarkFrontmatter from "remark-frontmatter";
 import rehypeRaw from "rehype-raw";
 import { cn } from "@/lib/utils";
 
@@ -97,7 +98,7 @@ export function MarkdownContent({ content, className }: MarkdownContentProps) {
 
   return (
     <div className={cn("space-y-3 text-sm", className)}>
-      <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeRaw]} components={components}>
+      <ReactMarkdown remarkPlugins={[remarkGfm, remarkFrontmatter]} rehypePlugins={[rehypeRaw]} components={components}>
         {content}
       </ReactMarkdown>
     </div>

--- a/cmd/sgai/webapp/src/components/MarkdownEditor.tsx
+++ b/cmd/sgai/webapp/src/components/MarkdownEditor.tsx
@@ -1,0 +1,441 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import Editor, { type OnMount } from "@monaco-editor/react";
+import type * as MonacoTypes from "monaco-editor";
+import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { MarkdownContent } from "@/components/MarkdownContent";
+import {
+  Bold,
+  Italic,
+  Strikethrough,
+  Heading1,
+  Heading2,
+  Heading3,
+  List,
+  ListOrdered,
+  ListChecks,
+  Code2,
+  Quote,
+  Link,
+  Image,
+  Minus,
+  Table,
+  Eye,
+  Pencil,
+} from "lucide-react";
+
+interface MarkdownEditorProps {
+  value: string;
+  onChange: (value: string | undefined) => void;
+  minHeight?: number;
+  defaultHeight?: number;
+  disabled?: boolean;
+  placeholder?: string;
+}
+
+type IStandaloneCodeEditor = MonacoTypes.editor.IStandaloneCodeEditor;
+
+interface ToolbarAction {
+  icon: React.ReactNode;
+  label: string;
+  action: (editor: IStandaloneCodeEditor) => void;
+}
+
+function wrapSelection(
+  editor: IStandaloneCodeEditor,
+  prefix: string,
+  suffix: string,
+) {
+  const selection = editor.getSelection();
+  if (!selection) return;
+  const model = editor.getModel();
+  if (!model) return;
+
+  const selectedText = model.getValueInRange(selection);
+  const replacement = selectedText
+    ? `${prefix}${selectedText}${suffix}`
+    : `${prefix}text${suffix}`;
+
+  editor.executeEdits("toolbar", [
+    { range: selection, text: replacement },
+  ]);
+
+  if (!selectedText) {
+    const startCol = selection.startColumn + prefix.length;
+    const endCol = startCol + 4;
+    editor.setSelection({
+      startLineNumber: selection.startLineNumber,
+      startColumn: startCol,
+      endLineNumber: selection.startLineNumber,
+      endColumn: endCol,
+    });
+  }
+
+  editor.focus();
+}
+
+function insertLink(editor: IStandaloneCodeEditor) {
+  const selection = editor.getSelection();
+  if (!selection) return;
+  const model = editor.getModel();
+  if (!model) return;
+  const selectedText = model.getValueInRange(selection);
+  const replacement = selectedText
+    ? `[${selectedText}](url)`
+    : "[link text](url)";
+  editor.executeEdits("toolbar", [
+    { range: selection, text: replacement },
+  ]);
+  editor.focus();
+}
+
+function insertAtLineStart(
+  editor: IStandaloneCodeEditor,
+  prefix: string,
+) {
+  const selection = editor.getSelection();
+  if (!selection) return;
+  const model = editor.getModel();
+  if (!model) return;
+
+  const lineNumber = selection.startLineNumber;
+  const lineContent = model.getLineContent(lineNumber);
+  const newContent = `${prefix}${lineContent}`;
+
+  editor.executeEdits("toolbar", [
+    {
+      range: {
+        startLineNumber: lineNumber,
+        startColumn: 1,
+        endLineNumber: lineNumber,
+        endColumn: lineContent.length + 1,
+      },
+      text: newContent,
+    },
+  ]);
+
+  editor.focus();
+}
+
+function insertAtCursor(
+  editor: IStandaloneCodeEditor,
+  text: string,
+) {
+  const selection = editor.getSelection();
+  if (!selection) return;
+
+  editor.executeEdits("toolbar", [
+    { range: selection, text },
+  ]);
+
+  editor.focus();
+}
+
+const TOOLBAR_ACTIONS: ToolbarAction[] = [
+  {
+    icon: <Bold className="h-4 w-4" />,
+    label: "Bold",
+    action: (editor) => wrapSelection(editor, "**", "**"),
+  },
+  {
+    icon: <Italic className="h-4 w-4" />,
+    label: "Italic",
+    action: (editor) => wrapSelection(editor, "_", "_"),
+  },
+  {
+    icon: <Strikethrough className="h-4 w-4" />,
+    label: "Strikethrough",
+    action: (editor) => wrapSelection(editor, "~~", "~~"),
+  },
+  {
+    icon: <Heading1 className="h-4 w-4" />,
+    label: "Heading 1",
+    action: (editor) => insertAtLineStart(editor, "# "),
+  },
+  {
+    icon: <Heading2 className="h-4 w-4" />,
+    label: "Heading 2",
+    action: (editor) => insertAtLineStart(editor, "## "),
+  },
+  {
+    icon: <Heading3 className="h-4 w-4" />,
+    label: "Heading 3",
+    action: (editor) => insertAtLineStart(editor, "### "),
+  },
+  {
+    icon: <List className="h-4 w-4" />,
+    label: "Bullet List",
+    action: (editor) => insertAtLineStart(editor, "- "),
+  },
+  {
+    icon: <ListOrdered className="h-4 w-4" />,
+    label: "Numbered List",
+    action: (editor) => insertAtLineStart(editor, "1. "),
+  },
+  {
+    icon: <ListChecks className="h-4 w-4" />,
+    label: "Checkbox List",
+    action: (editor) => insertAtLineStart(editor, "- [ ] "),
+  },
+  {
+    icon: <Code2 className="h-4 w-4" />,
+    label: "Code Block",
+    action: (editor) => {
+      const selection = editor.getSelection();
+      if (!selection) return;
+      const model = editor.getModel();
+      if (!model) return;
+      const selectedText = model.getValueInRange(selection);
+      const replacement = selectedText
+        ? `\`\`\`\n${selectedText}\n\`\`\``
+        : "```\ncode\n```";
+      editor.executeEdits("toolbar", [
+        { range: selection, text: replacement },
+      ]);
+      editor.focus();
+    },
+  },
+  {
+    icon: <Quote className="h-4 w-4" />,
+    label: "Blockquote",
+    action: (editor) => insertAtLineStart(editor, "> "),
+  },
+  {
+    icon: <Link className="h-4 w-4" />,
+    label: "Link",
+    action: (editor) => insertLink(editor),
+  },
+  {
+    icon: <Image className="h-4 w-4" />,
+    label: "Image",
+    action: (editor) =>
+      insertAtCursor(editor, "![alt text](image-url)"),
+  },
+  {
+    icon: <Minus className="h-4 w-4" />,
+    label: "Horizontal Rule",
+    action: (editor) => insertAtCursor(editor, "\n---\n"),
+  },
+  {
+    icon: <Table className="h-4 w-4" />,
+    label: "Table",
+    action: (editor) =>
+      insertAtCursor(
+        editor,
+        "\n| Header | Header |\n| ------ | ------ |\n| Cell   | Cell   |\n",
+      ),
+  },
+];
+
+export function MarkdownEditor({
+  value,
+  onChange,
+  minHeight = 200,
+  defaultHeight,
+  disabled = false,
+  placeholder,
+}: MarkdownEditorProps) {
+  const editorRef = useRef<IStandaloneCodeEditor | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const toolbarRef = useRef<HTMLDivElement>(null);
+  const modeBarRef = useRef<HTMLDivElement>(null);
+
+  const baseHeight = defaultHeight ?? minHeight;
+  const [editorHeight, setEditorHeight] = useState(baseHeight);
+  const [mode, setMode] = useState<"write" | "preview">("write");
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const observer = new ResizeObserver(() => {
+      const toolbar = toolbarRef.current;
+      const modeBar = modeBarRef.current;
+      const toolbarHeight = toolbar ? toolbar.offsetHeight : 0;
+      const modeBarHeight = modeBar ? modeBar.offsetHeight : 0;
+      const newHeight = container.clientHeight - toolbarHeight - modeBarHeight;
+      setEditorHeight(Math.max(newHeight, minHeight));
+    });
+
+    observer.observe(container);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [minHeight]);
+
+  const handleMount: OnMount = useCallback(
+    (editor, monaco) => {
+      editorRef.current = editor;
+
+      editor.addAction({
+        id: "markdown-bold",
+        label: "Bold",
+        keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyB],
+        run: (ed) => wrapSelection(ed, "**", "**"),
+      });
+
+      editor.addAction({
+        id: "markdown-italic",
+        label: "Italic",
+        keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyI],
+        run: (ed) => wrapSelection(ed, "_", "_"),
+      });
+
+      editor.addAction({
+        id: "markdown-link",
+        label: "Insert Link",
+        keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyK],
+        run: (ed) => insertLink(ed),
+      });
+
+      if (placeholder && !value) {
+        const model = editor.getModel();
+        if (model) {
+          const decorations = [
+            {
+              range: {
+                startLineNumber: 1,
+                startColumn: 1,
+                endLineNumber: 1,
+                endColumn: 1,
+              },
+              options: {
+                after: {
+                  content: placeholder,
+                  inlineClassName: "monaco-placeholder",
+                },
+              },
+            },
+          ];
+          let decorationIds = editor.deltaDecorations([], decorations);
+
+          editor.onDidChangeModelContent(() => {
+            const currentValue = model.getValue();
+            if (currentValue) {
+              decorationIds = editor.deltaDecorations(decorationIds, []);
+            } else {
+              decorationIds = editor.deltaDecorations(
+                decorationIds,
+                decorations,
+              );
+            }
+          });
+        }
+      }
+    },
+    [placeholder, value],
+  );
+
+  const handleToolbarAction = useCallback(
+    (action: (editor: IStandaloneCodeEditor) => void) => {
+      if (editorRef.current && !disabled) {
+        action(editorRef.current);
+      }
+    },
+    [disabled],
+  );
+
+  return (
+    <div
+      ref={containerRef}
+      className="border rounded-md overflow-hidden"
+      style={{ minHeight: `${minHeight}px`, resize: "vertical", overflow: "auto" }}
+      data-testid="markdown-editor"
+    >
+      <div
+        ref={modeBarRef}
+        className="flex gap-1 p-1 border-b bg-muted/30"
+      >
+        <Button
+          type="button"
+          variant={mode === "write" ? "secondary" : "ghost"}
+          size="sm"
+          className="h-7 px-3 text-xs"
+          onClick={() => setMode("write")}
+          aria-pressed={mode === "write"}
+        >
+          <Pencil className="h-3.5 w-3.5 mr-1" />
+          Write
+        </Button>
+        <Button
+          type="button"
+          variant={mode === "preview" ? "secondary" : "ghost"}
+          size="sm"
+          className="h-7 px-3 text-xs"
+          onClick={() => setMode("preview")}
+          aria-pressed={mode === "preview"}
+        >
+          <Eye className="h-3.5 w-3.5 mr-1" />
+          Preview
+        </Button>
+      </div>
+
+      {mode === "write" ? (
+        <>
+          <div ref={toolbarRef} className="flex flex-wrap gap-0.5 p-1 border-b bg-muted/50">
+            {TOOLBAR_ACTIONS.map((item) => (
+              <Tooltip key={item.label}>
+                <TooltipTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className="h-7 w-7"
+                    disabled={disabled}
+                    onClick={() => handleToolbarAction(item.action)}
+                    aria-label={item.label}
+                  >
+                    {item.icon}
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>{item.label}</TooltipContent>
+              </Tooltip>
+            ))}
+          </div>
+
+          <Editor
+            height={`${editorHeight}px`}
+            language="markdown"
+            value={value}
+            onChange={onChange}
+            onMount={handleMount}
+            options={{
+              wordWrap: "on",
+              automaticLayout: true,
+              minimap: { enabled: false },
+              scrollBeyondLastLine: false,
+              lineNumbers: "off",
+              glyphMargin: false,
+              folding: false,
+              renderLineHighlight: "none",
+              overviewRulerBorder: false,
+              hideCursorInOverviewRuler: true,
+              readOnly: disabled,
+              domReadOnly: disabled,
+              padding: { top: 8, bottom: 8 },
+            }}
+          />
+        </>
+      ) : (
+        <ScrollArea
+          style={{ height: `${editorHeight}px` }}
+          className="p-4"
+        >
+          {value ? (
+            <MarkdownContent content={value} />
+          ) : (
+            <p className="text-muted-foreground text-sm italic">
+              Nothing to preview
+            </p>
+          )}
+        </ScrollArea>
+      )}
+    </div>
+  );
+}

--- a/cmd/sgai/webapp/src/index.css
+++ b/cmd/sgai/webapp/src/index.css
@@ -172,3 +172,9 @@
     @apply bg-background text-foreground;
   }
 }
+
+.monaco-placeholder {
+  color: var(--muted-foreground);
+  opacity: 0.5;
+  font-style: italic;
+}

--- a/cmd/sgai/webapp/src/pages/AdhocOutput.tsx
+++ b/cmd/sgai/webapp/src/pages/AdhocOutput.tsx
@@ -5,7 +5,7 @@ import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Textarea } from "@/components/ui/textarea";
+import { MarkdownEditor } from "@/components/MarkdownEditor";
 import { PromptHistory } from "@/components/PromptHistory";
 import { useAdhocRun } from "@/hooks/useAdhocRun";
 
@@ -25,7 +25,6 @@ export function AdhocOutput(): JSX.Element {
     startRun,
     stopRun,
     handleSubmit,
-    handleKeyDown,
     outputRef,
     promptHistory,
     selectFromHistory,
@@ -88,15 +87,12 @@ export function AdhocOutput(): JSX.Element {
                 disabled={isRunning}
               />
             </div>
-            <Textarea
-              id="adhoc-prompt"
+            <MarkdownEditor
               value={prompt}
-              onChange={(e) => setPrompt(e.target.value)}
-              onKeyDown={handleKeyDown}
-              placeholder="Enter your prompt..."
-              rows={6}
-              className="resize-y"
+              onChange={(v) => setPrompt(v ?? "")}
+              defaultHeight={250}
               disabled={isRunning}
+              placeholder="Enter your prompt..."
             />
           </div>
         </div>

--- a/cmd/sgai/webapp/src/pages/EditGoal.test.tsx
+++ b/cmd/sgai/webapp/src/pages/EditGoal.test.tsx
@@ -1,8 +1,25 @@
-import { describe, test, expect, afterEach, spyOn } from "bun:test";
+import { describe, test, expect, afterEach, spyOn, mock } from "bun:test";
+import React from "react";
 import { render, screen, act, cleanup, fireEvent } from "@testing-library/react";
 import { MemoryRouter, Routes, Route } from "react-router";
 import { EditGoal } from "./EditGoal";
 import { TooltipProvider } from "@/components/ui/tooltip";
+
+mock.module("@monaco-editor/react", () => ({
+  default: () => null,
+}));
+
+mock.module("@/components/MarkdownEditor", () => ({
+  MarkdownEditor: (props: { value: string; onChange: (v: string | undefined) => void; disabled?: boolean; placeholder?: string }) =>
+    React.createElement("textarea", {
+      "aria-label": "GOAL.md Content",
+      value: props.value,
+      onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => props.onChange(e.target.value),
+      disabled: props.disabled,
+      placeholder: props.placeholder,
+      "data-testid": "markdown-editor",
+    }),
+}));
 
 const mockGoalContent = "---\ntitle: My Project\n---\n\n# My Project\n\nBuild something great";
 
@@ -49,7 +66,7 @@ describe("EditGoal", () => {
     expect(skeletons.length).toBeGreaterThan(0);
   });
 
-  test("renders heading and textarea after load", async () => {
+  test("renders heading and editor after load", async () => {
     fetchSpy = mockFetchSequence([mockGoalResponse]);
     await act(async () => { renderPage(); });
     await act(async () => { await new Promise((r) => setTimeout(r, 50)); });

--- a/cmd/sgai/webapp/src/pages/EditGoal.tsx
+++ b/cmd/sgai/webapp/src/pages/EditGoal.tsx
@@ -1,10 +1,10 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router";
 import { Button } from "@/components/ui/button";
-import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { MarkdownEditor } from "@/components/MarkdownEditor";
 import { api, ApiError } from "@/lib/api";
 import { ArrowLeft, Save, Loader2, CheckCircle2 } from "lucide-react";
 import { Link } from "react-router";
@@ -122,12 +122,10 @@ export function EditGoal(): JSX.Element {
       <div className="space-y-4">
         <div className="space-y-2">
           <Label htmlFor="goal-content">GOAL.md Content</Label>
-          <Textarea
-            id="goal-content"
+          <MarkdownEditor
             value={content}
-            onChange={(e) => setContent(e.target.value)}
-            rows={20}
-            className="resize-y font-mono text-sm"
+            onChange={(v) => setContent(v ?? "")}
+            defaultHeight={500}
             disabled={isSaving || saveSuccess}
           />
         </div>

--- a/cmd/sgai/webapp/src/pages/ResponseModal.test.tsx
+++ b/cmd/sgai/webapp/src/pages/ResponseModal.test.tsx
@@ -1,9 +1,25 @@
 import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
+import React from "react";
 import { render, screen, waitFor, fireEvent, cleanup } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
 import { ResponseModal } from "./ResponseModal";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import type { ApiPendingQuestionResponse, ApiWorkspaceEntry } from "@/types";
+
+mock.module("@monaco-editor/react", () => ({
+  default: () => null,
+}));
+
+mock.module("@/components/MarkdownEditor", () => ({
+  MarkdownEditor: (props: { value: string; onChange: (v: string | undefined) => void; disabled?: boolean; placeholder?: string }) =>
+    React.createElement("textarea", {
+      value: props.value,
+      onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => props.onChange(e.target.value),
+      disabled: props.disabled,
+      placeholder: props.placeholder ?? "Type your custom response here...",
+      "data-testid": "markdown-editor",
+    }),
+}));
 
 const pendingQuestion: ApiPendingQuestionResponse = {
   questionId: "modal-q-123",

--- a/cmd/sgai/webapp/src/pages/ResponseModal.tsx
+++ b/cmd/sgai/webapp/src/pages/ResponseModal.tsx
@@ -9,8 +9,8 @@ import {
 } from "@/components/ui/dialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
+import { MarkdownEditor } from "@/components/MarkdownEditor";
 import { MarkdownContent } from "@/components/MarkdownContent";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -129,14 +129,15 @@ export function ResponseModal({
                 <Label htmlFor="modal-other" className="font-semibold text-sm">
                   Other (additional comments or alternative answer):
                 </Label>
-                <Textarea
-                  id="modal-other"
-                  value={otherText}
-                  onChange={(e) => setOtherText(e.target.value)}
-                  placeholder="Type your custom response here..."
-                  rows={3}
-                  className="mt-2"
-                />
+                <div className="mt-2">
+                  <MarkdownEditor
+                    value={otherText}
+                    onChange={(v) => setOtherText(v ?? "")}
+                    defaultHeight={200}
+                    minHeight={150}
+                    placeholder="Type your custom response here..."
+                  />
+                </div>
               </div>
 
               <ResponseContext

--- a/cmd/sgai/webapp/src/pages/WizardStep1.test.tsx
+++ b/cmd/sgai/webapp/src/pages/WizardStep1.test.tsx
@@ -1,8 +1,25 @@
-import { describe, test, expect, afterEach, beforeEach, spyOn } from "bun:test";
+import { describe, test, expect, afterEach, beforeEach, spyOn, mock } from "bun:test";
+import React from "react";
 import { render, screen, act, cleanup, fireEvent } from "@testing-library/react";
 import { MemoryRouter, Routes, Route } from "react-router";
 import { WizardStep1 } from "./WizardStep1";
 import { TooltipProvider } from "@/components/ui/tooltip";
+
+mock.module("@monaco-editor/react", () => ({
+  default: () => null,
+}));
+
+mock.module("@/components/MarkdownEditor", () => ({
+  MarkdownEditor: (props: { value: string; onChange: (v: string | undefined) => void; disabled?: boolean; placeholder?: string }) =>
+    React.createElement("textarea", {
+      role: "textbox",
+      value: props.value,
+      onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => props.onChange(e.target.value),
+      disabled: props.disabled,
+      placeholder: props.placeholder,
+      "data-testid": "markdown-editor",
+    }),
+}));
 
 const mockComposeState = {
   workspace: "test-ws",
@@ -91,7 +108,7 @@ describe("WizardStep1", () => {
     expect(screen.getByText("Step 1: Project Description")).toBeTruthy();
   });
 
-  test("renders textarea with server description", async () => {
+  test("renders editor with server description", async () => {
     fetchSpy = mockFetchSequence([mockComposeState, mockPreview]);
 
     await act(async () => {

--- a/cmd/sgai/webapp/src/pages/WizardStep1.tsx
+++ b/cmd/sgai/webapp/src/pages/WizardStep1.tsx
@@ -1,9 +1,9 @@
 import { useCallback, useEffect } from "react";
 import { useSearchParams } from "react-router";
 import { Label } from "@/components/ui/label";
-import { Textarea } from "@/components/ui/textarea";
 import { Skeleton } from "@/components/ui/skeleton";
 import { WizardLayout } from "@/components/WizardLayout";
+import { MarkdownEditor } from "@/components/MarkdownEditor";
 import { useComposeWizard } from "@/hooks/useComposeWizard";
 import { MissingWorkspaceNotice } from "@/components/MissingWorkspaceNotice";
 
@@ -28,8 +28,8 @@ export function WizardStep1() {
   }
 
   const handleDescriptionChange = useCallback(
-    (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-      setWizardData((prev) => ({ ...prev, description: e.target.value }));
+    (value: string | undefined) => {
+      setWizardData((prev) => ({ ...prev, description: value ?? "" }));
     },
     [setWizardData],
   );
@@ -70,13 +70,11 @@ export function WizardStep1() {
 
         <div className="space-y-2">
           <Label htmlFor="description">Project Description</Label>
-          <Textarea
-            id="description"
+          <MarkdownEditor
             value={wizardData.description}
             onChange={handleDescriptionChange}
+            defaultHeight={300}
             placeholder="Example: Build a web application that manages user profiles with authentication, dashboard, and REST API endpoints."
-            rows={8}
-            className="resize-y"
           />
         </div>
       </div>


### PR DESCRIPTION
## Summary

- Replace plain `<Textarea>` components with a Monaco-powered `MarkdownEditor` in Edit GOAL, Compose Wizard Step 1, Respond to Agent, and Ad-Hoc Run pages
- Add markdown toolbar (bold, italic, headings, lists, code blocks, links, tables, etc.) with keyboard shortcuts and a write/preview toggle
- Archive completed GOAL into `GOALS/2026_02_28_rich_editor_monaco.md`