### PR TITLE
cmd/sgai: fix retrospective agent mode transition and add dedicated prompt sections

### DIFF
--- a/GOALS/2026_03_02_fix_retrospective_agent.md
+++ b/GOALS/2026_03_02_fix_retrospective_agent.md
@@ -1,0 +1,30 @@
+---
+flow: |
+  "backend-go-developer" -> "go-readability-reviewer"
+  "backend-go-developer" -> "stpa-analyst"
+  "go-readability-reviewer" -> "stpa-analyst"
+  "general-purpose" -> "stpa-analyst"
+  "react-developer" -> "react-reviewer"
+  "react-reviewer" -> "stpa-analyst"
+  "project-critic-council"
+  "skill-writer"
+models:
+  "coordinator": "anthropic/claude-opus-4-6 (max)"
+  "backend-go-developer": "anthropic/claude-opus-4-6"
+  "go-readability-reviewer": "anthropic/claude-opus-4-6"
+  "general-purpose": "anthropic/claude-opus-4-6"
+  "react-developer": "anthropic/claude-opus-4-6"
+  "react-reviewer": "anthropic/claude-opus-4-6"
+  "stpa-analyst": "anthropic/claude-opus-4-6"
+  "project-critic-council": ["anthropic/claude-opus-4-6","anthropic/claude-sonnet-4-6","anthropic/claude-opus-4-5"]
+  "skill-writer": "anthropic/claude-opus-4-6 (max)"
+completionGateScript: make test
+---
+
+# Retrospective Agent Seems Broken
+
+- [x] right now, in all workspaces that I start, when it finally hits the retrospective agent something bad happen
+  - [x] either it stays stuck and never finishes running
+  - [x] or the coordinator marks status:complete and skips the retrospective (even though there is a pending message that would have triggered the retrospective agent)
+
+*CRITICAL* use all analytical skills to evaluate what's broken

--- a/cmd/sgai/dag_test.go
+++ b/cmd/sgai/dag_test.go
@@ -828,6 +828,42 @@ func TestBuildFlowMessageSelfDriveMode(t *testing.T) {
 			t.Error("empty mode message should not contain building instructions")
 		}
 	})
