### PR TITLE
cmd/sgai: resolve symlinks in pinned directories to survive restarts

### DIFF
--- a/GOALS/2026_03_01_fix_directories_unpinned_on_restart.md
+++ b/GOALS/2026_03_01_fix_directories_unpinned_on_restart.md
@@ -1,0 +1,22 @@
+---
+flow: |
+  "backend-go-developer" -> "go-readability-reviewer"
+  "react-developer" -> "react-reviewer"
+  "general-purpose"
+  "project-critic-council"
+  "skill-writer"
+  "stpa-analyst"
+models:
+  "coordinator": "anthropic/claude-opus-4-6 (max)"
+  "backend-go-developer": "anthropic/claude-opus-4-6"
+  "go-readability-reviewer": "anthropic/claude-opus-4-6"
+  "general-purpose": "anthropic/claude-opus-4-6"
+  "react-developer": "anthropic/claude-opus-4-6"
+  "react-reviewer": "anthropic/claude-opus-4-6"
+  "stpa-analyst": "anthropic/claude-opus-4-6"
+  "project-critic-council": ["anthropic/claude-opus-4-6"]
+  "skill-writer": "anthropic/claude-opus-4-6 (max)"
+completionGateScript: make test
+---
+
+- [x] sgai workspaces are getting unpinned when sgai restarts, fix it


### PR DESCRIPTION
## Summary

- Resolve symlinks via `filepath.EvalSymlinks` when storing and querying pinned directories, so pins survive sgai restarts that change between symlink and real paths
- Add `resolveSymlinks` helper used in `loadPinnedProjects`, `isPinned`, `togglePin`, and all workspace/fork creation and rename paths
- Add tests covering symlink-to-real and real-to-symlink pin persistence across server instances