### PR TITLE
cmd/sgai/skel: increase MCP transport timeout to prevent premature disconnects

### DIFF
--- a/GOALS/2026_03_01_user_question_timeout.md
+++ b/GOALS/2026_03_01_user_question_timeout.md
@@ -1,0 +1,24 @@
+---
+flow: |
+  "backend-go-developer" -> "go-readability-reviewer"
+  "backend-go-developer" -> "stpa-analyst"
+  "go-readability-reviewer" -> "stpa-analyst"
+  "general-purpose" -> "stpa-analyst"
+  "react-developer" -> "react-reviewer"
+  "react-reviewer" -> "stpa-analyst"
+  "project-critic-council"
+  "skill-writer"
+models:
+  "coordinator": "anthropic/claude-opus-4-6 (max)"
+  "backend-go-developer": "anthropic/claude-opus-4-6"
+  "go-readability-reviewer": "anthropic/claude-opus-4-6"
+  "general-purpose": "anthropic/claude-opus-4-6"
+  "react-developer": "anthropic/claude-opus-4-6"
+  "react-reviewer": "anthropic/claude-opus-4-6"
+  "stpa-analyst": "anthropic/claude-opus-4-6"
+  "project-critic-council": ["anthropic/claude-opus-4-6", "anthropic/claude-sonnet-4-6", "anthropic/claude-opus-4-5"]
+  "skill-writer": "anthropic/claude-opus-4-6 (max)"
+completionGateScript: make test
+---
+
+- [x] both `ask_user_question` and `ask_user_work_gate` seem to be timing out too quickly

--- a/cmd/sgai/skel/.sgai/plugin/workbench.ts
+++ b/cmd/sgai/skel/.sgai/plugin/workbench.ts
@@ -25,7 +25,8 @@ export const Workbench: Plugin = async ({ directory }) => {
         url: process.env.SGAI_MCP_URL,
         headers: {
           "X-SGAI-Agent-Identity": process.env.SGAI_AGENT_IDENTITY || ""
-        }
+        },
+        timeout: 43200000
       };
     },
     // Tools are now provided by the MCP server configured above


### PR DESCRIPTION
## Summary

- Increase MCP transport timeout from default to 12 hours (43200000ms) in the workbench plugin to prevent `ask_user_question` and `ask_user_work_gate` from timing out prematurely during long-running agent sessions.
- Add goal spec to `GOALS/` directory.