+
+	t.Run("retrospectiveModeIncludesRetrospectiveInstructions", func(t *testing.T) {
+		msg := buildFlowMessage(d, "coordinator", visits, dir, state.ModeRetrospective)
+		if !strings.Contains(msg, "RETROSPECTIVE MODE ACTIVE") {
+			t.Error("retrospective mode message should contain RETROSPECTIVE MODE ACTIVE")
+		}
+		if strings.Contains(msg, "SELF-DRIVE MODE ACTIVE") {
+			t.Error("retrospective mode message should not contain SELF-DRIVE MODE ACTIVE")
+		}
+		if strings.Contains(msg, "BUILDING MODE ACTIVE") {
+			t.Error("retrospective mode message should not contain BUILDING MODE ACTIVE")
+		}
+		if strings.Contains(msg, "ASK ME QUESTIONS BEFORE BUILDING") {
+			t.Error("retrospective mode message should not contain brainstorming prompt")
+		}
+	})
+
+	t.Run("retrospectiveModeCoordinatorIncludesRelayInstructions", func(t *testing.T) {
+		msg := buildFlowMessage(d, "coordinator", visits, dir, state.ModeRetrospective)
+		if !strings.Contains(msg, "RETRO_QUESTION relay phase") {
+			t.Error("retrospective mode coordinator message should contain RETRO_QUESTION relay instructions")
+		}
+		if !strings.Contains(msg, "RETRO_COMPLETE") {
+			t.Error("retrospective mode coordinator message should mention RETRO_COMPLETE")
+		}
+	})
+
+	t.Run("retrospectiveModeNonCoordinator", func(t *testing.T) {
+		msg := buildFlowMessage(d, "planner", visits, dir, state.ModeRetrospective)
+		if !strings.Contains(msg, "RETROSPECTIVE MODE ACTIVE") {
+			t.Error("retrospective mode for non-coordinator should contain RETROSPECTIVE MODE ACTIVE")
+		}
+		if strings.Contains(msg, "RETRO_QUESTION relay phase") {
+			t.Error("retrospective mode for non-coordinator should not contain coordinator relay instructions")
+		}
+	})
 }
 
 func truncateForTest(s string) string {

--- a/cmd/sgai/main.go
+++ b/cmd/sgai/main.go
@@ -402,7 +402,7 @@ func unlockInteractiveForRetrospective(wfState *state.Workflow, currentAgent str
 	if currentAgent != "retrospective" {
 		return
 	}
-	if wfState.InteractionMode != state.ModeBuilding {
+	if wfState.InteractionMode == state.ModeRetrospective {
 		return
 	}
 	wfState.InteractionMode = state.ModeRetrospective

--- a/cmd/sgai/main_test.go
+++ b/cmd/sgai/main_test.go
@@ -799,7 +799,7 @@ func TestUnlockInteractiveForRetrospective(t *testing.T) {
 		}
 	})
 
-	t.Run("selfDriveStaysSelfDrive", func(t *testing.T) {
+	t.Run("selfDriveTransitionsToRetrospective", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		stPath := filepath.Join(tmpDir, "state.json")
 
@@ -814,8 +814,48 @@ func TestUnlockInteractiveForRetrospective(t *testing.T) {
 
 		unlockInteractiveForRetrospective(&wf, "retrospective", coord, "test")
 
-		if wf.InteractionMode != state.ModeSelfDrive {
-			t.Errorf("InteractionMode should stay %q in self-drive mode, got %q", state.ModeSelfDrive, wf.InteractionMode)
+		if wf.InteractionMode != state.ModeRetrospective {
+			t.Errorf("InteractionMode should transition to %q from self-drive, got %q", state.ModeRetrospective, wf.InteractionMode)
+		}
+	})
+
+	t.Run("alreadyRetrospectiveNoTransition", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		stPath := filepath.Join(tmpDir, "state.json")
+
+		wf := state.Workflow{
+			InteractionMode: state.ModeRetrospective,
+			Status:          state.StatusWorking,
+		}
+		coord := state.NewCoordinatorEmpty(stPath)
+		if errUpdate := coord.UpdateState(func(s *state.Workflow) { *s = wf }); errUpdate != nil {
+			t.Fatal(errUpdate)
+		}
+
+		unlockInteractiveForRetrospective(&wf, "retrospective", coord, "test")
+
+		if wf.InteractionMode != state.ModeRetrospective {
+			t.Errorf("InteractionMode should stay %q, got %q", state.ModeRetrospective, wf.InteractionMode)
+		}
+	})
+
+	t.Run("brainstormingTransitionsToRetrospective", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		stPath := filepath.Join(tmpDir, "state.json")
+
+		wf := state.Workflow{
+			InteractionMode: state.ModeBrainstorming,
+			Status:          state.StatusWorking,
+		}
+		coord := state.NewCoordinatorEmpty(stPath)
+		if errUpdate := coord.UpdateState(func(s *state.Workflow) { *s = wf }); errUpdate != nil {
+			t.Fatal(errUpdate)
+		}
+
+		unlockInteractiveForRetrospective(&wf, "retrospective", coord, "test")
+
+		if wf.InteractionMode != state.ModeRetrospective {
+			t.Errorf("InteractionMode should transition to %q, got %q", state.ModeRetrospective, wf.InteractionMode)
 		}
 	})
 

--- a/cmd/sgai/prompt_registry.go
+++ b/cmd/sgai/prompt_registry.go
@@ -69,6 +69,24 @@ You are running in Building mode. The brainstorming and work-gate phases are com
 const flowSectionBuildingModeCoordinator = `- Your master plan: read GOAL.md → delegate to agents → verify → ask project-critic-council → run retrospective → complete
 - When delegated work is done, send a message to project-critic-council to verify all GOAL.md checkboxes are genuinely complete
 - After project-critic-council approves, send a message to the retrospective agent to start analysis
+- IMPORTANT: The retrospective step is MANDATORY. You MUST send a message to the retrospective agent and wait for RETRO_COMPLETE before marking complete
+- Do NOT mark status:complete until the retrospective has finished
+`
+
+const flowSectionRetrospectiveMode = `# RETROSPECTIVE MODE ACTIVE
+You are running in Retrospective mode. The building phase is complete.
+- Human interaction tools (ask_user_question) are re-enabled
+- If you are the retrospective agent: analyze session artifacts and send RETRO_QUESTION messages to coordinator
+- If you are the coordinator: you MUST relay RETRO_QUESTION messages to the human using ask_user_question, then send the human's answer back to the retrospective agent
+- Do NOT skip the retrospective - it is a mandatory step
+`
+
+const flowSectionRetrospectiveModeCoordinator = `- You are in the RETRO_QUESTION relay phase
+- Check your inbox for messages from the retrospective agent
+- When you see RETRO_QUESTION: messages, relay them to the human using ask_user_question
+- Send the human's actual response back to the retrospective agent
+- When you see RETRO_COMPLETE: messages, proceed to mark the workflow as complete
+- Do NOT mark complete until RETRO_COMPLETE is received
 `
 
 const flowSectionPostSkillsCoordinator = `IMPORTANT: YOU COMMUNICATE WITH THE HUMAN ONLY VIA ask_user_question (structured multi-choice questions).`
@@ -158,6 +176,8 @@ func modeSectionForMode(interactionMode string) (modeSection, coordinatorPlan st
 		return flowSectionContinuousMode, flowSectionContinuousModeCoordinator
 	case state.ModeBuilding:
 		return flowSectionBuildingMode, flowSectionBuildingModeCoordinator
+	case state.ModeRetrospective:
+		return flowSectionRetrospectiveMode, flowSectionRetrospectiveModeCoordinator
 	default:
 		return flowSectionBrainstormingMode, ""
 	}

--- a/cmd/sgai/prompt_registry_test.go
+++ b/cmd/sgai/prompt_registry_test.go
@@ -13,6 +13,7 @@ func TestComposePromptSharedSectionsInAllModes(t *testing.T) {
 		state.ModeBuilding,
 		state.ModeSelfDrive,
 		state.ModeContinuous,
+		state.ModeRetrospective,
 	}
 
 	sharedSections := []string{
@@ -84,6 +85,18 @@ func TestComposePromptModeSectionInjected(t *testing.T) {
 		})
 		if !strings.Contains(msg, "ASK ME QUESTIONS BEFORE BUILDING") {
 			t.Error("brainstorming mode should inject ASK ME QUESTIONS BEFORE BUILDING")
+		}
+	})
+
+	t.Run("retrospectiveInjectsRetrospectiveMode", func(t *testing.T) {
+		modeSection, coordPlan := modeSectionForMode(state.ModeRetrospective)
+		msg := composePrompt(promptOptions{
+			agent:           "coordinator",
+			modeSection:     modeSection,
+			coordinatorPlan: coordPlan,
+		})
+		if !strings.Contains(msg, "RETROSPECTIVE MODE ACTIVE") {
+			t.Error("retrospective mode should inject RETROSPECTIVE MODE ACTIVE")
 		}
 	})
 }
