### PR TITLE
cmd/sgai: add auto-flow mode for GOAL.md without frontmatter

### DIFF
--- a/GOALS/2026_03_01_auto_flow_mode.md
+++ b/GOALS/2026_03_01_auto_flow_mode.md
@@ -1,0 +1,37 @@
+---
+flow: |
+  "backend-go-developer" -> "go-readability-reviewer"
+  "backend-go-developer" -> "stpa-analyst"
+  "go-readability-reviewer" -> "stpa-analyst"
+  "general-purpose" -> "stpa-analyst"
+  "react-developer" -> "react-reviewer"
+  "react-reviewer" -> "stpa-analyst"
+  "project-critic-council"
+  "skill-writer"
+models:
+  "coordinator": "anthropic/claude-opus-4-6 (max)"
+  "backend-go-developer": "anthropic/claude-opus-4-6"
+  "go-readability-reviewer": "anthropic/claude-opus-4-6"
+  "general-purpose": "anthropic/claude-opus-4-6"
+  "react-developer": "anthropic/claude-opus-4-6"
+  "react-reviewer": "anthropic/claude-opus-4-6"
+  "stpa-analyst": "anthropic/claude-opus-4-6"
+  "project-critic-council": ["anthropic/claude-opus-4-6","anthropic/claude-sonnet-4-6", "anthropic/claude-opus-4-5"]
+  "skill-writer": "anthropic/claude-opus-4-6 (max)"
+completionGateScript: make test
+---
+
+I want a new auto-mode. Basically, I am trying to fix the issue of the GOAL.md maybe not having a frontmatter block.
+
+Basically, if `flow: "auto"` OR the frontmatter is empty, then the automatic flow mode must kick in.
+
+What I would expect the coordinator to use a skill that:
+- [x] look at the workspace source code, and correctly pick the right agents for me
+  - [x] it would survey the agents from withing `.sgai/agent` subdirectory
+- [x] use the default model for these agents
+- [x] when picking up agents, correct pair agents (like developer with reviewer)
+
+
+In term of sequence of events: user writes GOAL without frontmatter, user starts sgai, the coordinator detects that frontmatter is missing or lacking flow, go shop for agents, update the GOAL.md with the agents, then resume as if GOAL.md had the flow defined all along.
+
+- [x] rebuildIfFlowChanged is conceptually incorrect, I guess. On every loop, you have to rebuild the DAG and the model configuration from GOAL.md, unconditionally. When you add tests like this, you make it the code more complex and less reliable. 

