### PR TITLE
cmd/sgai/webapp: add frontmatter table preview and select-all to Monaco editor

### DIFF
--- a/GOALS/2026_02_28_improve_monaco_editor.md
+++ b/GOALS/2026_02_28_improve_monaco_editor.md
@@ -1,0 +1,24 @@
+---
+flow: |
+  "backend-go-developer" -> "go-readability-reviewer"
+  "react-developer" -> "react-reviewer"
+  "general-purpose"
+  "project-critic-council"
+  "skill-writer"
+  "stpa-analyst"
+models:
+  "coordinator": "anthropic/claude-opus-4-6 (max)"
+  "backend-go-developer": "anthropic/claude-opus-4-6"
+  "go-readability-reviewer": "anthropic/claude-opus-4-6"
+  "general-purpose": "anthropic/claude-opus-4-6"
+  "react-developer": "anthropic/claude-opus-4-6"
+  "react-reviewer": "anthropic/claude-opus-4-6"
+  "stpa-analyst": "anthropic/claude-opus-4-6"
+  "project-critic-council": ["anthropic/claude-opus-4-6", "anthropic/claude-sonnet-4-6", "anthropic/claude-opus-4-5"]
+  "skill-writer": "anthropic/claude-opus-4-6 (max)"
+---
+
+Refer to https://microsoft.github.io/monaco-editor/
+
+- [x] In "Edit GOAL", in preview, please print a table with the frontmatter 
+- [x] Update Monaco editor component to enable "Select All"

--- a/cmd/sgai/webapp/bun.lock
+++ b/cmd/sgai/webapp/bun.lock
@@ -18,6 +18,7 @@
         "remark-gfm": "^4.0.0",
         "tailwind-merge": "^3.4.0",
         "tw-animate-css": "^1.4.0",