@@ -160,6 +173,16 @@ func TestModeSectionForMode(t *testing.T) {
 		}
 		if coordPlan != "" {
 			t.Errorf("expected empty coordinator plan for brainstorming, got %q", coordPlan)
+		}
+	})
+
+	t.Run("retrospectiveReturnsCorrectSections", func(t *testing.T) {
+		modeSection, coordPlan := modeSectionForMode(state.ModeRetrospective)
+		if modeSection != flowSectionRetrospectiveMode {
+			t.Errorf("expected flowSectionRetrospectiveMode, got different section")
+		}
+		if coordPlan != flowSectionRetrospectiveModeCoordinator {
+			t.Errorf("expected flowSectionRetrospectiveModeCoordinator, got different plan")
 		}
 	})
 }

--- a/sgai.json
+++ b/sgai.json
@@ -3,7 +3,7 @@
     {
       "name": "Create PR",
       "model": "anthropic/claude-opus-4-6",
-      "prompt": "copy GOAL.md into GOALS/ following the instructions from README.md; store the git path (by querying jj) into GIT_DIR, and using GH, make a draft PR for the commit at @ (jj); CRITICAL: commit message, the PR title and body, must adhere to the standard of previous commits - update all of these if necessary; once you are done, using bash(`open`), open the PR for me.",
+      "prompt": "copy GOAL.md into GOALS/ following the instructions from README.md; store the git path (by querying jj) into GIT_DIR, and using GH, make a draft PR for the commit at @ (jj); CRITICAL: commit message, the PR title and body, must adhere to the standard of previous commits - update all of these if necessary; once you are done, using bash(`open`), open the PR for me. REMEMBER: 'GOALS' must never be the used commit message or PR title prefix",
       "description": "Create a draft pull request from current changes"
     },
     {


### PR DESCRIPTION
## Summary

- Fix retrospective mode transition to allow all interaction modes (building, self-drive, brainstorming, continuous) to enter retrospective, instead of only building mode
- Add dedicated `ModeRetrospective` prompt sections so the coordinator knows to relay `RETRO_QUESTION` messages and wait for `RETRO_COMPLETE` before marking complete
- Add GOAL spec to GOALS/