--- a/cmd/sgai/dag.go
+++ b/cmd/sgai/dag.go
@@ -88,7 +88,7 @@ func parseFlow(flowSpec string, dir string) (*dag, error) {
 	var dotContent string
 
 	switch {
-	case flowSpec == "":
+	case isAutoFlowSpec(flowSpec):
 		dotContent = "digraph G {\n\"coordinator\" -> \"general-purpose\"\n}"
 	case strings.HasPrefix(flowSpec, "digraph"):
 		dotContent = flowSpec
@@ -333,7 +333,7 @@ func buildMultiModelSection(currentModel string, models map[string]any, currentA
 	return sb.String()
 }
 
-func buildFlowMessage(d *dag, currentAgent string, visitCounts map[string]int, dir string, interactionMode string) string {
+func buildFlowMessage(d *dag, currentAgent string, visitCounts map[string]int, dir string, interactionMode string, flowSpec string) string {
 	predecessors := d.getPredecessors(currentAgent)
 	predecessorsStr := strings.Join(predecessors, ", ")
 	if predecessorsStr == "" {
@@ -393,5 +393,20 @@ func buildFlowMessage(d *dag, currentAgent string, visitCounts map[string]int, d
 		msg += snippetNudge
 	}
 
+	if currentAgent == "coordinator" && isAutoFlowSpec(flowSpec) {
+		msg += autoFlowNudge
+	}
+
 	return msg
 }
+
+func isAutoFlowSpec(flowSpec string) bool {
+	return flowSpec == "" || flowSpec == "auto"
+}
+
+const autoFlowNudge = `
+CRITICAL: The GOAL.md has no explicit agent flow configured (flow is empty or "auto").
+You MUST use the ` + "`auto-flow-mode`" + ` skill to survey available agents, analyze the workspace,
+select and pair appropriate agents, and update GOAL.md with the flow configuration.
+Call skills({"name":"auto-flow-mode"}) IMMEDIATELY.
+`

--- a/cmd/sgai/dag_test.go
+++ b/cmd/sgai/dag_test.go
@@ -726,7 +726,7 @@ func TestBuildFlowMessageSelfDriveMode(t *testing.T) {
 	dir := t.TempDir()
 
 	t.Run("selfDriveIncludesSelfDriveInstructions", func(t *testing.T) {
-		msg := buildFlowMessage(d, "coordinator", visits, dir, state.ModeSelfDrive)
+		msg := buildFlowMessage(d, "coordinator", visits, dir, state.ModeSelfDrive, "some-flow")
 		if !strings.Contains(msg, "SELF-DRIVE MODE ACTIVE") {
 			t.Error("self-drive message should contain SELF-DRIVE MODE ACTIVE")
 		}
@@ -745,7 +745,7 @@ func TestBuildFlowMessageSelfDriveMode(t *testing.T) {
 	})
 
 	t.Run("interactiveModeIncludesAskQuestions", func(t *testing.T) {
-		msg := buildFlowMessage(d, "coordinator", visits, dir, state.ModeBrainstorming)
+		msg := buildFlowMessage(d, "coordinator", visits, dir, state.ModeBrainstorming, "some-flow")
 		if !strings.Contains(msg, "ASK ME QUESTIONS BEFORE BUILDING") {
 			t.Error("interactive message should contain ASK ME QUESTIONS prompt")
 		}
@@ -755,7 +755,7 @@ func TestBuildFlowMessageSelfDriveMode(t *testing.T) {
 	})
 
 	t.Run("selfDriveNonCoordinator", func(t *testing.T) {
-		msg := buildFlowMessage(d, "planner", visits, dir, state.ModeSelfDrive)
+		msg := buildFlowMessage(d, "planner", visits, dir, state.ModeSelfDrive, "some-flow")
 		if !strings.Contains(msg, "SELF-DRIVE MODE ACTIVE") {
 			t.Error("self-drive message for non-coordinator should contain SELF-DRIVE MODE ACTIVE")
 		}
@@ -771,7 +771,7 @@ func TestBuildFlowMessageSelfDriveMode(t *testing.T) {
 	})
 
 	t.Run("selfDriveCoordinatorIncludesDelegation", func(t *testing.T) {
-		msg := buildFlowMessage(d, "coordinator", visits, dir, state.ModeSelfDrive)
+		msg := buildFlowMessage(d, "coordinator", visits, dir, state.ModeSelfDrive, "some-flow")
 		if !strings.Contains(msg, "delegate work to specialized agents") {
 			t.Error("self-drive coordinator message should contain delegation instructions")
 		}
@@ -781,7 +781,7 @@ func TestBuildFlowMessageSelfDriveMode(t *testing.T) {
 	})
 
 	t.Run("buildingModeIncludesBuildingInstructions", func(t *testing.T) {
-		msg := buildFlowMessage(d, "coordinator", visits, dir, state.ModeBuilding)
+		msg := buildFlowMessage(d, "coordinator", visits, dir, state.ModeBuilding, "some-flow")
 		if !strings.Contains(msg, "BUILDING MODE ACTIVE") {
 			t.Error("building mode message should contain BUILDING MODE ACTIVE")
 		}
@@ -797,7 +797,7 @@ func TestBuildFlowMessageSelfDriveMode(t *testing.T) {
 	})
 
 	t.Run("buildingModeCoordinatorIncludesRetrospective", func(t *testing.T) {
-		msg := buildFlowMessage(d, "coordinator", visits, dir, state.ModeBuilding)
+		msg := buildFlowMessage(d, "coordinator", visits, dir, state.ModeBuilding, "some-flow")
 		if !strings.Contains(msg, "run retrospective") {
 			t.Error("building mode coordinator message should mention running retrospective")
 		}
@@ -807,7 +807,7 @@ func TestBuildFlowMessageSelfDriveMode(t *testing.T) {
 	})
 
 	t.Run("buildingModeNonCoordinator", func(t *testing.T) {
-		msg := buildFlowMessage(d, "planner", visits, dir, state.ModeBuilding)
+		msg := buildFlowMessage(d, "planner", visits, dir, state.ModeBuilding, "some-flow")
 		if !strings.Contains(msg, "BUILDING MODE ACTIVE") {
 			t.Error("building mode for non-coordinator should contain BUILDING MODE ACTIVE")
 		}
@@ -817,7 +817,7 @@ func TestBuildFlowMessageSelfDriveMode(t *testing.T) {
 	})
 
 	t.Run("emptyModeDefaultsToInteractive", func(t *testing.T) {
-		msg := buildFlowMessage(d, "coordinator", visits, dir, "")
+		msg := buildFlowMessage(d, "coordinator", visits, dir, "", "some-flow")
 		if !strings.Contains(msg, "ASK ME QUESTIONS BEFORE BUILDING") {
 			t.Error("empty mode message should contain interactive prompt")
 		}
@@ -830,7 +830,7 @@ func TestBuildFlowMessageSelfDriveMode(t *testing.T) {
 	})
 
 	t.Run("retrospectiveModeIncludesRetrospectiveInstructions", func(t *testing.T) {
-		msg := buildFlowMessage(d, "coordinator", visits, dir, state.ModeRetrospective)
+		msg := buildFlowMessage(d, "coordinator", visits, dir, state.ModeRetrospective, "some-flow")
 		if !strings.Contains(msg, "RETROSPECTIVE MODE ACTIVE") {
 			t.Error("retrospective mode message should contain RETROSPECTIVE MODE ACTIVE")
 		}
@@ -846,7 +846,7 @@ func TestBuildFlowMessageSelfDriveMode(t *testing.T) {
 	})
 
 	t.Run("retrospectiveModeCoordinatorIncludesRelayInstructions", func(t *testing.T) {
-		msg := buildFlowMessage(d, "coordinator", visits, dir, state.ModeRetrospective)
+		msg := buildFlowMessage(d, "coordinator", visits, dir, state.ModeRetrospective, "some-flow")
 		if !strings.Contains(msg, "RETRO_QUESTION relay phase") {
 			t.Error("retrospective mode coordinator message should contain RETRO_QUESTION relay instructions")
 		}
@@ -856,12 +856,211 @@ func TestBuildFlowMessageSelfDriveMode(t *testing.T) {
 	})
 
 	t.Run("retrospectiveModeNonCoordinator", func(t *testing.T) {
-		msg := buildFlowMessage(d, "planner", visits, dir, state.ModeRetrospective)
+		msg := buildFlowMessage(d, "planner", visits, dir, state.ModeRetrospective, "some-flow")
 		if !strings.Contains(msg, "RETROSPECTIVE MODE ACTIVE") {
 			t.Error("retrospective mode for non-coordinator should contain RETROSPECTIVE MODE ACTIVE")
 		}
 		if strings.Contains(msg, "RETRO_QUESTION relay phase") {
 			t.Error("retrospective mode for non-coordinator should not contain coordinator relay instructions")
+		}
+	})
+}
+
+func TestParseFlowAuto(t *testing.T) {
+	d, err := parseFlow("auto", "")
+	if err != nil {
+		t.Fatalf("parseFlow with auto spec failed: %v", err)
+	}
+
+	if len(d.Nodes) != 3 {
+		t.Errorf("expected 3 nodes (coordinator, general-purpose, project-critic-council), got %d", len(d.Nodes))
+	}
+
+	if len(d.EntryNodes) != 1 || d.EntryNodes[0] != "coordinator" {
+		t.Errorf("expected coordinator to be the only entry node, got %v", d.EntryNodes)
+	}
+
+	coordNode := d.Nodes["coordinator"]
+	if !slices.Contains(coordNode.Successors, "general-purpose") {
+		t.Errorf("coordinator should have general-purpose as successor, got: %v", coordNode.Successors)
+	}
+
+	if !d.isTerminal("general-purpose") {
+		t.Error("general-purpose should be a terminal node")
+	}
+}
+
+func TestParseFlowAutoMatchesEmpty(t *testing.T) {
+	dagAuto, errAuto := parseFlow("auto", "")
+	if errAuto != nil {
+		t.Fatalf("parseFlow(auto) failed: %v", errAuto)
+	}
+
+	dagEmpty, errEmpty := parseFlow("", "")
+	if errEmpty != nil {
+		t.Fatalf("parseFlow(empty) failed: %v", errEmpty)
+	}
+
+	autoAgents := dagAuto.allAgents()
+	emptyAgents := dagEmpty.allAgents()
+	if !slices.Equal(autoAgents, emptyAgents) {
+		t.Errorf("auto and empty should produce the same agents, got auto=%v, empty=%v", autoAgents, emptyAgents)
+	}
+}
+
+func TestIsAutoFlowSpec(t *testing.T) {
+	cases := []struct {
+		name string
+		spec string
+		want bool
+	}{
+		{"empty", "", true},
+		{"auto", "auto", true},
+		{"explicitFlow", "coordinator -> planner", false},
+		{"digraph", "digraph G {}", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isAutoFlowSpec(tc.spec); got != tc.want {
+				t.Errorf("isAutoFlowSpec(%q) = %v; want %v", tc.spec, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBuildFlowMessageAutoFlowNudge(t *testing.T) {
+	d, err := parseFlow("", "")
+	if err != nil {
+		t.Fatalf("parseFlow failed: %v", err)
+	}
+
+	visits := map[string]int{"coordinator": 0, "general-purpose": 0, "project-critic-council": 0}
+	dir := t.TempDir()
+
+	t.Run("coordinatorWithEmptyFlowGetsNudge", func(t *testing.T) {
+		msg := buildFlowMessage(d, "coordinator", visits, dir, state.ModeBuilding, "")
+		if !strings.Contains(msg, "auto-flow-mode") {
+			t.Error("coordinator with empty flow should get auto-flow-mode nudge")
+		}
+		if !strings.Contains(msg, "CRITICAL") {
+			t.Error("nudge should contain CRITICAL marker")
+		}
+	})
+
+	t.Run("coordinatorWithAutoFlowGetsNudge", func(t *testing.T) {
+		msg := buildFlowMessage(d, "coordinator", visits, dir, state.ModeBuilding, "auto")
+		if !strings.Contains(msg, "auto-flow-mode") {
+			t.Error("coordinator with auto flow should get auto-flow-mode nudge")
+		}
+	})
+
+	t.Run("coordinatorWithExplicitFlowNoNudge", func(t *testing.T) {
+		msg := buildFlowMessage(d, "coordinator", visits, dir, state.ModeBuilding, "coordinator -> planner")
+		if strings.Contains(msg, "auto-flow-mode") {
+			t.Error("coordinator with explicit flow should NOT get auto-flow-mode nudge")
+		}
+	})
+
+	t.Run("nonCoordinatorWithEmptyFlowNoNudge", func(t *testing.T) {
+		msg := buildFlowMessage(d, "general-purpose", visits, dir, state.ModeBuilding, "")
+		if strings.Contains(msg, "auto-flow-mode") {
+			t.Error("non-coordinator agents should NOT get auto-flow-mode nudge")
+		}
+	})
+}
+
+func TestRebuildDAG(t *testing.T) {
+	t.Run("returnsCorrectDAG", func(t *testing.T) {
+		metadata := GoalMetadata{Flow: "planner -> coder"}
+		visitCounts := make(map[string]int)
+		d, agents, longest, err := rebuildDAG(&metadata, t.TempDir(), visitCounts)
+		if err != nil {
+			t.Fatalf("rebuildDAG failed: %v", err)
+		}
+		if !slices.Contains(agents, "planner") {
+			t.Error("agents should contain planner")
+		}
+		if !slices.Contains(agents, "coder") {
+			t.Error("agents should contain coder")
+		}
+		if !slices.Contains(agents, "coordinator") {
+			t.Error("agents should contain coordinator")
+		}
+		if _, exists := d.Nodes["planner"]; !exists {
+			t.Error("DAG should contain planner node")
+		}
+		if _, exists := d.Nodes["coder"]; !exists {
+			t.Error("DAG should contain coder node")
+		}
+		if longest < len("coordinator") {
+			t.Errorf("longestNameLen should be at least %d, got %d", len("coordinator"), longest)
+		}
+	})
+
+	t.Run("newAgentsGetZeroVisitCounts", func(t *testing.T) {
+		metadata := GoalMetadata{Flow: "planner -> coder"}
+		visitCounts := map[string]int{"coordinator": 3}
+		_, _, _, err := rebuildDAG(&metadata, t.TempDir(), visitCounts)
+		if err != nil {
+			t.Fatalf("rebuildDAG failed: %v", err)
+		}
+		if visitCounts["planner"] != 0 {
+			t.Errorf("new agent planner should have 0 visits, got %d", visitCounts["planner"])
+		}
+		if visitCounts["coder"] != 0 {
+			t.Errorf("new agent coder should have 0 visits, got %d", visitCounts["coder"])
+		}
+	})
+
+	t.Run("existingVisitCountsPreserved", func(t *testing.T) {
+		metadata := GoalMetadata{Flow: "planner -> coder"}
+		visitCounts := map[string]int{"coordinator": 5, "planner": 2}
+		_, _, _, err := rebuildDAG(&metadata, t.TempDir(), visitCounts)
+		if err != nil {
+			t.Fatalf("rebuildDAG failed: %v", err)
+		}
+		if visitCounts["coordinator"] != 5 {
+			t.Errorf("existing coordinator visits should be 5, got %d", visitCounts["coordinator"])
+		}
+		if visitCounts["planner"] != 2 {
+			t.Errorf("existing planner visits should be 2, got %d", visitCounts["planner"])
+		}
+	})
+
+	t.Run("invalidFlowReturnsError", func(t *testing.T) {
+		metadata := GoalMetadata{Flow: "digraph INVALID {{{"}
+		visitCounts := make(map[string]int)
+		_, _, _, err := rebuildDAG(&metadata, t.TempDir(), visitCounts)
+		if err == nil {
+			t.Error("rebuildDAG should return error for invalid flow")
+		}
+	})
+
+	t.Run("retrospectiveInjectedWhenEnabled", func(t *testing.T) {
+		metadata := GoalMetadata{Flow: "planner -> coder", Retrospective: "yes"}
+		visitCounts := make(map[string]int)
+		d, agents, _, err := rebuildDAG(&metadata, t.TempDir(), visitCounts)
+		if err != nil {
+			t.Fatalf("rebuildDAG failed: %v", err)
+		}
+		if _, exists := d.Nodes["retrospective"]; !exists {
+			t.Error("DAG should contain retrospective node when enabled")
+		}
+		if !slices.Contains(agents, "retrospective") {
+			t.Error("agents should contain retrospective when enabled")
+		}
+	})
+
+	t.Run("retrospectiveNotInjectedWhenDisabled", func(t *testing.T) {
+		metadata := GoalMetadata{Flow: "planner -> coder", Retrospective: "no"}
+		visitCounts := make(map[string]int)
+		d, _, _, err := rebuildDAG(&metadata, t.TempDir(), visitCounts)
+		if err != nil {
+			t.Fatalf("rebuildDAG failed: %v", err)
+		}
+		if _, exists := d.Nodes["retrospective"]; exists {
+			t.Error("DAG should not contain retrospective node when disabled")
 		}
 	})
 }

--- a/cmd/sgai/main.go
+++ b/cmd/sgai/main.go
@@ -138,17 +138,10 @@ func runWorkflow(ctx context.Context, args []string, mcpURL string, logWriter io
 		log.Fatalln("failed to apply custom MCPs:", err)
 	}
 
-	flowDag, err := parseFlow(metadata.Flow, dir)
-	if err != nil {
-		log.Fatalln("failed to parse flow:", err)
+	flowDag, allAgents, longestNameLen, errRebuild := rebuildDAG(&metadata, dir, make(map[string]int))
+	if errRebuild != nil {
+		log.Fatalln("failed to build DAG:", errRebuild)
 	}
-
-	if retrospectiveEnabled(metadata) {
-		flowDag.injectRetrospectiveEdge()
-	}
-
-	ensureImplicitProjectCriticCouncilModel(flowDag, &metadata)
-	ensureImplicitRetrospectiveModel(flowDag, &metadata)
 
 	if err := validateModels(metadata.Models); err != nil {
 		log.Fatalln(err)
@@ -172,18 +165,7 @@ func runWorkflow(ctx context.Context, args []string, mcpURL string, logWriter io
 		log.Fatalln("failed to compute GOAL.md checksum:", err)
 	}
 
-	dagAgents := flowDag.allAgents()
-	var allAgents []string
-	if slices.Contains(dagAgents, "coordinator") {
-		allAgents = dagAgents
-	} else {
-		allAgents = append([]string{"coordinator"}, dagAgents...)
-	}
 	workspaceName := filepath.Base(dir)
-	longestNameLen := len("sgai")
-	for _, agent := range allAgents {
-		longestNameLen = max(longestNameLen, len(agent))
-	}
 	paddedsgai := workspaceName + "][" + "sgai" + strings.Repeat(" ", max(0, longestNameLen-len("sgai")))
 
 	pmPath := filepath.Join(dir, ".sgai", "PROJECT_MANAGEMENT.md")
@@ -312,6 +294,13 @@ func runWorkflow(ctx context.Context, args []string, mcpURL string, logWriter io
 			log.Println("failed to reload GOAL.md frontmatter:", errReloadGoalMetadata)
 			return
 		}
+		newDag, _, newLongest, errRebuild := rebuildDAG(&metadata, dir, wfState.VisitCounts)
+		if errRebuild != nil {
+			log.Println("failed to rebuild DAG:", errRebuild, "- keeping old DAG")
+		} else {
+			flowDag = newDag
+			longestNameLen = newLongest
+		}
 		unlockInteractiveForRetrospective(&wfState, currentAgent, coord, paddedsgai)
 		wfState = runFlowAgent(ctx, dir, goalPath, currentAgent, flowDag, wfState, stateJSONPath, coord, metadata, retrospectiveDir, longestNameLen, paddedsgai, &iterationCounter, mcpURL, logWriter, retroStdoutLog, retroStderrLog)
 		if wfState.Status == state.StatusComplete {
@@ -365,6 +354,13 @@ func runWorkflow(ctx context.Context, args []string, mcpURL string, logWriter io
 			if errReloadGoalMetadata != nil {
 				log.Println("failed to reload GOAL.md frontmatter:", errReloadGoalMetadata)
 				return
+			}
+			newDag, _, newLongest, errRebuild := rebuildDAG(&metadata, dir, wfState.VisitCounts)
+			if errRebuild != nil {
+				log.Println("failed to rebuild DAG:", errRebuild, "- keeping old DAG")
+			} else {
+				flowDag = newDag
+				longestNameLen = newLongest
 			}
 			unlockInteractiveForRetrospective(&wfState, currentAgent, coord, paddedsgai)
 			wfState = runFlowAgent(ctx, dir, goalPath, currentAgent, flowDag, wfState, stateJSONPath, coord, metadata, retrospectiveDir, longestNameLen, paddedsgai, &iterationCounter, mcpURL, logWriter, retroStdoutLog, retroStderrLog)
@@ -714,7 +710,7 @@ func runFlowAgentWithModel(ctx context.Context, cfg multiModelConfig, wfState st
 		}
 		args = append(args, "--title", title)
 
-		msg := buildFlowMessage(cfg.flowDag, cfg.agent, wfState.VisitCounts, cfg.dir, wfState.InteractionMode)
+		msg := buildFlowMessage(cfg.flowDag, cfg.agent, wfState.VisitCounts, cfg.dir, wfState.InteractionMode, metadata.Flow)
 
 		multiModelSection := buildMultiModelSection(wfState.CurrentModel, metadata.Models, cfg.agent)
 		if multiModelSection != "" {
@@ -1231,6 +1227,37 @@ func fetchValidModels() (map[string]bool, error) {
 	}
 
 	return validModels, nil
+}
+
+func rebuildDAG(metadata *GoalMetadata, dir string, visitCounts map[string]int) (*dag, []string, int, error) {
+	newDag, errParse := parseFlow(metadata.Flow, dir)
+	if errParse != nil {
+		return nil, nil, 0, errParse
+	}
+
+	if retrospectiveEnabled(*metadata) {
+		newDag.injectRetrospectiveEdge()
+	}
+	ensureImplicitProjectCriticCouncilModel(newDag, metadata)
+	ensureImplicitRetrospectiveModel(newDag, metadata)
+
+	dagAgents := newDag.allAgents()
+	var allAgents []string
+	if slices.Contains(dagAgents, "coordinator") {
+		allAgents = dagAgents
+	} else {
+		allAgents = append([]string{"coordinator"}, dagAgents...)
+	}
+
+	longestNameLen := len("sgai")
+	for _, agent := range allAgents {
+		if _, exists := visitCounts[agent]; !exists {
+			visitCounts[agent] = 0
+		}
+		longestNameLen = max(longestNameLen, len(agent))
+	}
+
+	return newDag, allAgents, longestNameLen, nil
 }
 
 // tryReloadGoalMetadata attempts to reload GOAL.md frontmatter from disk.

--- a/cmd/sgai/skel/.sgai/skills/auto-flow-mode/SKILL.md
+++ b/cmd/sgai/skel/.sgai/skills/auto-flow-mode/SKILL.md
@@ -1,0 +1,301 @@
+---
+name: auto-flow-mode
+description: Use when GOAL.md has no flow defined or flow is set to "auto" - guides coordinator through surveying agents, analyzing workspace technologies, selecting and pairing agents, and updating GOAL.md with the flow configuration
+---
+
+# Auto-Flow Mode
+
+## Overview
+
+When GOAL.md has no explicit agent flow configured (empty frontmatter or `flow: "auto"`), this skill guides the coordinator through automatically detecting the right agents for the project and writing the flow configuration.
+
+**Core principle:** Survey the available agents, analyze the workspace, pick agents that match the technologies present, pair developers with reviewers, and write the configuration to GOAL.md so the DAG hot-reload picks it up.
+
+## When to Use
+
+- Use when GOAL.md has no frontmatter at all
+- Use when GOAL.md frontmatter has no `flow:` key
+- Use when GOAL.md frontmatter has `flow: "auto"` or `flow: auto`
+- Use when the system nudge tells you: "The GOAL.md has no explicit agent flow configured"
+
+**Do NOT use when:**
+- GOAL.md already has a valid `flow:` with agent edges defined
+- The human partner has explicitly configured the flow
+
+## Process
+
+### Step 1: Survey Available Agents
+
+Read all agent definition files from `.sgai/agent/` directory to build a catalog.
+
+- [ ] Use the Task tool with `explore` subagent type to list and read all `.sgai/agent/*.md` files
+- [ ] For each agent file, extract the YAML frontmatter fields:
+  - `description` - what the agent does
+  - `mode` - either `primary` (developer/coder) or `all` (reviewer)
+- [ ] Build a table of agents with their capabilities:
+
+```
+| Agent Name | Mode | Description |
+|------------|------|-------------|
+| backend-go-developer | primary | Expert Go backend developer... |
+| go-readability-reviewer | all | Reviews Go code... |
+| ... | ... | ... |
+```
+
+### Step 2: Analyze Workspace
+
+Scan the workspace to determine what technologies are in use.
+
+- [ ] Use the Task tool with `explore` subagent type to analyze the workspace:
+  - File extensions present (`.go`, `.tsx`, `.jsx`, `.ts`, `.js`, `.py`, `.sh`, `.html`, `.css`, etc.)
+  - Build files (Makefile, package.json, go.mod, pyproject.toml, Cargo.toml, etc.)
+  - Project structure (cmd/, internal/, src/, components/, etc.)
+  - Frameworks and libraries (check imports, dependencies)
+- [ ] Summarize the technologies detected
+
+### Step 3: Select Agents
+
+Based on the workspace analysis, select agents that match the detected technologies.
+
+- [ ] Apply the following technology-to-agent mapping as guidance:
+
+| Technology Signal | Developer Agent | Notes |
+|-------------------|----------------|-------|
+| `.go` files, `go.mod`, `Makefile` | `backend-go-developer` | Go backend code |
+| `.tsx`, `.jsx`, `package.json` with React | `react-developer` | React frontend code |
+| `.html` with HTMX attributes, PicoCSS | `htmx-picocss-frontend-developer` | HTMX+Pico frontend |
+| `.sh`, `.bash` scripts, shell-heavy Makefiles | `shell-script-coder` | Shell scripting |
+| `.py` files, `pyproject.toml` | Consider `general-purpose` | Python work |
+| Mixed or unclear | `general-purpose` | Catch-all |
+
+- [ ] Always include `general-purpose` as a catch-all agent
+- [ ] If no technology is identifiable at all, default to just `general-purpose`
+- [ ] Use your judgment — the table above is guidance, not exhaustive. If the workspace has technologies that match other agents in the catalog, include them.
+
+### Step 4: Pair Developers with Reviewers
+
+For each selected developer agent, find and include its corresponding reviewer.
+
+- [ ] Apply the known developer-reviewer pairings:
+
+| Developer Agent | Reviewer Agent |
+|----------------|---------------|
+| `backend-go-developer` | `go-readability-reviewer` |
+| `react-developer` | `react-reviewer` |
+| `htmx-picocss-frontend-developer` | `htmx-picocss-frontend-reviewer` |
+| `shell-script-coder` | `shell-script-reviewer` |
+
+- [ ] For each pairing, create a flow edge: `"developer-agent" -> "reviewer-agent"`
+- [ ] If a developer agent has no known reviewer, include it as a standalone node: `"agent-name"`
+- [ ] The `general-purpose` agent has no dedicated reviewer — include it as a standalone node
+
+### Step 5: Set Default Models
+
+Assign a default model to each selected agent.
+
+- [ ] Use `anthropic/claude-sonnet-4-6` as the default model for all agents
+- [ ] Use `anthropic/claude-sonnet-4-6` for the coordinator as well
+- [ ] Format each entry as: `"agent-name": "anthropic/claude-sonnet-4-6"`
+
+### Step 6: Update GOAL.md
+
+Write the flow configuration into GOAL.md's YAML frontmatter.
+
+- [ ] **CRITICAL: Preserve ALL existing body content** — everything after the frontmatter closing `---` must remain unchanged
+- [ ] Read the current GOAL.md content
+- [ ] Construct the new frontmatter with:
+  - `flow: |` followed by indented edge specifications
+  - `models:` section with each agent and its model
+- [ ] If GOAL.md already has frontmatter (even if empty/auto), replace only the frontmatter
+- [ ] If GOAL.md has no frontmatter, add it at the top
+
+**Flow syntax format** (DOT-like edge specification):
+```yaml
+flow: |
+  "backend-go-developer" -> "go-readability-reviewer"
+  "react-developer" -> "react-reviewer"
+  "general-purpose"
+```
+
+**Models syntax format:**
+```yaml
+models:
+  "coordinator": "anthropic/claude-sonnet-4-6"
+  "backend-go-developer": "anthropic/claude-sonnet-4-6"
+  "go-readability-reviewer": "anthropic/claude-sonnet-4-6"
+  "general-purpose": "anthropic/claude-sonnet-4-6"
+```
+
+**Complete frontmatter example:**
+```yaml
+---
+flow: |
+  "backend-go-developer" -> "go-readability-reviewer"
+  "react-developer" -> "react-reviewer"
+  "general-purpose"
+models:
+  "coordinator": "anthropic/claude-sonnet-4-6"
+  "backend-go-developer": "anthropic/claude-sonnet-4-6"
+  "go-readability-reviewer": "anthropic/claude-sonnet-4-6"
+  "react-developer": "anthropic/claude-sonnet-4-6"
+  "react-reviewer": "anthropic/claude-sonnet-4-6"
+  "general-purpose": "anthropic/claude-sonnet-4-6"
+---
+
+[existing GOAL.md body content preserved here]
+```
+
+### Step 7: Signal Completion
+
+- [ ] Set `agent-done` status so the DAG hot-reload picks up the new configuration
+- [ ] The system will automatically rebuild the DAG from the updated GOAL.md on the next iteration
+
+## Rules
+
+1. **Always preserve body content** — The GOAL.md body (everything after the frontmatter) contains the user's actual goals. Losing it is unacceptable.
+2. **Always include coordinator in models** — The coordinator is always part of the flow (the system injects coordinator edges automatically).
+3. **Always include general-purpose** — It serves as a catch-all for work that doesn't match specialized agents.
+4. **Don't over-select agents** — Only include agents relevant to the detected technologies. Including unnecessary agents adds noise to the workflow.
+5. **Don't under-select agents** — If a technology is clearly present, include its matching agent. Missing agents means work won't get done.
+6. **Reviewer comes with developer** — Never include a reviewer without its corresponding developer, and always include the reviewer when including the developer.
+7. **Use the explore subagent** — Don't try to guess what technologies are present. Actually scan the workspace using the Task tool with `explore` subagent type.
+
+## Automatic Injections
+
+The system automatically adds these to the DAG regardless of what you write in the flow:
+- `coordinator -> <all entry nodes>` — coordinator is always the entry point
+- `coordinator -> project-critic-council` — always injected for quality gates
+
+You do NOT need to include these edges in the flow specification. They are handled by the system.
+
+## Rationalization Table
+
+| Excuse | Reality |
+|--------|---------|
+| "GOAL.md already tells me what technologies are used" | GOAL.md describes goals, not the full technology stack. The workspace may have shell scripts, Makefiles, or frameworks not mentioned in the goals. Always scan. |
+| "I'll skip reviewers to save time on this urgent fix" | Urgency makes reviewers MORE important, not less. Auth bugs and security issues need a second pair of eyes. |
+| "Including all agents is safer than missing one" | Extra agents add noise and wasted cycles. Be precise. Only include agents for detected technologies. |
+| "This is just a small project, I can eyeball it" | Even small projects have build files and dependencies that reveal technology choices. Use the explore subagent. |
+| "I'll add the reviewer later if needed" | "Later" never comes. Pair them now. The flow is written once and reused for the entire session. |
+
+## Red Flags - STOP
+
+- You're about to write a flow without scanning the workspace first — **STOP and analyze**
+- You're including agents that don't match any detected technology — **STOP and reconsider**
+- You're writing the frontmatter and realize you might lose the body content — **STOP and verify**
+- You're skipping the reviewer for a developer agent that has one — **STOP and pair them**
+- You're about to hardcode specific agent names without surveying `.sgai/agent/` first — **STOP and survey**
+
+## Examples
+
+### Good Example: Go + React Project
+
+Workspace analysis reveals: `go.mod`, `.go` files in `cmd/` and `internal/`, `package.json` with React, `.tsx` files in `src/`.
+
+```yaml
+---
+flow: |
+  "backend-go-developer" -> "go-readability-reviewer"
+  "react-developer" -> "react-reviewer"
+  "general-purpose"
+models:
+  "coordinator": "anthropic/claude-sonnet-4-6"
+  "backend-go-developer": "anthropic/claude-sonnet-4-6"
+  "go-readability-reviewer": "anthropic/claude-sonnet-4-6"
+  "react-developer": "anthropic/claude-sonnet-4-6"
+  "react-reviewer": "anthropic/claude-sonnet-4-6"
+  "general-purpose": "anthropic/claude-sonnet-4-6"
+---
+```
+
+### Good Example: Pure Go Project
+
+Workspace analysis reveals: only `go.mod`, `.go` files, `Makefile`.
+
+```yaml
+---
+flow: |
+  "backend-go-developer" -> "go-readability-reviewer"
+  "general-purpose"
+models:
+  "coordinator": "anthropic/claude-sonnet-4-6"
+  "backend-go-developer": "anthropic/claude-sonnet-4-6"
+  "go-readability-reviewer": "anthropic/claude-sonnet-4-6"
+  "general-purpose": "anthropic/claude-sonnet-4-6"
+---
+```
+
+### Good Example: Unknown/Empty Workspace
+
+Workspace analysis reveals nothing identifiable.
+
+```yaml
+---
+flow: |
+  "general-purpose"
+models:
+  "coordinator": "anthropic/claude-sonnet-4-6"
+  "general-purpose": "anthropic/claude-sonnet-4-6"
+---
+```
+
+### Bad Example: Including Everything
+
+**DON'T** include all 28 agents because "more is better":
+
+```yaml
+# BAD - includes agents for technologies not present in workspace
+flow: |
+  "backend-go-developer" -> "go-readability-reviewer"
+  "react-developer" -> "react-reviewer"
+  "htmx-picocss-frontend-developer" -> "htmx-picocss-frontend-reviewer"
+  "shell-script-coder" -> "shell-script-reviewer"
+  "stpa-analyst"
+  "general-purpose"
+```
+
+This wastes agent cycles on technologies that aren't in the workspace.
+
+### Bad Example: Missing Reviewer
+
+**DON'T** include a developer without its reviewer:
+
+```yaml
+# BAD - backend-go-developer has no paired reviewer
+flow: |
+  "backend-go-developer"
+  "general-purpose"
+```
+
+The reviewer is essential for code quality.
+
+### Bad Example: Losing Body Content
+
+**DON'T** write only frontmatter and lose the goals:
+
+```yaml
+# BAD - where did the user's goals go?
+---
+flow: |
+  "general-purpose"
+models:
+  "coordinator": "anthropic/claude-sonnet-4-6"
+---
+```
+
+The body content MUST be preserved after the closing `---`.
+
+## Checklist
+
+Before completing, verify:
+
+- [ ] Surveyed `.sgai/agent/` directory for available agents
+- [ ] Analyzed workspace for technologies using explore subagent
+- [ ] Selected agents matching detected technologies
+- [ ] Paired every developer with its reviewer
+- [ ] Included `general-purpose` as catch-all
+- [ ] Included `coordinator` in models section
+- [ ] Used `anthropic/claude-sonnet-4-6` as default model
+- [ ] Preserved ALL existing GOAL.md body content
+- [ ] Flow syntax uses correct DOT-like format with quoted agent names
+- [ ] Set `agent-done` status after writing GOAL.md


### PR DESCRIPTION
## Summary

- Add auto-flow mode that activates when GOAL.md has no frontmatter or `flow: "auto"`, falling back to a default coordinator → general-purpose DAG
- Extract `rebuildDAG` helper to unconditionally rebuild the DAG and model configuration from GOAL.md on every loop iteration
- Add `auto-flow-mode` skill that guides the coordinator through surveying agents, analyzing workspace technologies, and writing the flow configuration