+        "yaml": "^2.8.2",
       },
       "devDependencies": {
         "@happy-dom/global-registrator": "^20.6.1",
@@ -642,6 +643,8 @@
     "whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
 
     "ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
+
+    "yaml": ["yaml@2.8.2", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A=="],
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 

--- a/cmd/sgai/webapp/package.json
+++ b/cmd/sgai/webapp/package.json
@@ -24,7 +24,8 @@
     "remark-frontmatter": "^5.0.0",
     "remark-gfm": "^4.0.0",
     "tailwind-merge": "^3.4.0",
-    "tw-animate-css": "^1.4.0"
+    "tw-animate-css": "^1.4.0",
+    "yaml": "^2.8.2"
   },
   "devDependencies": {
     "@happy-dom/global-registrator": "^20.6.1",

--- a/cmd/sgai/webapp/src/components/MarkdownContent.test.tsx
+++ b/cmd/sgai/webapp/src/components/MarkdownContent.test.tsx
@@ -1,0 +1,127 @@
+import { describe, test, expect, afterEach } from "bun:test";
+import { render, screen, cleanup } from "@testing-library/react";
+import { MarkdownContent } from "./MarkdownContent";
+
+describe("MarkdownContent", () => {
+  afterEach(cleanup);
+
+  test("renders markdown body without frontmatter", () => {
+    render(<MarkdownContent content="# Hello World" />);
+    expect(screen.getByText("Hello World")).toBeTruthy();
+  });
+
+  test("renders frontmatter table when content has frontmatter", () => {
+    const content = "---\ntitle: My Project\nversion: 1\n---\n\n# Hello";
+    render(<MarkdownContent content={content} />);
+
+    const table = document.querySelector("[data-testid='frontmatter-table']");
+    expect(table).toBeTruthy();
+    expect(screen.getByText("Key")).toBeTruthy();
+    expect(screen.getByText("Value")).toBeTruthy();
+    expect(screen.getByText("title")).toBeTruthy();
+    expect(screen.getByText("My Project")).toBeTruthy();
+    expect(screen.getByText("version")).toBeTruthy();
+  });
+
+  test("does not render frontmatter table when no frontmatter", () => {
+    render(<MarkdownContent content="# Just Markdown\n\nSome content" />);
+
+    const table = document.querySelector("[data-testid='frontmatter-table']");
+    expect(table).toBeNull();
+    expect(screen.getByText(/Just Markdown/)).toBeTruthy();
+  });
+
+  test("renders simple string values inline", () => {
+    const content = '---\nname: simple-value\n---\n\nBody';
+    render(<MarkdownContent content={content} />);
+
+    expect(screen.getByText("simple-value").tagName).toBe("SPAN");
+  });
+
+  test("renders boolean values inline", () => {
+    const content = "---\nenabled: true\n---\n\nBody";
+    render(<MarkdownContent content={content} />);
+
+    expect(screen.getByText("true").tagName).toBe("SPAN");
+  });
+
+  test("renders number values inline", () => {
+    const content = "---\ncount: 42\n---\n\nBody";
+    render(<MarkdownContent content={content} />);
+
+    expect(screen.getByText("42").tagName).toBe("SPAN");
+  });
+
+  test("renders multi-line string values as pre-formatted text", () => {
+    const content = '---\nflow: |\n  line1\n  line2\n---\n\nBody';
+    render(<MarkdownContent content={content} />);
+
+    const preElements = document.querySelectorAll("pre");
+    const found = Array.from(preElements).some(
+      (pre) => pre.textContent?.includes("line1") && pre.textContent?.includes("line2"),
+    );
+    expect(found).toBe(true);
+  });
+
+  test("renders nested object values as pre-formatted text", () => {
+    const content = '---\nmodels:\n  coordinator: model-a\n  developer: model-b\n---\n\nBody';
+    render(<MarkdownContent content={content} />);
+
+    const preElements = document.querySelectorAll("pre");
+    const found = Array.from(preElements).some(
+      (pre) => pre.textContent?.includes("coordinator"),
+    );
+    expect(found).toBe(true);
+  });
+
+  test("renders markdown body below the frontmatter table", () => {
+    const content = "---\ntitle: Project\n---\n\n# Heading\n\nParagraph text";
+    render(<MarkdownContent content={content} />);
+
+    expect(document.querySelector("[data-testid='frontmatter-table']")).toBeTruthy();
+    expect(screen.getByText("Heading")).toBeTruthy();
+    expect(screen.getByText("Paragraph text")).toBeTruthy();
+  });
+
+  test("handles invalid YAML gracefully", () => {
+    const content = "---\n: invalid: yaml: [[\n---\n\n# Heading";
+    render(<MarkdownContent content={content} />);
+
+    const table = document.querySelector("[data-testid='frontmatter-table']");
+    expect(table).toBeNull();
+    expect(screen.getByText("Heading")).toBeTruthy();
+  });
+
+  test("handles empty frontmatter", () => {
+    const content = "---\n\n---\n\n# Heading";
+    render(<MarkdownContent content={content} />);
+
+    const table = document.querySelector("[data-testid='frontmatter-table']");
+    expect(table).toBeNull();
+  });
+
+  test("renders real-world GOAL.md frontmatter", () => {
+    const content = [
+      "---",
+      "flow: |",
+      '  "backend-go-developer" -> "go-readability-reviewer"',
+      '  "react-developer" -> "react-reviewer"',
+      "models:",
+      '  "coordinator": "anthropic/claude-opus-4-6 (max)"',
+      '  "backend-go-developer": "anthropic/claude-opus-4-6"',
+      "---",
+      "",
+      "# Build the project",
+      "",
+      "- [ ] Task one",
+    ].join("\n");
+
+    render(<MarkdownContent content={content} />);
+
+    expect(document.querySelector("[data-testid='frontmatter-table']")).toBeTruthy();
+    expect(screen.getByText("flow")).toBeTruthy();
+    expect(screen.getByText("models")).toBeTruthy();
+    expect(screen.getByText("Build the project")).toBeTruthy();
+    expect(screen.getByText("Task one")).toBeTruthy();
+  });
+});

--- a/cmd/sgai/webapp/src/components/MarkdownEditor.test.tsx
+++ b/cmd/sgai/webapp/src/components/MarkdownEditor.test.tsx
@@ -1,0 +1,215 @@
+import { describe, test, expect, afterEach, mock, beforeEach } from "bun:test";
+import React from "react";
+import { render, screen, cleanup, fireEvent, act } from "@testing-library/react";
+import { TooltipProvider } from "@/components/ui/tooltip";
+
+const mockAddAction = mock(() => {});
+const mockSetSelection = mock(() => {});
+const mockGetFullModelRange = mock(() => ({
+  startLineNumber: 1,
+  startColumn: 1,
+  endLineNumber: 5,
+  endColumn: 10,
+}));
+const mockGetModel = mock(() => ({
+  getFullModelRange: mockGetFullModelRange,
+  getValue: mock(() => "test content"),
+  getValueInRange: mock(() => ""),
+  getLineContent: mock(() => ""),
+}));
+const mockDeltaDecorations = mock(() => []);
+const mockOnDidChangeModelContent = mock(() => {});
+const mockFocus = mock(() => {});
+const mockGetSelection = mock(() => ({
+  startLineNumber: 1,
+  startColumn: 1,
+  endLineNumber: 1,
+  endColumn: 1,
+}));
+const mockExecuteEdits = mock(() => {});
+
+let capturedOnMount: ((editor: unknown, monaco: unknown) => void) | null = null;
+
+mock.module("@monaco-editor/react", () => ({
+  default: (props: { onMount?: (editor: unknown, monaco: unknown) => void; value?: string; onChange?: (v: string | undefined) => void }) => {
+    capturedOnMount = props.onMount ?? null;
+    return React.createElement("div", { "data-testid": "mock-monaco-editor" }, props.value);
+  },
+}));
+
+function createMockEditor() {
+  return {
+    addAction: mockAddAction,
+    setSelection: mockSetSelection,
+    getModel: mockGetModel,
+    deltaDecorations: mockDeltaDecorations,
+    onDidChangeModelContent: mockOnDidChangeModelContent,
+    focus: mockFocus,
+    getSelection: mockGetSelection,
+    executeEdits: mockExecuteEdits,
+  };
+}
+
+function createMockMonaco() {
+  return {
+    KeyMod: { CtrlCmd: 2048 },
+    KeyCode: {
+      KeyB: 32,
+      KeyI: 39,
+      KeyK: 41,
+      KeyA: 31,
+    },
+  };
+}
+
+function renderEditor(props?: Partial<{ value: string; onChange: (v: string | undefined) => void; disabled: boolean }>) {
+  const { MarkdownEditor } = require("./MarkdownEditor");
+  return render(
+    <TooltipProvider>
+      <MarkdownEditor
+        value={props?.value ?? "# Hello World"}
+        onChange={props?.onChange ?? (() => {})}
+        disabled={props?.disabled}
+      />
+    </TooltipProvider>,
+  );
+}
+
+describe("MarkdownEditor", () => {
+  beforeEach(() => {
+    mockAddAction.mockClear();
+    mockSetSelection.mockClear();
+    mockGetFullModelRange.mockClear();
+    mockGetModel.mockClear();
+    capturedOnMount = null;
+  });
+
+  afterEach(cleanup);
+
+  test("renders write/preview mode buttons", () => {
+    renderEditor();
+    expect(screen.getByText("Write")).toBeTruthy();
+    expect(screen.getByText("Preview")).toBeTruthy();
+  });
+
+  test("renders toolbar actions in write mode", () => {
+    renderEditor();
+    expect(screen.getByLabelText("Bold")).toBeTruthy();
+    expect(screen.getByLabelText("Italic")).toBeTruthy();
+    expect(screen.getByLabelText("Link")).toBeTruthy();
+  });
+
+  test("registers select-all action on mount", () => {
+    renderEditor();
+    expect(capturedOnMount).toBeTruthy();
+
+    const mockEditor = createMockEditor();
+    const mockMonaco = createMockMonaco();
+
+    capturedOnMount!(mockEditor, mockMonaco);
+
+    const actionCalls = mockAddAction.mock.calls;
+    const selectAllAction = actionCalls.find(
+      (call: unknown[]) => (call[0] as { id: string }).id === "select-all",
+    );
+    expect(selectAllAction).toBeTruthy();
+
+    const action = selectAllAction![0] as {
+      id: string;
+      label: string;
+      keybindings: number[];
+      run: (ed: unknown) => void;
+    };
+    expect(action.label).toBe("Select All");
+    expect(action.keybindings).toEqual([2048 | 31]);
+  });
+
+  test("select-all action selects the full model range", () => {
+    renderEditor();
+    expect(capturedOnMount).toBeTruthy();
+
+    const mockEditor = createMockEditor();
+    const mockMonaco = createMockMonaco();
+
+    capturedOnMount!(mockEditor, mockMonaco);
+
+    const actionCalls = mockAddAction.mock.calls;
+    const selectAllAction = actionCalls.find(
+      (call: unknown[]) => (call[0] as { id: string }).id === "select-all",
+    );
+    expect(selectAllAction).toBeTruthy();
+
+    const action = selectAllAction![0] as { run: (ed: unknown) => void };
+    action.run(mockEditor);
+
+    expect(mockGetModel).toHaveBeenCalled();
+    expect(mockGetFullModelRange).toHaveBeenCalled();
+    expect(mockSetSelection).toHaveBeenCalledWith({
+      startLineNumber: 1,
+      startColumn: 1,
+      endLineNumber: 5,
+      endColumn: 10,
+    });
+  });
+
+  test("select-all action handles missing model gracefully", () => {
+    renderEditor();
+    expect(capturedOnMount).toBeTruthy();
+
+    const mockEditor = createMockEditor();
+    mockEditor.getModel = mock(() => null);
+    const mockMonaco = createMockMonaco();
+
+    capturedOnMount!(mockEditor, mockMonaco);
+
+    const actionCalls = mockAddAction.mock.calls;
+    const selectAllAction = actionCalls.find(
+      (call: unknown[]) => (call[0] as { id: string }).id === "select-all",
+    );
+
+    const action = selectAllAction![0] as { run: (ed: unknown) => void };
+    action.run(mockEditor);
+
+    expect(mockSetSelection).not.toHaveBeenCalled();
+  });
+
+  test("registers bold, italic, link, and select-all actions", () => {
+    renderEditor();
+    expect(capturedOnMount).toBeTruthy();
+
+    const mockEditor = createMockEditor();
+    const mockMonaco = createMockMonaco();
+
+    capturedOnMount!(mockEditor, mockMonaco);
+
+    const actionIds = mockAddAction.mock.calls.map(
+      (call: unknown[]) => (call[0] as { id: string }).id,
+    );
+    expect(actionIds).toContain("markdown-bold");
+    expect(actionIds).toContain("markdown-italic");
+    expect(actionIds).toContain("markdown-link");
+    expect(actionIds).toContain("select-all");
+  });
+
+  test("switches to preview mode and shows content", async () => {
+    renderEditor({ value: "# Hello World" });
+
+    const previewButton = screen.getByText("Preview");
+    await act(async () => {
+      fireEvent.click(previewButton);
+    });
+
+    expect(screen.getByText("Hello World")).toBeTruthy();
+  });
+
+  test("shows nothing to preview when value is empty", async () => {
+    renderEditor({ value: "" });
+
+    const previewButton = screen.getByText("Preview");
+    await act(async () => {
+      fireEvent.click(previewButton);
+    });
+
+    expect(screen.getByText("Nothing to preview")).toBeTruthy();
+  });
+});

--- a/cmd/sgai/webapp/src/components/MarkdownEditor.tsx
+++ b/cmd/sgai/webapp/src/components/MarkdownEditor.tsx
@@ -294,6 +294,18 @@ export function MarkdownEditor({
         run: (ed) => insertLink(ed),
       });
 
+      editor.addAction({
+        id: "select-all",
+        label: "Select All",
+        keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyA],
+        run: (ed) => {
+          const model = ed.getModel();
+          if (model) {
+            ed.setSelection(model.getFullModelRange());
+          }
+        },
+      });
+
       if (placeholder && !value) {
         const model = editor.getModel();
         if (model) {


### PR DESCRIPTION
## Summary

- Add frontmatter table rendering in GOAL preview using shadcn/ui Table component with YAML parsing
- Enable Cmd/Ctrl+A (Select All) keyboard shortcut in the Monaco editor
- Add comprehensive tests for MarkdownContent frontmatter extraction and MarkdownEditor actions