### PR TITLE
cmd/sgai/webapp: navigate to goal editor after fork creation

### DIFF
--- a/GOALS/2026_02_28_auto_edit_on_fork.md
+++ b/GOALS/2026_02_28_auto_edit_on_fork.md
@@ -1,0 +1,21 @@
+---
+flow: |
+  "backend-go-developer" -> "go-readability-reviewer"
+  "react-developer" -> "react-reviewer"
+  "general-purpose"
+  "project-critic-council"
+  "skill-writer"
+  "stpa-analyst"
+models:
+  "coordinator": "anthropic/claude-opus-4-6 (max)"
+  "backend-go-developer": "anthropic/claude-opus-4-6"
+  "go-readability-reviewer": "anthropic/claude-opus-4-6"
+  "general-purpose": "anthropic/claude-opus-4-6"
+  "react-developer": "anthropic/claude-opus-4-6"
+  "react-reviewer": "anthropic/claude-opus-4-6"
+  "stpa-analyst": "anthropic/claude-opus-4-6"
+  "project-critic-council": ["anthropic/claude-opus-4-6", "anthropic/claude-sonnet-4-6", "anthropic/claude-opus-4-5"]
+  "skill-writer": "anthropic/claude-opus-4-6 (max)"
+---
+
+- [x] Update `Fork` button so that after a Fork is created, it immediatelly navigates to `/goal/edit`

--- a/cmd/sgai/webapp/src/pages/NewFork.test.tsx
+++ b/cmd/sgai/webapp/src/pages/NewFork.test.tsx
@@ -21,6 +21,7 @@ function renderPage(workspace = "root-ws") {
       <TooltipProvider>
         <Routes>
           <Route path="workspaces/:name/fork/new" element={<NewFork />} />
+          <Route path="workspaces/:name/goal/edit" element={<div>Edit Goal</div>} />
           <Route path="workspaces/:name" element={<div>Workspace Detail</div>} />
         </Routes>
       </TooltipProvider>
@@ -78,7 +79,7 @@ describe("NewFork", () => {
     await act(async () => { fireEvent.click(button); });
     await act(async () => { await new Promise((r) => setTimeout(r, 50)); });
 
-    expect(screen.getByText("Workspace Detail")).toBeTruthy();
+    expect(screen.getByText("Edit Goal")).toBeTruthy();
   });
 
   test("shows error on conflict", async () => {

--- a/cmd/sgai/webapp/src/pages/NewFork.tsx
+++ b/cmd/sgai/webapp/src/pages/NewFork.tsx
@@ -26,7 +26,7 @@ export function NewFork() {
 
       try {
         const result = await api.workspaces.fork(workspaceName, trimmed);
-        navigate(`/workspaces/${encodeURIComponent(result.name)}`);
+        navigate(`/workspaces/${encodeURIComponent(result.name)}/goal/edit`);
       } catch (err) {
         if (err instanceof ApiError) {
           setError(err.message);


### PR DESCRIPTION
After creating a fork, the user is immediately navigated to `/goal/edit` so they can start editing the goal right away instead of landing on the workspace overview.

Includes the goal specification in `GOALS/2026_02_28_auto_edit_on_fork.md`.