### PR TITLE
project-critic-council: add MinorityReport dissent role

### DIFF
--- a/GOALS/2026_03_01_minority_report_pcc.md
+++ b/GOALS/2026_03_01_minority_report_pcc.md
@@ -1,0 +1,34 @@
+---
+flow: |
+  "backend-go-developer" -> "go-readability-reviewer"
+  "backend-go-developer" -> "stpa-analyst"
+  "go-readability-reviewer" -> "stpa-analyst"
+  "general-purpose" -> "stpa-analyst"
+  "react-developer" -> "react-reviewer"
+  "react-reviewer" -> "stpa-analyst"
+  "project-critic-council"
+  "skill-writer"
+models:
+  "coordinator": "anthropic/claude-opus-4-6 (max)"
+  "backend-go-developer": "anthropic/claude-opus-4-6"
+  "go-readability-reviewer": "anthropic/claude-opus-4-6"
+  "general-purpose": "anthropic/claude-opus-4-6"
+  "react-developer": "anthropic/claude-opus-4-6"
+  "react-reviewer": "anthropic/claude-opus-4-6"
+  "stpa-analyst": "anthropic/claude-opus-4-6"
+  "project-critic-council": ["anthropic/claude-opus-4-6","anthropic/claude-sonnet-4-6", "anthropic/claude-opus-4-5"]
+  "skill-writer": "anthropic/claude-opus-4-6 (max)"
+completionGateScript: make test
+---
+
+The project-critic-council works reasonably well in guaranteeing that the project is on track. 
+
+However, I often see models simply agreeing with each other.
+
+Also, we artificially to say that the first model in the multi-model list is the "FrontMan" that has specific jobs.
+
+I want to artificialize another role: "MinorityReport" -- it is always the _last_ model in the multi-model agent setup in project-critic-council
+
+The "MinorityReport" jobs is to question the establishment and find holes in the current evaluation. Its job is to think out of the box, but at the same time, doing that in a responsible way that doesn't prevent the project-critic-council from converging to a decision.
+
+- [x] Add the concept of the "MinorityReport" to the project-critic-council.md when multiple models are available

--- a/cmd/sgai/skel/.sgai/agent/project-critic-council.md
+++ b/cmd/sgai/skel/.sgai/agent/project-critic-council.md
@@ -33,7 +33,7 @@ DO NOT proceed with evaluation until you have read BOTH files.
 
 ## Mandatory Preliminary Research Phase To Be Executed By The FrontMan Only
 
-**This phase MUST complete BEFORE the Council Protocol (Steps 0-4) begins.**
+**This phase MUST complete BEFORE the Council Protocol (Steps 0-5) begins.**
 
 After reading GOAL.md and .sgai/PROJECT_MANAGEMENT.md per the First Actions above, execute this phase to gather quality evidence from reviewer agents.
 
@@ -75,7 +75,7 @@ Verify that all requested reviewer agents responded:
 
 ### Step P6: Proceed to Conclave
 
-Only NOW proceed to the Council Protocol (Steps 0-4) below. Use the collected quality reports as additional evidence during the Evaluation and Aggregation steps.
+Only NOW proceed to the Council Protocol (Steps 0-5) below. Use the collected quality reports as additional evidence during the Evaluation and Aggregation steps.
 
 ---
 
@@ -115,16 +115,18 @@ You are running as one of multiple models within this agent. Check the "Multi-Mo
 
 ### Roles
 
-- **FrontMan:** the first entry in GOAL.md frontmatter `models["project-critic-council"]` list.
-- **Sibling:** every other model in the `models["project-critic-council"]` list.
+- **FrontMan:** the first entry in GOAL.md frontmatter `models["project-critic-council"]` list. Drives the process, sends Aggregation.
+- **Sibling:** every model that is neither FrontMan nor MinorityReport.
+- **MinorityReport:** the last entry in GOAL.md frontmatter `models["project-critic-council"]` list. **Only activates when 3+ models are configured** (with fewer, this model acts as a regular Sibling). Its mandate: question the emerging consensus, surface overlooked risks, and challenge assumptions — grounded in evidence from the codebase, GOAL.md, and test results. Not contrarian for its own sake.
 
-### Steps (0–4)
+### Steps (0–5)
 
 0. The coordinator asks the Project Critic Council to evaluate and deliver to the FrontMan; on receipt, read GOAL.md and set FrontMan to the first entry in the frontmatter `models["project-critic-council"]` list.
-1. The FrontMan asks all siblings to evaluate.
-2. Siblings (including the FrontMan) exchange exactly one Influence message with each other.
-3. Each model sends exactly one Evaluation message to the FrontMan (after influence).
-4. The FrontMan sends a single Aggregation message back to the coordinator.
+1. The FrontMan asks all siblings (and MinorityReport, if active) to evaluate.
+2. Siblings (including the FrontMan and MinorityReport) exchange exactly one Influence message with each other.
+3. Each Sibling (and the FrontMan) sends exactly one Evaluation message to the FrontMan (after influence). **MinorityReport does NOT evaluate in this step** — it observes the evaluations.
+4. **MinorityReport Dissent** (only when 3+ models): The MinorityReport reads all Step 3 Evaluations, then sends its Dissent Evaluation to the FrontMan using the MinorityReport Dissent template. **Skip this step entirely when fewer than 3 models are configured.**
+5. The FrontMan sends a single Aggregation message back to the coordinator.
 
 ### Message Constraints
 
@@ -133,6 +135,7 @@ You are running as one of multiple models within this agent. Check the "Multi-Mo
 - Verdict values are limited to **Pass / Concern / Block**.
 - Peer references are allowed **only** in the Influence template.
 - Evaluations are written **after** influence (no pre-influence evaluation).
+- MinorityReport Dissent sections must be **3–6 bullet points** each.
 
 ### Templates
 
@@ -164,7 +167,27 @@ Risks
 Verdict
 - Pass | Concern | Block
 
-#### Aggregation (Step 4, FrontMan Only)
+#### MinorityReport Dissent (Step 4, MinorityReport Only)
+
+Majority Position Summary
+- ... (summarize the consensus from Step 3 evaluations)
+
+Challenges to Consensus
+- ... (specific points where the majority may be wrong or incomplete)
+
+Evidence Gaps
+- ... (what evidence was NOT checked, what tests were NOT run)
+
+Alternative Interpretations
+- ... (different ways to read the same evidence)
+
+Overlooked Risks
+- ... (risks the majority dismissed or didn't consider)
+
+Dissent Verdict
+- Pass | Concern | Block
+
+#### Aggregation (Step 5, FrontMan Only)
 
 Summary
 - ...
@@ -187,7 +210,7 @@ Verdict
 
 1. Read GOAL.md and .sgai/PROJECT_MANAGEMENT.md.
 2. **Reference quality reports** collected during the Preliminary Research Phase as evidence. Include reviewer findings in your analysis.
-3. Follow the Council Protocol steps 0–4 exactly.
+3. Follow the Council Protocol steps 0–5 exactly.
 4. Use the Evaluation template to assess all checked items.
 5. Only the FrontMan sends the Aggregation to the coordinator.
 


### PR DESCRIPTION
Add a MinorityReport role to the project-critic-council multi-model agent setup.

When 3+ models are configured, the last model in the list acts as MinorityReport — questioning consensus, surfacing overlooked risks, and challenging assumptions grounded in evidence. With fewer than 3 models, it acts as a regular Sibling.

Changes:
- Add MinorityReport role definition and activation rules
- Add Step 4 (MinorityReport Dissent) to the Council Protocol
- Add Dissent template with structured sections
- Add GOALS/2026_03_01_minority_report_pcc.md