### PR TITLE
cmd/sgai: fix completion gate script process termination on context cancellation

### DIFF
--- a/GOALS/2026_03_01_fix_continuous_mode_completion_gate.md
+++ b/GOALS/2026_03_01_fix_continuous_mode_completion_gate.md
@@ -1,0 +1,26 @@
+---
+flow: |
+  "backend-go-developer" -> "go-readability-reviewer"
+  "react-developer" -> "react-reviewer"
+  "general-purpose"
+  "project-critic-council"
+  "skill-writer"
+  "stpa-analyst"
+models:
+  "coordinator": "anthropic/claude-opus-4-6 (max)"
+  "backend-go-developer": "anthropic/claude-opus-4-6"
+  "go-readability-reviewer": "anthropic/claude-opus-4-6"
+  "general-purpose": "anthropic/claude-opus-4-6"
+  "react-developer": "anthropic/claude-opus-4-6"
+  "react-reviewer": "anthropic/claude-opus-4-6"
+  "stpa-analyst": "anthropic/claude-opus-4-6"
+  "project-critic-council": ["anthropic/claude-opus-4-6"]
+  "skill-writer": "anthropic/claude-opus-4-6 (max)"
+completionGateScript: make test
+---
+
+Check the source code and...
+
+- [x] prove the continuous mode isn't broken
+  - [x] in a separate session, it seems I am not able to see the cronjob actually being triggered.
+  - [x] it seems to be stuck in `running completionGateScript: make test` (I don't see `make test` in the process tree)


### PR DESCRIPTION
## Summary

- Fix `runCompletionGateScript` to use process groups (`Setpgid`) and terminate the entire process tree on context cancellation, preventing orphaned child processes
- Add context cancellation and timeout tests for the completion gate script runner
- Archive completed goal specification to `GOALS/2026_03_01_fix_continuous_mode_completion_gate.md`