### PR TITLE
feat: support Claude Code as agent backend

### DIFF
--- a/cmd/sgai/backend.go
+++ b/cmd/sgai/backend.go
@@ -45,6 +45,7 @@ type AgentRunParams struct {
 	ModelSpec string // e.g. "anthropic/claude-opus-4-6 (max)"
 	SessionID string // resume session
 	AgentDir  string // workspace directory containing .sgai/agent/*.md files
+	McpURL    string // SGAI MCP server URL for --mcp-config injection
 }
 
 // AgentEnvParams contains the parameters for BuildEnv.

--- a/cmd/sgai/backend.go
+++ b/cmd/sgai/backend.go
@@ -1,0 +1,55 @@
+package main
+
+// Backend abstracts the CLI agent runner (opencode vs Claude Code).
+type Backend interface {
+	// Name returns the backend identifier ("opencode" or "claude-code").
+	Name() string
+
+	// BinaryName returns the CLI binary to exec (e.g. "opencode" or "claude").
+	BinaryName() string
+
+	// BuildAgentArgs builds CLI arguments for a workflow agent run.
+	BuildAgentArgs(p AgentRunParams) []string
+
+	// BuildAdhocArgs builds CLI arguments for an ad-hoc prompt run.
+	BuildAdhocArgs(modelSpec string) []string
+
+	// BuildEnv builds the environment variable slice for the agent process.
+	BuildEnv(p AgentEnvParams) []string
+
+	// BuildContinuousArgs builds CLI arguments for continuous mode.
+	BuildContinuousArgs() []string
+
+	// ParseEvent normalizes a JSON line from the agent's stdout into a
+	// streamEvent. Returns false if the line is not a recognized event.
+	ParseEvent(line []byte) (streamEvent, bool)
+
+	// ValidateModels checks that all model specs are valid for this backend.
+	// Returns nil if validation is not supported (e.g. Claude Code has no
+	// models command).
+	ValidateModels(models map[string]any) error
+
+	// ExportSession exports a session to the given output path.
+	// Returns nil if export is not supported.
+	ExportSession(dir, sessionID, outputPath string) error
+
+	// StripProviderPrefix transforms a model spec for this backend.
+	// opencode expects "anthropic/claude-opus-4-6", Claude Code expects "claude-opus-4-6".
+	StripProviderPrefix(model string) string
+}
+
+// AgentRunParams contains the parameters for BuildAgentArgs.
+type AgentRunParams struct {
+	Agent     string // display name (may include alias resolution)
+	BaseAgent string // agent identity passed to CLI --agent flag
+	ModelSpec string // e.g. "anthropic/claude-opus-4-6 (max)"
+	SessionID string // resume session
+}
+
+// AgentEnvParams contains the parameters for BuildEnv.
+type AgentEnvParams struct {
+	Dir             string
+	McpURL          string
+	AgentIdentity   string
+	InteractiveMode string // "yes" or "auto"
+}

--- a/cmd/sgai/backend.go
+++ b/cmd/sgai/backend.go
@@ -44,6 +44,7 @@ type AgentRunParams struct {
 	BaseAgent string // agent identity passed to CLI --agent flag
 	ModelSpec string // e.g. "anthropic/claude-opus-4-6 (max)"
 	SessionID string // resume session
+	AgentDir  string // workspace directory containing .sgai/agent/*.md files
 }
 
 // AgentEnvParams contains the parameters for BuildEnv.

--- a/cmd/sgai/backend_claudecode.go
+++ b/cmd/sgai/backend_claudecode.go
@@ -45,6 +45,14 @@ func (b *claudeCodeBackend) BuildAgentArgs(p AgentRunParams) []string {
 	// Skip permissions — SGAI controls permissions via its own MCP layer
 	args = append(args, "--permission-mode", "bypassPermissions")
 
+	// Inject MCP config with SGAI MCP server
+	if p.McpURL != "" {
+		mcpConfig, err := buildClaudeCodeMCPConfig(p.McpURL, nil)
+		if err == nil {
+			args = append(args, "--mcp-config", mcpConfig)
+		}
+	}
+
 	return args
 }
 

--- a/cmd/sgai/backend_claudecode.go
+++ b/cmd/sgai/backend_claudecode.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"os"
+	"path/filepath"
 	"strings"
 )
 
@@ -29,6 +30,21 @@ func (b *claudeCodeBackend) BuildAgentArgs(p AgentRunParams) []string {
 		title = p.Agent + " [" + p.ModelSpec + "]"
 	}
 	args = append(args, "--name", title)
+
+	// Inject agent system prompt from .sgai/agent/<name>.md
+	if p.AgentDir != "" && p.BaseAgent != "" {
+		agentPath := filepath.Join(p.AgentDir, ".sgai", "agent", p.BaseAgent+".md")
+		if content, err := os.ReadFile(agentPath); err == nil {
+			body := strings.TrimSpace(string(extractBody(content)))
+			if body != "" {
+				args = append(args, "--append-system-prompt", body)
+			}
+		}
+	}
+
+	// Skip permissions — SGAI controls permissions via its own MCP layer
+	args = append(args, "--permission-mode", "bypassPermissions")
+
 	return args
 }
 

--- a/cmd/sgai/backend_claudecode.go
+++ b/cmd/sgai/backend_claudecode.go
@@ -1,0 +1,157 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+)
+
+type claudeCodeBackend struct{}
+
+func (b *claudeCodeBackend) Name() string       { return "claude-code" }
+func (b *claudeCodeBackend) BinaryName() string { return "claude" }
+
+func (b *claudeCodeBackend) BuildAgentArgs(p AgentRunParams) []string {
+	args := []string{"-p", "--output-format", "stream-json", "--verbose"}
+
+	if p.ModelSpec != "" {
+		model, variant := parseModelAndVariant(p.ModelSpec)
+		args = append(args, "--model", b.StripProviderPrefix(model))
+		if variant != "" {
+			args = append(args, "--effort", variant)
+		}
+	}
+	if p.SessionID != "" {
+		args = append(args, "--session-id", p.SessionID)
+	}
+	title := p.Agent
+	if p.ModelSpec != "" {
+		title = p.Agent + " [" + p.ModelSpec + "]"
+	}
+	args = append(args, "--name", title)
+	return args
+}
+
+func (b *claudeCodeBackend) BuildAdhocArgs(modelSpec string) []string {
+	baseModel, variant := parseModelAndVariant(modelSpec)
+	args := []string{"-p", "--output-format", "stream-json", "--verbose",
+		"--model", b.StripProviderPrefix(baseModel),
+		"--name", "adhoc [" + modelSpec + "]"}
+	if variant != "" {
+		args = append(args, "--effort", variant)
+	}
+	return args
+}
+
+func (b *claudeCodeBackend) BuildEnv(p AgentEnvParams) []string {
+	return append(os.Environ(),
+		"SGAI_MCP_URL="+p.McpURL,
+		"SGAI_AGENT_IDENTITY="+p.AgentIdentity,
+		"SGAI_MCP_INTERACTIVE="+p.InteractiveMode)
+}
+
+func (b *claudeCodeBackend) BuildContinuousArgs() []string {
+	return []string{"-p", "--output-format", "stream-json", "--verbose",
+		"--name", "continuous-mode-prompt"}
+}
+
+func (b *claudeCodeBackend) StripProviderPrefix(model string) string {
+	if idx := strings.Index(model, "/"); idx >= 0 {
+		return model[idx+1:]
+	}
+	return model
+}
+
+func (b *claudeCodeBackend) ValidateModels(models map[string]any) error {
+	return nil // Claude Code has no `models` command; skip validation
+}
+
+func (b *claudeCodeBackend) ExportSession(dir, sessionID, outputPath string) error {
+	return nil // Claude Code sessions are stored in ~/.claude/; no export needed
+}
+
+// claudeCodeRawEvent represents the raw JSON from Claude Code's stream-json output.
+type claudeCodeRawEvent struct {
+	Type      string `json:"type"`
+	Subtype   string `json:"subtype,omitempty"`
+	SessionID string `json:"session_id,omitempty"`
+	Message   *struct {
+		Content []struct {
+			Type     string         `json:"type"`
+			Text     string         `json:"text,omitempty"`
+			Thinking string         `json:"thinking,omitempty"`
+			Name     string         `json:"name,omitempty"`
+			ID       string         `json:"id,omitempty"`
+			Input    map[string]any `json:"input,omitempty"`
+		} `json:"content,omitempty"`
+		Usage *struct {
+			InputTokens  int `json:"input_tokens"`
+			OutputTokens int `json:"output_tokens"`
+		} `json:"usage,omitempty"`
+	} `json:"message,omitempty"`
+	// Result event fields (type=="result")
+	Result       string  `json:"result,omitempty"`
+	TotalCostUSD float64 `json:"total_cost_usd,omitempty"`
+	Usage        *struct {
+		InputTokens              int `json:"input_tokens"`
+		OutputTokens             int `json:"output_tokens"`
+		CacheReadInputTokens     int `json:"cache_read_input_tokens"`
+		CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
+	} `json:"usage,omitempty"`
+}
+
+func (b *claudeCodeBackend) ParseEvent(line []byte) (streamEvent, bool) {
+	var raw claudeCodeRawEvent
+	if err := json.Unmarshal(line, &raw); err != nil {
+		return streamEvent{}, false
+	}
+
+	base := streamEvent{SessionID: raw.SessionID}
+
+	switch raw.Type {
+	case "system":
+		if raw.SessionID != "" {
+			base.Type = "system"
+			return base, true
+		}
+		return streamEvent{}, false
+
+	case "assistant":
+		if raw.Message == nil || len(raw.Message.Content) == 0 {
+			return streamEvent{}, false
+		}
+		content := raw.Message.Content[0]
+		switch content.Type {
+		case "text":
+			base.Type = "text"
+			base.Part.Text = content.Text
+		case "thinking":
+			base.Type = "reasoning"
+			base.Part.Text = content.Thinking
+		case "tool_use":
+			base.Type = "tool_use"
+			base.Part.Tool = content.Name
+			base.Part.State = &toolState{
+				Status: "running",
+				Input:  content.Input,
+			}
+		default:
+			return streamEvent{}, false
+		}
+		return base, true
+
+	case "result":
+		base.Type = "result"
+		if raw.Usage != nil {
+			base.Part.Cost = raw.TotalCostUSD
+			base.Part.Tokens.Input = raw.Usage.InputTokens
+			base.Part.Tokens.Output = raw.Usage.OutputTokens
+			base.Part.Tokens.Cache.Read = raw.Usage.CacheReadInputTokens
+			base.Part.Tokens.Cache.Write = raw.Usage.CacheCreationInputTokens
+		}
+		return base, true
+
+	default:
+		return streamEvent{}, false
+	}
+}

--- a/cmd/sgai/backend_claudecode_mcp.go
+++ b/cmd/sgai/backend_claudecode_mcp.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"encoding/json"
+)
+
+// buildClaudeCodeMCPConfig generates the MCP config JSON for Claude Code's --mcp-config flag.
+// It always injects the SGAI MCP server and optionally translates project MCPs from
+// opencode format (sgai.json "mcp" section) to Claude Code format.
+func buildClaudeCodeMCPConfig(sgaiMCPURL string, projectMCPs map[string]json.RawMessage) (string, error) {
+	servers := map[string]any{
+		"sgai": map[string]any{
+			"type": "sse",
+			"url":  sgaiMCPURL,
+		},
+	}
+
+	for name, rawConfig := range projectMCPs {
+		var ocMCP struct {
+			Type    string   `json:"type"`
+			Command []string `json:"command"`
+			Enabled *bool    `json:"enabled,omitempty"`
+		}
+		if err := json.Unmarshal(rawConfig, &ocMCP); err != nil {
+			continue
+		}
+		if ocMCP.Enabled != nil && !*ocMCP.Enabled {
+			continue
+		}
+		if ocMCP.Type == "local" && len(ocMCP.Command) > 0 {
+			servers[name] = map[string]any{
+				"command": ocMCP.Command[0],
+				"args":    ocMCP.Command[1:],
+			}
+		}
+	}
+
+	config := map[string]any{
+		"mcpServers": servers,
+	}
+
+	data, err := json.Marshal(config)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}

--- a/cmd/sgai/backend_claudecode_mcp_test.go
+++ b/cmd/sgai/backend_claudecode_mcp_test.go
@@ -1,0 +1,195 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestBuildClaudeCodeMCPConfigBasic(t *testing.T) {
+	result, err := buildClaudeCodeMCPConfig("http://localhost:8080/mcp", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var config map[string]any
+	if err := json.Unmarshal([]byte(result), &config); err != nil {
+		t.Fatal("invalid JSON:", err)
+	}
+
+	servers, ok := config["mcpServers"].(map[string]any)
+	if !ok {
+		t.Fatal("missing mcpServers")
+	}
+
+	sgai, ok := servers["sgai"].(map[string]any)
+	if !ok {
+		t.Fatal("missing sgai server")
+	}
+
+	if sgai["type"] != "sse" {
+		t.Errorf("got type %q, want sse", sgai["type"])
+	}
+	if sgai["url"] != "http://localhost:8080/mcp" {
+		t.Errorf("got url %q, want http://localhost:8080/mcp", sgai["url"])
+	}
+}
+
+func TestBuildClaudeCodeMCPConfigWithProjectMCPs(t *testing.T) {
+	projectMCPs := map[string]json.RawMessage{
+		"playwright": json.RawMessage(`{"type": "local", "command": ["npx", "@playwright/mcp"]}`),
+		"context7":   json.RawMessage(`{"type": "local", "command": ["npx", "-y", "@upstash/context7-mcp"]}`),
+	}
+
+	result, err := buildClaudeCodeMCPConfig("http://localhost:8080/mcp", projectMCPs)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var config map[string]any
+	if err := json.Unmarshal([]byte(result), &config); err != nil {
+		t.Fatal("invalid JSON:", err)
+	}
+
+	servers := config["mcpServers"].(map[string]any)
+
+	// SGAI server should be present
+	if _, ok := servers["sgai"]; !ok {
+		t.Error("missing sgai server")
+	}
+
+	// Playwright should be translated
+	pw, ok := servers["playwright"].(map[string]any)
+	if !ok {
+		t.Fatal("missing playwright server")
+	}
+	if pw["command"] != "npx" {
+		t.Errorf("got command %q, want npx", pw["command"])
+	}
+	args, ok := pw["args"].([]any)
+	if !ok {
+		t.Fatal("missing args")
+	}
+	if len(args) != 1 || args[0] != "@playwright/mcp" {
+		t.Errorf("got args %v, want [@playwright/mcp]", args)
+	}
+
+	// Context7 should be translated
+	c7, ok := servers["context7"].(map[string]any)
+	if !ok {
+		t.Fatal("missing context7 server")
+	}
+	if c7["command"] != "npx" {
+		t.Errorf("got command %q, want npx", c7["command"])
+	}
+}
+
+func TestBuildClaudeCodeMCPConfigDisabledServer(t *testing.T) {
+	projectMCPs := map[string]json.RawMessage{
+		"disabled": json.RawMessage(`{"type": "local", "command": ["test"], "enabled": false}`),
+		"enabled":  json.RawMessage(`{"type": "local", "command": ["test2"]}`),
+	}
+
+	result, err := buildClaudeCodeMCPConfig("http://localhost:8080/mcp", projectMCPs)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var config map[string]any
+	if err := json.Unmarshal([]byte(result), &config); err != nil {
+		t.Fatal("invalid JSON:", err)
+	}
+
+	servers := config["mcpServers"].(map[string]any)
+
+	if _, ok := servers["disabled"]; ok {
+		t.Error("disabled server should not be included")
+	}
+	if _, ok := servers["enabled"]; !ok {
+		t.Error("enabled server should be included")
+	}
+}
+
+func TestBuildClaudeCodeMCPConfigNonLocalSkipped(t *testing.T) {
+	projectMCPs := map[string]json.RawMessage{
+		"remote": json.RawMessage(`{"type": "remote", "url": "http://example.com"}`),
+	}
+
+	result, err := buildClaudeCodeMCPConfig("http://localhost:8080/mcp", projectMCPs)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var config map[string]any
+	if err := json.Unmarshal([]byte(result), &config); err != nil {
+		t.Fatal("invalid JSON:", err)
+	}
+
+	servers := config["mcpServers"].(map[string]any)
+	if _, ok := servers["remote"]; ok {
+		t.Error("non-local server should not be included")
+	}
+}
+
+func TestBuildClaudeCodeMCPConfigInvalidJSON(t *testing.T) {
+	projectMCPs := map[string]json.RawMessage{
+		"bad": json.RawMessage(`not json`),
+	}
+
+	result, err := buildClaudeCodeMCPConfig("http://localhost:8080/mcp", projectMCPs)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Should still have valid JSON with just sgai server
+	var config map[string]any
+	if err := json.Unmarshal([]byte(result), &config); err != nil {
+		t.Fatal("invalid JSON:", err)
+	}
+	servers := config["mcpServers"].(map[string]any)
+	if _, ok := servers["sgai"]; !ok {
+		t.Error("sgai server should still be present")
+	}
+	if _, ok := servers["bad"]; ok {
+		t.Error("bad server should not be included")
+	}
+}
+
+func TestClaudeCodeBuildAgentArgsMCPConfig(t *testing.T) {
+	b := &claudeCodeBackend{}
+	args := b.BuildAgentArgs(AgentRunParams{
+		Agent:     "coordinator",
+		BaseAgent: "coordinator",
+		McpURL:    "http://localhost:8080/mcp",
+	})
+
+	assertContains(t, args, "--mcp-config")
+
+	// Find the --mcp-config value and verify it's valid JSON with sgai server
+	for i, arg := range args {
+		if arg == "--mcp-config" && i+1 < len(args) {
+			var config map[string]any
+			if err := json.Unmarshal([]byte(args[i+1]), &config); err != nil {
+				t.Fatal("--mcp-config value is not valid JSON:", err)
+			}
+			servers := config["mcpServers"].(map[string]any)
+			sgai, ok := servers["sgai"].(map[string]any)
+			if !ok {
+				t.Fatal("missing sgai server in --mcp-config")
+			}
+			if sgai["url"] != "http://localhost:8080/mcp" {
+				t.Errorf("sgai url = %q, want http://localhost:8080/mcp", sgai["url"])
+			}
+			return
+		}
+	}
+	t.Error("--mcp-config flag not found in args")
+}
+
+func TestClaudeCodeBuildAgentArgsNoMCPWithoutURL(t *testing.T) {
+	b := &claudeCodeBackend{}
+	args := b.BuildAgentArgs(AgentRunParams{
+		Agent:     "coordinator",
+		BaseAgent: "coordinator",
+	})
+	assertNotContains(t, args, "--mcp-config")
+}

--- a/cmd/sgai/backend_claudecode_test.go
+++ b/cmd/sgai/backend_claudecode_test.go
@@ -1,0 +1,261 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestClaudeCodeBackendName(t *testing.T) {
+	b := &claudeCodeBackend{}
+	if b.Name() != "claude-code" {
+		t.Errorf("got %q, want claude-code", b.Name())
+	}
+	if b.BinaryName() != "claude" {
+		t.Errorf("got %q, want claude", b.BinaryName())
+	}
+}
+
+func TestClaudeCodeBackendBuildAgentArgs(t *testing.T) {
+	b := &claudeCodeBackend{}
+	args := b.BuildAgentArgs(AgentRunParams{
+		Agent:     "coordinator",
+		BaseAgent: "coordinator",
+		ModelSpec: "anthropic/claude-opus-4-6 (max)",
+		SessionID: "abc-123-def",
+	})
+	assertContains(t, args, "-p")
+	assertContains(t, args, "--output-format")
+	assertContains(t, args, "stream-json")
+	assertContains(t, args, "--verbose")
+	assertContains(t, args, "--model")
+	assertContains(t, args, "claude-opus-4-6") // provider prefix stripped
+	assertContains(t, args, "--effort")
+	assertContains(t, args, "max")
+	assertContains(t, args, "--session-id")
+	assertContains(t, args, "abc-123-def")
+	assertContains(t, args, "--name")
+	assertNotContains(t, args, "--format=json") // opencode flag
+	// Verify no "anthropic/" in args
+	for _, arg := range args {
+		if strings.HasPrefix(arg, "anthropic/") {
+			t.Errorf("args should not contain anthropic/ prefixed model, got %q", arg)
+		}
+	}
+}
+
+func TestClaudeCodeBackendBuildAgentArgsNoModel(t *testing.T) {
+	b := &claudeCodeBackend{}
+	args := b.BuildAgentArgs(AgentRunParams{
+		Agent:     "builder",
+		BaseAgent: "builder",
+	})
+	assertContains(t, args, "-p")
+	assertNotContains(t, args, "--model")
+	assertNotContains(t, args, "--effort")
+	assertNotContains(t, args, "--session-id")
+}
+
+func TestClaudeCodeBackendBuildAdhocArgs(t *testing.T) {
+	b := &claudeCodeBackend{}
+	args := b.BuildAdhocArgs("anthropic/claude-opus-4-6 (max)")
+	assertContains(t, args, "-p")
+	assertContains(t, args, "--output-format")
+	assertContains(t, args, "stream-json")
+	assertContains(t, args, "--model")
+	assertContains(t, args, "claude-opus-4-6")
+	assertContains(t, args, "--effort")
+	assertContains(t, args, "max")
+	assertNotContains(t, args, "run") // opencode uses "run"
+}
+
+func TestClaudeCodeBackendBuildContinuousArgs(t *testing.T) {
+	b := &claudeCodeBackend{}
+	args := b.BuildContinuousArgs()
+	assertContains(t, args, "-p")
+	assertContains(t, args, "--output-format")
+	assertContains(t, args, "--name")
+	assertContains(t, args, "continuous-mode-prompt")
+}
+
+func TestClaudeCodeBackendBuildEnv(t *testing.T) {
+	b := &claudeCodeBackend{}
+	env := b.BuildEnv(AgentEnvParams{
+		Dir:             "/tmp/project",
+		McpURL:          "http://localhost:8080/mcp",
+		AgentIdentity:   "coordinator",
+		InteractiveMode: "yes",
+	})
+	found := map[string]bool{}
+	for _, e := range env {
+		switch {
+		case e == "SGAI_MCP_URL=http://localhost:8080/mcp":
+			found["mcp"] = true
+		case e == "SGAI_AGENT_IDENTITY=coordinator":
+			found["identity"] = true
+		case e == "SGAI_MCP_INTERACTIVE=yes":
+			found["interactive"] = true
+		}
+	}
+	for _, key := range []string{"mcp", "identity", "interactive"} {
+		if !found[key] {
+			t.Errorf("env missing %s", key)
+		}
+	}
+	// Should NOT have OPENCODE_CONFIG_DIR
+	for _, e := range env {
+		if strings.HasPrefix(e, "OPENCODE_CONFIG_DIR=") {
+			t.Error("env should not contain OPENCODE_CONFIG_DIR for claude-code backend")
+		}
+	}
+}
+
+func TestClaudeCodeStripProviderPrefix(t *testing.T) {
+	b := &claudeCodeBackend{}
+	tests := []struct{ input, want string }{
+		{"anthropic/claude-opus-4-6", "claude-opus-4-6"},
+		{"openai/gpt-4o", "gpt-4o"},
+		{"claude-opus-4-6", "claude-opus-4-6"}, // no prefix
+	}
+	for _, tt := range tests {
+		got := b.StripProviderPrefix(tt.input)
+		if got != tt.want {
+			t.Errorf("StripProviderPrefix(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestClaudeCodeBackendValidateModels(t *testing.T) {
+	b := &claudeCodeBackend{}
+	// Should always return nil (no validation for Claude Code)
+	if err := b.ValidateModels(map[string]any{"coordinator": "whatever"}); err != nil {
+		t.Errorf("expected nil, got %v", err)
+	}
+}
+
+func TestClaudeCodeBackendExportSession(t *testing.T) {
+	b := &claudeCodeBackend{}
+	// Should always return nil (no export for Claude Code)
+	if err := b.ExportSession("/tmp", "ses_1", "/tmp/out.json"); err != nil {
+		t.Errorf("expected nil, got %v", err)
+	}
+}
+
+func TestClaudeCodeParseEventText(t *testing.T) {
+	b := &claudeCodeBackend{}
+	line := []byte(`{"type":"assistant","message":{"content":[{"type":"text","text":"hello"}]},"session_id":"abc-123"}`)
+	event, ok := b.ParseEvent(line)
+	if !ok {
+		t.Fatal("expected ok")
+	}
+	if event.Type != "text" {
+		t.Errorf("got type %q, want text", event.Type)
+	}
+	if event.Part.Text != "hello" {
+		t.Errorf("got text %q, want hello", event.Part.Text)
+	}
+	if event.SessionID != "abc-123" {
+		t.Errorf("got session %q, want abc-123", event.SessionID)
+	}
+}
+
+func TestClaudeCodeParseEventThinking(t *testing.T) {
+	b := &claudeCodeBackend{}
+	line := []byte(`{"type":"assistant","message":{"content":[{"type":"thinking","thinking":"reasoning here"}]},"session_id":"s1"}`)
+	event, ok := b.ParseEvent(line)
+	if !ok {
+		t.Fatal("expected ok")
+	}
+	if event.Type != "reasoning" {
+		t.Errorf("got type %q, want reasoning", event.Type)
+	}
+	if event.Part.Text != "reasoning here" {
+		t.Errorf("got text %q, want 'reasoning here'", event.Part.Text)
+	}
+}
+
+func TestClaudeCodeParseEventToolUse(t *testing.T) {
+	b := &claudeCodeBackend{}
+	line := []byte(`{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Edit","input":{"file":"main.go"}}]},"session_id":"s1"}`)
+	event, ok := b.ParseEvent(line)
+	if !ok {
+		t.Fatal("expected ok")
+	}
+	if event.Type != "tool_use" {
+		t.Errorf("got type %q, want tool_use", event.Type)
+	}
+	if event.Part.Tool != "Edit" {
+		t.Errorf("got tool %q, want Edit", event.Part.Tool)
+	}
+	if event.Part.State == nil {
+		t.Fatal("expected non-nil state")
+	}
+	if event.Part.State.Status != "running" {
+		t.Errorf("got status %q, want running", event.Part.State.Status)
+	}
+}
+
+func TestClaudeCodeParseEventResult(t *testing.T) {
+	b := &claudeCodeBackend{}
+	line := []byte(`{"type":"result","session_id":"s1","total_cost_usd":0.05,"usage":{"input_tokens":100,"output_tokens":50,"cache_read_input_tokens":10,"cache_creation_input_tokens":5}}`)
+	event, ok := b.ParseEvent(line)
+	if !ok {
+		t.Fatal("expected ok")
+	}
+	if event.Type != "result" {
+		t.Errorf("got type %q, want result", event.Type)
+	}
+	if event.Part.Cost != 0.05 {
+		t.Errorf("got cost %f, want 0.05", event.Part.Cost)
+	}
+	if event.Part.Tokens.Input != 100 {
+		t.Errorf("got input tokens %d, want 100", event.Part.Tokens.Input)
+	}
+	if event.Part.Tokens.Output != 50 {
+		t.Errorf("got output tokens %d, want 50", event.Part.Tokens.Output)
+	}
+	if event.Part.Tokens.Cache.Read != 10 {
+		t.Errorf("got cache read %d, want 10", event.Part.Tokens.Cache.Read)
+	}
+	if event.Part.Tokens.Cache.Write != 5 {
+		t.Errorf("got cache write %d, want 5", event.Part.Tokens.Cache.Write)
+	}
+}
+
+func TestClaudeCodeParseEventSystem(t *testing.T) {
+	b := &claudeCodeBackend{}
+	line := []byte(`{"type":"system","subtype":"init","session_id":"s1"}`)
+	event, ok := b.ParseEvent(line)
+	if !ok {
+		t.Fatal("expected ok")
+	}
+	if event.Type != "system" {
+		t.Errorf("got type %q, want system", event.Type)
+	}
+	if event.SessionID != "s1" {
+		t.Errorf("got session %q, want s1", event.SessionID)
+	}
+}
+
+func TestClaudeCodeParseEventSystemNoSession(t *testing.T) {
+	b := &claudeCodeBackend{}
+	_, ok := b.ParseEvent([]byte(`{"type":"system","subtype":"other"}`))
+	if ok {
+		t.Error("expected not ok for system event without session_id")
+	}
+}
+
+func TestClaudeCodeParseEventInvalid(t *testing.T) {
+	b := &claudeCodeBackend{}
+	_, ok := b.ParseEvent([]byte(`not json`))
+	if ok {
+		t.Error("expected not ok for invalid JSON")
+	}
+}
+
+func TestClaudeCodeParseEventUnknownType(t *testing.T) {
+	b := &claudeCodeBackend{}
+	_, ok := b.ParseEvent([]byte(`{"type":"unknown"}`))
+	if ok {
+		t.Error("expected not ok for unknown type")
+	}
+}

--- a/cmd/sgai/backend_claudecode_test.go
+++ b/cmd/sgai/backend_claudecode_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -138,6 +140,88 @@ func TestClaudeCodeBackendExportSession(t *testing.T) {
 	if err := b.ExportSession("/tmp", "ses_1", "/tmp/out.json"); err != nil {
 		t.Errorf("expected nil, got %v", err)
 	}
+}
+
+func TestClaudeCodeBuildAgentArgsWithSystemPrompt(t *testing.T) {
+	dir := t.TempDir()
+	agentDir := filepath.Join(dir, ".sgai", "agent")
+	if err := os.MkdirAll(agentDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	agentContent := "---\npermissions:\n  edit: allow\n---\nYou are a coordinator agent.\nFollow these rules carefully."
+	if err := os.WriteFile(filepath.Join(agentDir, "coordinator.md"), []byte(agentContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	b := &claudeCodeBackend{}
+	args := b.BuildAgentArgs(AgentRunParams{
+		Agent:     "coordinator",
+		BaseAgent: "coordinator",
+		ModelSpec: "anthropic/claude-opus-4-6",
+		AgentDir:  dir,
+	})
+
+	// Should have --append-system-prompt with the body (frontmatter stripped)
+	assertContains(t, args, "--append-system-prompt")
+	found := false
+	for i, arg := range args {
+		if arg == "--append-system-prompt" && i+1 < len(args) {
+			if strings.Contains(args[i+1], "You are a coordinator agent.") {
+				found = true
+			}
+			// Should NOT contain frontmatter
+			if strings.Contains(args[i+1], "permissions:") {
+				t.Error("system prompt should not contain frontmatter")
+			}
+		}
+	}
+	if !found {
+		t.Error("expected --append-system-prompt to contain agent body")
+	}
+}
+
+func TestClaudeCodeBuildAgentArgsPermissionMode(t *testing.T) {
+	b := &claudeCodeBackend{}
+	args := b.BuildAgentArgs(AgentRunParams{
+		Agent:     "builder",
+		BaseAgent: "builder",
+	})
+	assertContains(t, args, "--permission-mode")
+	assertContains(t, args, "bypassPermissions")
+}
+
+func TestClaudeCodeBuildAgentArgsNoAgentFile(t *testing.T) {
+	dir := t.TempDir()
+	b := &claudeCodeBackend{}
+	args := b.BuildAgentArgs(AgentRunParams{
+		Agent:     "builder",
+		BaseAgent: "builder",
+		AgentDir:  dir,
+	})
+	// No --append-system-prompt when agent file doesn't exist
+	assertNotContains(t, args, "--append-system-prompt")
+	// But permission mode should still be set
+	assertContains(t, args, "--permission-mode")
+}
+
+func TestClaudeCodeBuildAgentArgsEmptyBody(t *testing.T) {
+	dir := t.TempDir()
+	agentDir := filepath.Join(dir, ".sgai", "agent")
+	if err := os.MkdirAll(agentDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	// Agent file with only frontmatter, no body
+	if err := os.WriteFile(filepath.Join(agentDir, "builder.md"), []byte("---\npermissions:\n  edit: allow\n---\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	b := &claudeCodeBackend{}
+	args := b.BuildAgentArgs(AgentRunParams{
+		Agent:     "builder",
+		BaseAgent: "builder",
+		AgentDir:  dir,
+	})
+	assertNotContains(t, args, "--append-system-prompt")
 }
 
 func TestClaudeCodeParseEventText(t *testing.T) {

--- a/cmd/sgai/backend_opencode.go
+++ b/cmd/sgai/backend_opencode.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+type opencodeBackend struct{}
+
+func (b *opencodeBackend) Name() string       { return "opencode" }
+func (b *opencodeBackend) BinaryName() string { return "opencode" }
+
+func (b *opencodeBackend) BuildAgentArgs(p AgentRunParams) []string {
+	args := []string{"run", "--format=json", "--agent", p.BaseAgent}
+	if p.ModelSpec != "" {
+		model, variant := parseModelAndVariant(p.ModelSpec)
+		args = append(args, "--model", model)
+		if variant != "" {
+			args = append(args, "--variant", variant)
+		}
+	}
+	if p.SessionID != "" {
+		args = append(args, "--session", p.SessionID)
+	}
+	title := p.Agent
+	if p.ModelSpec != "" {
+		title = p.Agent + " [" + p.ModelSpec + "]"
+	}
+	args = append(args, "--title", title)
+	return args
+}
+
+func (b *opencodeBackend) BuildAdhocArgs(modelSpec string) []string {
+	baseModel, variant := parseModelAndVariant(modelSpec)
+	args := []string{"run", "-m", baseModel, "--agent", "build", "--title", "adhoc [" + modelSpec + "]"}
+	if variant != "" {
+		args = append(args, "--variant", variant)
+	}
+	return args
+}
+
+func (b *opencodeBackend) BuildEnv(p AgentEnvParams) []string {
+	return append(os.Environ(),
+		"OPENCODE_CONFIG_DIR="+filepath.Join(p.Dir, ".sgai"),
+		"SGAI_MCP_URL="+p.McpURL,
+		"SGAI_AGENT_IDENTITY="+p.AgentIdentity,
+		"SGAI_MCP_INTERACTIVE="+p.InteractiveMode)
+}
+
+func (b *opencodeBackend) BuildContinuousArgs() []string {
+	return []string{"run", "--title", "continuous-mode-prompt"}
+}
+
+func (b *opencodeBackend) ParseEvent(line []byte) (streamEvent, bool) {
+	var event streamEvent
+	if err := json.Unmarshal(line, &event); err != nil {
+		return streamEvent{}, false
+	}
+	return event, true
+}
+
+func (b *opencodeBackend) ValidateModels(models map[string]any) error {
+	return validateModels(models)
+}
+
+func (b *opencodeBackend) ExportSession(dir, sessionID, outputPath string) error {
+	cmd := exec.Command("opencode", "export", sessionID)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "OPENCODE_CONFIG_DIR="+filepath.Join(dir, ".sgai"))
+	output, err := cmd.Output()
+	if err != nil {
+		return fmt.Errorf("opencode export failed: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(outputPath), 0755); err != nil {
+		return err
+	}
+	return os.WriteFile(outputPath, output, 0644)
+}
+
+func (b *opencodeBackend) StripProviderPrefix(model string) string {
+	return model // opencode uses the full "anthropic/claude-opus-4-6" form
+}

--- a/cmd/sgai/backend_opencode_test.go
+++ b/cmd/sgai/backend_opencode_test.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"slices"
+	"testing"
+)
+
+func assertContains(t *testing.T, args []string, want string) {
+	t.Helper()
+	if !slices.Contains(args, want) {
+		t.Errorf("args %v should contain %q", args, want)
+	}
+}
+
+func assertNotContains(t *testing.T, args []string, notWant string) {
+	t.Helper()
+	if slices.Contains(args, notWant) {
+		t.Errorf("args %v should not contain %q", args, notWant)
+	}
+}
+
+func TestOpencodeBackendName(t *testing.T) {
+	b := &opencodeBackend{}
+	if b.Name() != "opencode" {
+		t.Errorf("got %q, want opencode", b.Name())
+	}
+	if b.BinaryName() != "opencode" {
+		t.Errorf("got %q, want opencode", b.BinaryName())
+	}
+}
+
+func TestOpencodeBackendBuildAgentArgs(t *testing.T) {
+	b := &opencodeBackend{}
+	args := b.BuildAgentArgs(AgentRunParams{
+		Agent:     "coordinator",
+		BaseAgent: "coordinator",
+		ModelSpec: "anthropic/claude-opus-4-6 (max)",
+		SessionID: "ses_123",
+	})
+	assertContains(t, args, "--format=json")
+	assertContains(t, args, "--agent")
+	assertContains(t, args, "--variant")
+	assertContains(t, args, "--session")
+	assertContains(t, args, "coordinator")
+	assertContains(t, args, "anthropic/claude-opus-4-6")
+	assertContains(t, args, "max")
+	assertContains(t, args, "ses_123")
+}
+
+func TestOpencodeBackendBuildAgentArgsNoModel(t *testing.T) {
+	b := &opencodeBackend{}
+	args := b.BuildAgentArgs(AgentRunParams{
+		Agent:     "builder",
+		BaseAgent: "builder",
+	})
+	assertContains(t, args, "--format=json")
+	assertContains(t, args, "--agent")
+	assertNotContains(t, args, "--model")
+	assertNotContains(t, args, "--variant")
+	assertNotContains(t, args, "--session")
+}
+
+func TestOpencodeBackendBuildAdhocArgs(t *testing.T) {
+	b := &opencodeBackend{}
+	args := b.BuildAdhocArgs("anthropic/claude-opus-4-6 (max)")
+	assertContains(t, args, "run")
+	assertContains(t, args, "-m")
+	assertContains(t, args, "anthropic/claude-opus-4-6")
+	assertContains(t, args, "--variant")
+	assertContains(t, args, "max")
+}
+
+func TestOpencodeBackendBuildContinuousArgs(t *testing.T) {
+	b := &opencodeBackend{}
+	args := b.BuildContinuousArgs()
+	assertContains(t, args, "run")
+	assertContains(t, args, "--title")
+	assertContains(t, args, "continuous-mode-prompt")
+}
+
+func TestOpencodeBackendBuildEnv(t *testing.T) {
+	b := &opencodeBackend{}
+	env := b.BuildEnv(AgentEnvParams{
+		Dir:             "/tmp/project",
+		McpURL:          "http://localhost:8080/mcp",
+		AgentIdentity:   "coordinator",
+		InteractiveMode: "yes",
+	})
+	found := map[string]bool{}
+	for _, e := range env {
+		switch {
+		case e == "OPENCODE_CONFIG_DIR=/tmp/project/.sgai":
+			found["config"] = true
+		case e == "SGAI_MCP_URL=http://localhost:8080/mcp":
+			found["mcp"] = true
+		case e == "SGAI_AGENT_IDENTITY=coordinator":
+			found["identity"] = true
+		case e == "SGAI_MCP_INTERACTIVE=yes":
+			found["interactive"] = true
+		}
+	}
+	for _, key := range []string{"config", "mcp", "identity", "interactive"} {
+		if !found[key] {
+			t.Errorf("env missing %s", key)
+		}
+	}
+}
+
+func TestOpencodeBackendParseEvent(t *testing.T) {
+	b := &opencodeBackend{}
+	line := []byte(`{"type":"text","sessionID":"ses_1","part":{"type":"text","text":"hello"}}`)
+	event, ok := b.ParseEvent(line)
+	if !ok {
+		t.Fatal("expected ok")
+	}
+	if event.Type != "text" {
+		t.Errorf("got type %q, want text", event.Type)
+	}
+	if event.SessionID != "ses_1" {
+		t.Errorf("got session %q, want ses_1", event.SessionID)
+	}
+}
+
+func TestOpencodeBackendParseEventInvalid(t *testing.T) {
+	b := &opencodeBackend{}
+	_, ok := b.ParseEvent([]byte(`not json`))
+	if ok {
+		t.Error("expected not ok for invalid JSON")
+	}
+}
+
+func TestOpencodeBackendStripProviderPrefix(t *testing.T) {
+	b := &opencodeBackend{}
+	if got := b.StripProviderPrefix("anthropic/claude-opus-4-6"); got != "anthropic/claude-opus-4-6" {
+		t.Errorf("got %q, want original value preserved", got)
+	}
+}

--- a/cmd/sgai/backend_test.go
+++ b/cmd/sgai/backend_test.go
@@ -1,0 +1,178 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBackendSelection(t *testing.T) {
+	t.Run("nilConfig", func(t *testing.T) {
+		b := resolveBackend(nil)
+		assert.Equal(t, "opencode", b.Name())
+	})
+	t.Run("emptyConfig", func(t *testing.T) {
+		b := resolveBackend(&projectConfig{})
+		assert.Equal(t, "opencode", b.Name())
+	})
+	t.Run("explicitOpencode", func(t *testing.T) {
+		b := resolveBackend(&projectConfig{Backend: "opencode"})
+		assert.Equal(t, "opencode", b.Name())
+	})
+	t.Run("claudeCode", func(t *testing.T) {
+		b := resolveBackend(&projectConfig{Backend: "claude-code"})
+		assert.Equal(t, "claude-code", b.Name())
+	})
+}
+
+func TestBackendStrictValidation(t *testing.T) {
+	t.Run("nilConfig", func(t *testing.T) {
+		b, err := resolveBackendStrict(nil)
+		require.NoError(t, err)
+		assert.Equal(t, "opencode", b.Name())
+	})
+	t.Run("emptyBackend", func(t *testing.T) {
+		b, err := resolveBackendStrict(&projectConfig{})
+		require.NoError(t, err)
+		assert.Equal(t, "opencode", b.Name())
+	})
+	t.Run("validClaudeCode", func(t *testing.T) {
+		b, err := resolveBackendStrict(&projectConfig{Backend: "claude-code"})
+		require.NoError(t, err)
+		assert.Equal(t, "claude-code", b.Name())
+	})
+	t.Run("invalidBackend", func(t *testing.T) {
+		_, err := resolveBackendStrict(&projectConfig{Backend: "invalid"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unsupported backend")
+	})
+}
+
+func TestBothBackendsProduceValidAgentArgs(t *testing.T) {
+	backends := []Backend{&opencodeBackend{}, &claudeCodeBackend{}}
+	params := AgentRunParams{
+		Agent:     "coordinator",
+		BaseAgent: "coordinator",
+		ModelSpec: "anthropic/claude-opus-4-6 (max)",
+		SessionID: "session-123",
+	}
+
+	for _, b := range backends {
+		t.Run(b.Name(), func(t *testing.T) {
+			args := b.BuildAgentArgs(params)
+			assert.NotEmpty(t, args)
+			// All backends should produce a --name or --title with the agent name
+			found := false
+			for _, arg := range args {
+				if arg == "coordinator [anthropic/claude-opus-4-6 (max)]" {
+					found = true
+					break
+				}
+			}
+			assert.True(t, found, "expected agent title in args for %s backend", b.Name())
+		})
+	}
+}
+
+func TestBothBackendsProduceValidAdhocArgs(t *testing.T) {
+	backends := []Backend{&opencodeBackend{}, &claudeCodeBackend{}}
+	modelSpec := "anthropic/claude-opus-4-6 (max)"
+
+	for _, b := range backends {
+		t.Run(b.Name(), func(t *testing.T) {
+			args := b.BuildAdhocArgs(modelSpec)
+			assert.NotEmpty(t, args)
+			// All backends should produce args with the model
+			hasModel := false
+			for _, arg := range args {
+				if arg == "--model" || arg == "-m" {
+					hasModel = true
+					break
+				}
+			}
+			assert.True(t, hasModel, "expected model flag in adhoc args for %s backend", b.Name())
+		})
+	}
+}
+
+func TestBothBackendsProduceValidEnv(t *testing.T) {
+	backends := []Backend{&opencodeBackend{}, &claudeCodeBackend{}}
+	params := AgentEnvParams{
+		Dir:             "/tmp/workspace",
+		McpURL:          "http://localhost:8080/mcp",
+		AgentIdentity:   "coordinator",
+		InteractiveMode: "yes",
+	}
+
+	for _, b := range backends {
+		t.Run(b.Name(), func(t *testing.T) {
+			env := b.BuildEnv(params)
+			assert.NotEmpty(t, env)
+
+			envMap := make(map[string]string)
+			for _, e := range env {
+				for i := 0; i < len(e); i++ {
+					if e[i] == '=' {
+						envMap[e[:i]] = e[i+1:]
+						break
+					}
+				}
+			}
+
+			// Both backends should set SGAI_MCP_URL
+			assert.Equal(t, "http://localhost:8080/mcp", envMap["SGAI_MCP_URL"])
+			assert.Equal(t, "coordinator", envMap["SGAI_AGENT_IDENTITY"])
+			assert.Equal(t, "yes", envMap["SGAI_MCP_INTERACTIVE"])
+		})
+	}
+}
+
+func TestBothBackendsParseOwnEvents(t *testing.T) {
+	t.Run("opencode", func(t *testing.T) {
+		b := &opencodeBackend{}
+		line := []byte(`{"type":"text","part":{"text":"hello"},"session_id":"s1"}`)
+		event, ok := b.ParseEvent(line)
+		assert.True(t, ok)
+		assert.Equal(t, "text", event.Type)
+		assert.Equal(t, "hello", event.Part.Text)
+	})
+	t.Run("claudeCode", func(t *testing.T) {
+		b := &claudeCodeBackend{}
+		line := []byte(`{"type":"assistant","message":{"content":[{"type":"text","text":"hello"}]},"session_id":"s1"}`)
+		event, ok := b.ParseEvent(line)
+		assert.True(t, ok)
+		assert.Equal(t, "text", event.Type)
+		assert.Equal(t, "hello", event.Part.Text)
+	})
+}
+
+func TestBothBackendsHandleInvalidEvents(t *testing.T) {
+	backends := []Backend{&opencodeBackend{}, &claudeCodeBackend{}}
+	for _, b := range backends {
+		t.Run(b.Name(), func(t *testing.T) {
+			_, ok := b.ParseEvent([]byte(`not json`))
+			assert.False(t, ok)
+		})
+	}
+}
+
+func TestBackendBinaryNames(t *testing.T) {
+	assert.Equal(t, "opencode", (&opencodeBackend{}).BinaryName())
+	assert.Equal(t, "claude", (&claudeCodeBackend{}).BinaryName())
+}
+
+func TestBackendStripProviderPrefix(t *testing.T) {
+	oc := &opencodeBackend{}
+	cc := &claudeCodeBackend{}
+
+	// opencode keeps the prefix
+	assert.Equal(t, "anthropic/claude-opus-4-6", oc.StripProviderPrefix("anthropic/claude-opus-4-6"))
+
+	// claude-code strips the prefix
+	assert.Equal(t, "claude-opus-4-6", cc.StripProviderPrefix("anthropic/claude-opus-4-6"))
+
+	// Both handle no-prefix models
+	assert.Equal(t, "claude-opus-4-6", oc.StripProviderPrefix("claude-opus-4-6"))
+	assert.Equal(t, "claude-opus-4-6", cc.StripProviderPrefix("claude-opus-4-6"))
+}

--- a/cmd/sgai/config.go
+++ b/cmd/sgai/config.go
@@ -139,8 +139,12 @@ func applyConfigDefaults(config *projectConfig, metadata *GoalMetadata) {
 	}
 }
 
-func applyCustomMCPs(dir string, config *projectConfig) error {
+func applyCustomMCPs(dir string, config *projectConfig, backend Backend) error {
 	if config == nil || len(config.MCP) == 0 {
+		return nil
+	}
+	// Claude Code handles MCPs via --mcp-config flag at runtime, not via opencode.jsonc
+	if backend.Name() != "opencode" {
 		return nil
 	}
 

--- a/cmd/sgai/config.go
+++ b/cmd/sgai/config.go
@@ -44,9 +44,30 @@ type actionConfig struct {
 // The configuration file must be located at the project root, as a sibling to the .sgai directory.
 type projectConfig struct {
 	DefaultModel string                     `json:"defaultModel,omitempty"`
+	Backend      string                     `json:"backend,omitempty"` // "opencode" (default) or "claude-code"
 	MCP          map[string]json.RawMessage `json:"mcp,omitempty"`
 	Editor       string                     `json:"editor,omitempty"`
 	Actions      []actionConfig             `json:"actions,omitempty"`
+}
+
+// resolveBackend returns the Backend implementation for the given config.
+// Defaults to opencode if config is nil or backend is unset.
+func resolveBackend(config *projectConfig) Backend {
+	if config != nil && config.Backend == "claude-code" {
+		return &claudeCodeBackend{}
+	}
+	return &opencodeBackend{}
+}
+
+// resolveBackendStrict returns an error for invalid backend values.
+func resolveBackendStrict(config *projectConfig) (Backend, error) {
+	if config == nil || config.Backend == "" || config.Backend == "opencode" {
+		return &opencodeBackend{}, nil
+	}
+	if config.Backend == "claude-code" {
+		return &claudeCodeBackend{}, nil
+	}
+	return nil, fmt.Errorf("unsupported backend: %q (valid: \"opencode\", \"claude-code\")", config.Backend)
 }
 
 func loadProjectConfig(dir string) (*projectConfig, error) {

--- a/cmd/sgai/config_test.go
+++ b/cmd/sgai/config_test.go
@@ -385,7 +385,7 @@ func TestApplyCustomMCPs(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			dir := t.TempDir()
 			tt.setupFunc(t, dir)
-			err := applyCustomMCPs(dir, tt.config)
+			err := applyCustomMCPs(dir, tt.config, &opencodeBackend{})
 			if tt.wantErr {
 				require.Error(t, err)
 				return
@@ -452,6 +452,19 @@ func TestLoadProjectConfigBackendField(t *testing.T) {
 	assert.Equal(t, "claude-code", b.Name())
 }
 
+func TestApplyCustomMCPsClaudeCodeSkips(t *testing.T) {
+	// Claude Code backend should skip applyCustomMCPs entirely
+	dir := t.TempDir()
+	cfg := &projectConfig{
+		MCP: map[string]json.RawMessage{
+			"test-server": json.RawMessage(`{"command": "test"}`),
+		},
+	}
+	// No .sgai/opencode.jsonc exists, but should not error because claude-code skips
+	err := applyCustomMCPs(dir, cfg, &claudeCodeBackend{})
+	assert.NoError(t, err)
+}
+
 func TestLoadProjectConfigTypeError(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(dir, configFileName), []byte(`{"editor": 12345}`), 0644))
@@ -481,7 +494,7 @@ func TestApplyCustomMCPsInvalidOpencodeJSON(t *testing.T) {
 			"test-server": json.RawMessage(`{"command": "test"}`),
 		},
 	}
-	err := applyCustomMCPs(dir, cfg)
+	err := applyCustomMCPs(dir, cfg, &opencodeBackend{})
 	assert.Error(t, err)
 }
 
@@ -495,7 +508,7 @@ func TestApplyCustomMCPsInvalidMCPSection(t *testing.T) {
 			"test-server": json.RawMessage(`{"command": "test"}`),
 		},
 	}
-	err := applyCustomMCPs(dir, cfg)
+	err := applyCustomMCPs(dir, cfg, &opencodeBackend{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "extracting mcp section")
 }

--- a/cmd/sgai/config_test.go
+++ b/cmd/sgai/config_test.go
@@ -398,6 +398,60 @@ func TestApplyCustomMCPs(t *testing.T) {
 	}
 }
 
+func TestResolveBackend(t *testing.T) {
+	t.Run("defaultsToOpencode", func(t *testing.T) {
+		b := resolveBackend(nil)
+		assert.Equal(t, "opencode", b.Name())
+	})
+	t.Run("emptyBackendDefaultsToOpencode", func(t *testing.T) {
+		config := &projectConfig{}
+		b := resolveBackend(config)
+		assert.Equal(t, "opencode", b.Name())
+	})
+	t.Run("explicitOpencode", func(t *testing.T) {
+		config := &projectConfig{Backend: "opencode"}
+		b := resolveBackend(config)
+		assert.Equal(t, "opencode", b.Name())
+	})
+	t.Run("claudeCode", func(t *testing.T) {
+		config := &projectConfig{Backend: "claude-code"}
+		b := resolveBackend(config)
+		assert.Equal(t, "claude-code", b.Name())
+	})
+}
+
+func TestResolveBackendStrict(t *testing.T) {
+	t.Run("nilConfig", func(t *testing.T) {
+		b, err := resolveBackendStrict(nil)
+		require.NoError(t, err)
+		assert.Equal(t, "opencode", b.Name())
+	})
+	t.Run("validClaudeCode", func(t *testing.T) {
+		b, err := resolveBackendStrict(&projectConfig{Backend: "claude-code"})
+		require.NoError(t, err)
+		assert.Equal(t, "claude-code", b.Name())
+	})
+	t.Run("invalidBackend", func(t *testing.T) {
+		_, err := resolveBackendStrict(&projectConfig{Backend: "invalid"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unsupported backend")
+	})
+}
+
+func TestLoadProjectConfigBackendField(t *testing.T) {
+	dir := t.TempDir()
+	data := []byte(`{"backend": "claude-code", "defaultModel": "anthropic/claude-opus-4-6"}`)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, configFileName), data, 0644))
+
+	config, err := loadProjectConfig(dir)
+	require.NoError(t, err)
+	require.NotNil(t, config)
+	assert.Equal(t, "claude-code", config.Backend)
+
+	b := resolveBackend(config)
+	assert.Equal(t, "claude-code", b.Name())
+}
+
 func TestLoadProjectConfigTypeError(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(dir, configFileName), []byte(`{"editor": 12345}`), 0644))

--- a/cmd/sgai/continuous.go
+++ b/cmd/sgai/continuous.go
@@ -41,7 +41,7 @@ func runContinuousWorkflow(ctx context.Context, dir string, continuousPrompt str
 	runner.runContinuous(ctx, continuousPrompt)
 }
 
-func runContinuousModePrompt(ctx context.Context, dir string, prompt string, mcpURL string, coord *state.Coordinator) {
+func runContinuousModePrompt(ctx context.Context, dir string, prompt string, mcpURL string, coord *state.Coordinator, backend Backend) {
 	updateContinuousModeState(coord, "Running continuous mode prompt...", "continuous-mode", "continuous mode prompt started")
 
 	for attempt := range continuousModeMaxRetries {
@@ -49,12 +49,14 @@ func runContinuousModePrompt(ctx context.Context, dir string, prompt string, mcp
 			return
 		}
 
-		cmd := exec.CommandContext(ctx, "opencode", "run", "--title", "continuous-mode-prompt")
+		args := backend.BuildContinuousArgs()
+		cmd := exec.CommandContext(ctx, backend.BinaryName(), args...)
 		cmd.Dir = dir
-		cmd.Env = append(os.Environ(),
-			"OPENCODE_CONFIG_DIR="+filepath.Join(dir, ".sgai"),
-			"SGAI_MCP_URL="+mcpURL,
-			"SGAI_MCP_INTERACTIVE=auto")
+		cmd.Env = backend.BuildEnv(AgentEnvParams{
+			Dir:             dir,
+			McpURL:          mcpURL,
+			InteractiveMode: "auto",
+		})
 		cmd.Stdin = strings.NewReader(prompt)
 
 		if errRun := cmd.Run(); errRun != nil {

--- a/cmd/sgai/main.go
+++ b/cmd/sgai/main.go
@@ -50,11 +50,8 @@ func main() {
 		subcommand = os.Args[1]
 	}
 
-	if subcommand != "help" && subcommand != "-h" && subcommand != "--help" {
-		if _, err := exec.LookPath("opencode"); err != nil {
-			log.Fatalln("opencode is required but not found in PATH")
-		}
-	}
+	// Binary check is deferred to workflow startup where the backend is known.
+	// Each backend validates its CLI binary availability via BinaryName().
 
 	switch subcommand {
 	case "help", "-h", "--help":
@@ -250,6 +247,7 @@ type multiModelConfig struct {
 	logWriter        io.Writer
 	stdoutLog        io.Writer
 	stderrLog        io.Writer
+	backend          Backend
 }
 
 func runMultiModelAgent(ctx context.Context, cfg multiModelConfig, wfState state.Workflow, metadata GoalMetadata, iterationCounter *int) state.Workflow {
@@ -374,7 +372,12 @@ func runFlowAgentWithModel(ctx context.Context, cfg multiModelConfig, wfState st
 		copyProjectManagementToRetrospective(cfg.dir, cfg.retrospectiveDir)
 
 		baseAgent := resolveBaseAgent(metadata.Alias, cfg.agent)
-		agentArgs := buildAgentArgs(cfg.agent, baseAgent, modelSpec, capturedSessionID)
+		agentArgs := cfg.backend.BuildAgentArgs(AgentRunParams{
+			Agent:     cfg.agent,
+			BaseAgent: baseAgent,
+			ModelSpec: modelSpec,
+			SessionID: capturedSessionID,
+		})
 		agentMsg := buildAgentMessage(cfg, wfState, metadata)
 
 		newState, capturedSessionID, errExec := executeAgentProcess(ctx, cfg, agentArgs, agentMsg, prefix, outputCapture, wfState)
@@ -446,26 +449,6 @@ func copyProjectManagementToRetrospective(dir, retrospectiveDir string) {
 	}
 }
 
-func buildAgentArgs(agent, baseAgent, modelSpec, sessionID string) []string {
-	args := []string{"run", "--format=json", "--agent", baseAgent}
-	if modelSpec != "" {
-		model, variant := parseModelAndVariant(modelSpec)
-		args = append(args, "--model", model)
-		if variant != "" {
-			args = append(args, "--variant", variant)
-		}
-	}
-	if sessionID != "" {
-		args = append(args, "--session", sessionID)
-	}
-	title := agent
-	if modelSpec != "" {
-		title = agent + " [" + modelSpec + "]"
-	}
-	args = append(args, "--title", title)
-	return args
-}
-
 func buildAgentMessage(cfg multiModelConfig, wfState state.Workflow, metadata GoalMetadata) string {
 	msg := buildFlowMessage(cfg.flowDag, cfg.agent, wfState.VisitCounts, cfg.dir, wfState.InteractionMode, metadata.Alias)
 
@@ -516,24 +499,25 @@ func buildAgentEnv(cfg multiModelConfig, wfState state.Workflow, modelSpec strin
 		agentIdentity = cfg.agent + "|" + model + "|" + variant
 	}
 
-	return append(os.Environ(),
-		"OPENCODE_CONFIG_DIR="+filepath.Join(cfg.dir, ".sgai"),
-		"SGAI_MCP_URL="+cfg.mcpURL,
-		"SGAI_AGENT_IDENTITY="+agentIdentity,
-		"SGAI_MCP_INTERACTIVE="+interactiveEnv)
+	return cfg.backend.BuildEnv(AgentEnvParams{
+		Dir:             cfg.dir,
+		McpURL:          cfg.mcpURL,
+		AgentIdentity:   agentIdentity,
+		InteractiveMode: interactiveEnv,
+	})
 }
 
 func executeAgentProcess(ctx context.Context, cfg multiModelConfig, agentArgs []string, agentMsg, prefix string, outputCapture *ringWriter, wfState state.Workflow) (state.Workflow, string, *state.Workflow) {
 	stderrOut := buildAgentOutputWriter(os.Stderr, cfg.logWriter, cfg.stderrLog)
 	stdoutOut := buildAgentOutputWriter(os.Stdout, cfg.logWriter, cfg.stdoutLog)
 	stderrWriter := &prefixWriter{prefix: prefix + " ", w: stderrOut, startTime: time.Now()}
-	jsonWriter := &jsonPrettyWriter{prefix: prefix + " ", w: stdoutOut, coord: cfg.coord, currentAgent: cfg.agent, startTime: time.Now()}
+	jsonWriter := &jsonPrettyWriter{prefix: prefix + " ", w: stdoutOut, coord: cfg.coord, currentAgent: cfg.agent, startTime: time.Now(), backend: cfg.backend}
 
 	cfg.coord.ResetAgentDoneWatchdog()
 	agentCtx, agentCancel := context.WithCancel(ctx)
 	cfg.coord.SetAgentCancel(agentCancel)
 
-	cmd := exec.CommandContext(agentCtx, "opencode", agentArgs...)
+	cmd := exec.CommandContext(agentCtx, cfg.backend.BinaryName(), agentArgs...)
 	cmd.Dir = cfg.dir
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	cmd.Env = buildAgentEnv(cfg, wfState, extractModelFromArgs(agentArgs))
@@ -543,7 +527,7 @@ func executeAgentProcess(ctx context.Context, cfg multiModelConfig, agentArgs []
 
 	if errStart := cmd.Start(); errStart != nil {
 		agentCancel()
-		fmt.Fprintln(os.Stderr, "failed to start opencode:", errStart)
+		fmt.Fprintln(os.Stderr, "failed to start "+cfg.backend.BinaryName()+":", errStart)
 		if errUpdate := cfg.coord.UpdateState(func(wf *state.Workflow) {
 			wf.Status = state.StatusAgentDone
 		}); errUpdate != nil {
@@ -596,7 +580,7 @@ func extractModelFromArgs(args []string) string {
 func exportAgentSession(cfg multiModelConfig, sessionID string, iteration int) {
 	timestamp := time.Now().Format("20060102150405")
 	sessionFile := filepath.Join(cfg.retrospectiveDir, fmt.Sprintf("%04d-%s-%s.json", iteration, cfg.agent, timestamp))
-	if err := exportSession(cfg.dir, sessionID, sessionFile); err != nil {
+	if err := cfg.backend.ExportSession(cfg.dir, sessionID, sessionFile); err != nil {
 		log.Fatalln("failed to export session:", err)
 	}
 }
@@ -1306,6 +1290,7 @@ type jsonPrettyWriter struct {
 	currentAgent string
 	stepCounter  int
 	startTime    time.Time
+	backend      Backend
 }
 
 func (j *jsonPrettyWriter) tsPrefix() string {
@@ -1332,8 +1317,8 @@ func (j *jsonPrettyWriter) processBuffer() {
 			continue
 		}
 
-		var event streamEvent
-		if err := json.Unmarshal(line, &event); err != nil {
+		event, ok := j.backend.ParseEvent(line)
+		if !ok {
 			continue
 		}
 
@@ -1741,20 +1726,6 @@ func copyFinalStateToRetrospective(dir, retrospectiveDir string) error {
 	}
 
 	return nil
-}
-
-func exportSession(dir, sessionID, outputPath string) error {
-	cmd := exec.Command("opencode", "export", sessionID)
-	cmd.Dir = dir
-	cmd.Env = append(os.Environ(), "OPENCODE_CONFIG_DIR="+filepath.Join(dir, ".sgai"))
-	output, err := cmd.Output()
-	if err != nil {
-		return fmt.Errorf("opencode export failed: %w", err)
-	}
-	if err := os.MkdirAll(filepath.Dir(outputPath), 0755); err != nil {
-		return err
-	}
-	return os.WriteFile(outputPath, output, 0644)
 }
 
 func formatDuration(d time.Duration) string {

--- a/cmd/sgai/main.go
+++ b/cmd/sgai/main.go
@@ -378,6 +378,7 @@ func runFlowAgentWithModel(ctx context.Context, cfg multiModelConfig, wfState st
 			ModelSpec: modelSpec,
 			SessionID: capturedSessionID,
 			AgentDir:  cfg.dir,
+			McpURL:    cfg.mcpURL,
 		})
 		agentMsg := buildAgentMessage(cfg, wfState, metadata)
 

--- a/cmd/sgai/main.go
+++ b/cmd/sgai/main.go
@@ -377,6 +377,7 @@ func runFlowAgentWithModel(ctx context.Context, cfg multiModelConfig, wfState st
 			BaseAgent: baseAgent,
 			ModelSpec: modelSpec,
 			SessionID: capturedSessionID,
+			AgentDir:  cfg.dir,
 		})
 		agentMsg := buildAgentMessage(cfg, wfState, metadata)
 

--- a/cmd/sgai/main_test.go
+++ b/cmd/sgai/main_test.go
@@ -485,7 +485,8 @@ func TestBuildAgentArgsVariants(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			args := buildAgentArgs(tc.agent, tc.baseAgent, tc.modelSpec, tc.sessionID)
+			b := &opencodeBackend{}
+			args := b.BuildAgentArgs(AgentRunParams{Agent: tc.agent, BaseAgent: tc.baseAgent, ModelSpec: tc.modelSpec, SessionID: tc.sessionID})
 			assert.Contains(t, args, "run")
 			assert.Contains(t, args, "--agent")
 			if tc.wantModel {
@@ -1806,7 +1807,8 @@ func TestBuildAgentArgs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := buildAgentArgs(tt.agent, tt.baseAgent, tt.modelSpec, tt.sessionID)
+			b := &opencodeBackend{}
+			result := b.BuildAgentArgs(AgentRunParams{Agent: tt.agent, BaseAgent: tt.baseAgent, ModelSpec: tt.modelSpec, SessionID: tt.sessionID})
 			assert.Equal(t, tt.expected, result)
 		})
 	}
@@ -2251,8 +2253,9 @@ func TestBuildAgentMessage(t *testing.T) {
 
 func TestBuildAgentEnv(t *testing.T) {
 	cfg := multiModelConfig{
-		agent: "test-agent",
-		dir:   "/tmp/test-workspace",
+		agent:   "test-agent",
+		dir:     "/tmp/test-workspace",
+		backend: &opencodeBackend{},
 	}
 	wfState := state.Workflow{
 		InteractionMode: state.ModeSelfDrive,
@@ -2278,8 +2281,9 @@ func TestBuildAgentEnv(t *testing.T) {
 
 func TestBuildAgentEnvWithModel(t *testing.T) {
 	cfg := multiModelConfig{
-		agent: "test-agent",
-		dir:   "/tmp/test-workspace",
+		agent:   "test-agent",
+		dir:     "/tmp/test-workspace",
+		backend: &opencodeBackend{},
 	}
 	wfState := state.Workflow{}
 
@@ -3118,6 +3122,7 @@ func TestJSONPrettyWriterWrite(t *testing.T) {
 		prefix:    " [test] ",
 		w:         &buf,
 		startTime: time.Now(),
+		backend:   &opencodeBackend{},
 	}
 
 	event := streamEvent{Type: "text", Part: part{Text: "hello world"}}
@@ -3139,6 +3144,7 @@ func TestJSONPrettyWriterProcessEventText(t *testing.T) {
 		prefix:    " ",
 		w:         &buf,
 		startTime: time.Now(),
+		backend:   &opencodeBackend{},
 	}
 
 	w.processEvent(streamEvent{Type: "text", Part: part{Text: "some text"}})
@@ -3154,6 +3160,7 @@ func TestJSONPrettyWriterProcessEventToolPending(t *testing.T) {
 		prefix:    " ",
 		w:         &buf,
 		startTime: time.Now(),
+		backend:   &opencodeBackend{},
 	}
 
 	w.processEvent(streamEvent{
@@ -3177,6 +3184,7 @@ func TestJSONPrettyWriterProcessEventToolRunning(t *testing.T) {
 		prefix:    " ",
 		w:         &buf,
 		startTime: time.Now(),
+		backend:   &opencodeBackend{},
 	}
 
 	w.processEvent(streamEvent{
@@ -3201,6 +3209,7 @@ func TestJSONPrettyWriterProcessEventToolCompleted(t *testing.T) {
 		prefix:    " ",
 		w:         &buf,
 		startTime: time.Now(),
+		backend:   &opencodeBackend{},
 	}
 
 	w.processEvent(streamEvent{
@@ -3226,6 +3235,7 @@ func TestJSONPrettyWriterProcessEventToolCompletedTodo(t *testing.T) {
 		prefix:    " ",
 		w:         &buf,
 		startTime: time.Now(),
+		backend:   &opencodeBackend{},
 	}
 
 	todos := `[{"content":"task1","status":"completed","priority":"high"},{"content":"task2","status":"pending","priority":"medium"}]`
@@ -3254,6 +3264,7 @@ func TestJSONPrettyWriterProcessEventToolError(t *testing.T) {
 		prefix:    " ",
 		w:         &buf,
 		startTime: time.Now(),
+		backend:   &opencodeBackend{},
 	}
 
 	w.processEvent(streamEvent{
@@ -3279,6 +3290,7 @@ func TestJSONPrettyWriterProcessEventStepStart(t *testing.T) {
 		prefix:    " ",
 		w:         &buf,
 		startTime: time.Now(),
+		backend:   &opencodeBackend{},
 	}
 
 	w.currentText.WriteString("buffered text")
@@ -3294,6 +3306,7 @@ func TestJSONPrettyWriterProcessEventReasoning(t *testing.T) {
 		prefix:    " ",
 		w:         &buf,
 		startTime: time.Now(),
+		backend:   &opencodeBackend{},
 	}
 
 	w.processEvent(streamEvent{Type: "reasoning", Part: part{Text: "thinking about it"}})
@@ -3306,6 +3319,7 @@ func TestJSONPrettyWriterProcessEventUnknownType(t *testing.T) {
 		prefix:    " ",
 		w:         &buf,
 		startTime: time.Now(),
+		backend:   &opencodeBackend{},
 	}
 
 	w.processEvent(streamEvent{Type: "custom_event"})
@@ -3318,6 +3332,7 @@ func TestJSONPrettyWriterSessionIDCapture(t *testing.T) {
 		prefix:    " ",
 		w:         &buf,
 		startTime: time.Now(),
+		backend:   &opencodeBackend{},
 	}
 
 	w.processEvent(streamEvent{Type: "text", SessionID: "sess-123", Part: part{Text: "hi"}})
@@ -3330,6 +3345,7 @@ func TestJSONPrettyWriterFlushEmpty(t *testing.T) {
 		prefix:    " ",
 		w:         &buf,
 		startTime: time.Now(),
+		backend:   &opencodeBackend{},
 	}
 
 	w.Flush()
@@ -3342,6 +3358,7 @@ func TestJSONPrettyWriterProcessBufferMultipleEvents(t *testing.T) {
 		prefix:    " ",
 		w:         &buf,
 		startTime: time.Now(),
+		backend:   &opencodeBackend{},
 	}
 
 	event1, _ := json.Marshal(streamEvent{Type: "text", Part: part{Text: "hello"}})
@@ -3360,6 +3377,7 @@ func TestJSONPrettyWriterProcessBufferPartialLine(t *testing.T) {
 		prefix:    " ",
 		w:         &buf,
 		startTime: time.Now(),
+		backend:   &opencodeBackend{},
 	}
 
 	event, _ := json.Marshal(streamEvent{Type: "text", Part: part{Text: "partial"}})
@@ -3386,6 +3404,7 @@ func TestJSONPrettyWriterRecordStepCost(t *testing.T) {
 		coord:        coord,
 		currentAgent: "test-agent",
 		stepCounter:  1,
+		backend:      &opencodeBackend{},
 	}
 
 	w.recordStepCost(part{
@@ -3417,6 +3436,7 @@ func TestJSONPrettyWriterRecordStepCostMultipleSteps(t *testing.T) {
 		coord:        coord,
 		currentAgent: "test-agent",
 		stepCounter:  1,
+		backend:      &opencodeBackend{},
 	}
 
 	w.recordStepCost(part{Cost: 0.01, Tokens: partTokens{Input: 10, Output: 5}}, time.Now().UnixMilli())
@@ -3436,6 +3456,7 @@ func TestJSONPrettyWriterRecordStepCostNilCoord(_ *testing.T) {
 		startTime:    time.Now(),
 		coord:        nil,
 		currentAgent: "test-agent",
+		backend:      &opencodeBackend{},
 	}
 
 	w.recordStepCost(part{Cost: 0.05}, time.Now().UnixMilli())
@@ -3453,6 +3474,7 @@ func TestJSONPrettyWriterRecordStepCostEmptyAgent(t *testing.T) {
 		startTime:    time.Now(),
 		coord:        coord,
 		currentAgent: "",
+		backend:      &opencodeBackend{},
 	}
 
 	w.recordStepCost(part{Cost: 0.05}, time.Now().UnixMilli())
@@ -3472,6 +3494,7 @@ func TestJSONPrettyWriterRecordStepCostZeroValues(t *testing.T) {
 		startTime:    time.Now(),
 		coord:        coord,
 		currentAgent: "agent",
+		backend:      &opencodeBackend{},
 	}
 
 	w.recordStepCost(part{Cost: 0, Tokens: partTokens{}}, time.Now().UnixMilli())
@@ -3485,6 +3508,7 @@ func TestJSONPrettyWriterFormatTodoOutput(t *testing.T) {
 		prefix:    " ",
 		w:         &buf,
 		startTime: time.Now(),
+		backend:   &opencodeBackend{},
 	}
 
 	todos := `[{"content":"write tests","status":"in_progress","priority":"high"},{"content":"fix bug","status":"completed","priority":"medium"},{"content":"deploy","status":"cancelled","priority":"low"}]`
@@ -3505,6 +3529,7 @@ func TestJSONPrettyWriterFormatTodoOutputInvalidJSON(t *testing.T) {
 		prefix:    " ",
 		w:         &buf,
 		startTime: time.Now(),
+		backend:   &opencodeBackend{},
 	}
 
 	w.formatTodoOutput("not json at all")
@@ -3520,6 +3545,7 @@ func TestJSONPrettyWriterFormatTodoOutputWithPrefix(t *testing.T) {
 		prefix:    " ",
 		w:         &buf,
 		startTime: time.Now(),
+		backend:   &opencodeBackend{},
 	}
 
 	todos := "Updated todos\n" + `[{"content":"task","status":"pending","priority":"high"}]`
@@ -3543,6 +3569,7 @@ func TestJSONPrettyWriterProcessEventStepFinish(t *testing.T) {
 		coord:        coord,
 		currentAgent: "test-agent",
 		stepCounter:  1,
+		backend:      &opencodeBackend{},
 	}
 
 	w.currentText.WriteString("some text")
@@ -3566,6 +3593,7 @@ func TestJSONPrettyWriterToolNilState(t *testing.T) {
 		prefix:    " ",
 		w:         &buf,
 		startTime: time.Now(),
+		backend:   &opencodeBackend{},
 	}
 
 	w.processEvent(streamEvent{
@@ -3770,7 +3798,8 @@ func TestTerminateProcessGroupOnCancelWithContext(t *testing.T) {
 func TestExportSessionMissingBinary(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".sgai"), 0755))
-	err := exportSession(dir, "session-1", filepath.Join(dir, "output.json"))
+	b := &opencodeBackend{}
+	err := b.ExportSession(dir, "session-1", filepath.Join(dir, "output.json"))
 	assert.Error(t, err)
 }
 

--- a/cmd/sgai/serve_api.go
+++ b/cmd/sgai/serve_api.go
@@ -2109,11 +2109,12 @@ func (s *Server) handleAPIAdhoc(w http.ResponseWriter, r *http.Request) {
 	st.selectedModel = strings.TrimSpace(req.Model)
 	st.promptText = strings.TrimSpace(req.Prompt)
 
-	args := buildAdhocArgs(st.selectedModel)
-	cmd := exec.Command("opencode", args...)
+	backend := s.resolveAdhocBackend(workspacePath)
+	args := backend.BuildAdhocArgs(st.selectedModel)
+	cmd := exec.Command(backend.BinaryName(), args...)
 	cmd.Dir = workspacePath
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-	cmd.Env = append(os.Environ(), "OPENCODE_CONFIG_DIR="+filepath.Join(workspacePath, ".sgai"))
+	cmd.Env = backend.BuildEnv(AgentEnvParams{Dir: workspacePath})
 	cmd.Stdin = strings.NewReader(st.promptText)
 	writer := &lockedWriter{mu: &st.mu, buf: &st.output}
 	prefix := fmt.Sprintf("[%s][adhoc:0000]", filepath.Base(workspacePath))
@@ -2121,7 +2122,7 @@ func (s *Server) handleAPIAdhoc(w http.ResponseWriter, r *http.Request) {
 	stderrPW := &prefixWriter{prefix: prefix + " ", w: os.Stderr, startTime: time.Now()}
 	cmd.Stdout = io.MultiWriter(stdoutPW, writer)
 	cmd.Stderr = io.MultiWriter(stderrPW, writer)
-	commandLine := "$ opencode " + strings.Join(args, " ")
+	commandLine := "$ " + backend.BinaryName() + " " + strings.Join(args, " ")
 	promptLine := "prompt: " + st.promptText
 	_, _ = fmt.Fprintln(stderrPW, commandLine)
 	_, _ = fmt.Fprintln(stderrPW, promptLine)
@@ -2157,14 +2158,6 @@ func (s *Server) handleAPIAdhoc(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-func buildAdhocArgs(modelSpec string) []string {
-	baseModel, variant := parseModelAndVariant(modelSpec)
-	args := []string{"run", "-m", baseModel, "--agent", "build", "--title", "adhoc [" + modelSpec + "]"}
-	if variant != "" {
-		args = append(args, "--variant", variant)
-	}
-	return args
-}
 
 func (s *Server) handleAPIAdhocStop(w http.ResponseWriter, r *http.Request) {
 	workspacePath, ok := s.resolveWorkspaceFromPath(w, r)

--- a/cmd/sgai/serve_api_test.go
+++ b/cmd/sgai/serve_api_test.go
@@ -646,13 +646,15 @@ func TestCollectAgentModelsVariants(t *testing.T) {
 }
 
 func TestBuildAdhocArgs(t *testing.T) {
+	b := &opencodeBackend{}
+
 	t.Run("simpleModel", func(t *testing.T) {
-		args := buildAdhocArgs("claude-opus-4")
+		args := b.BuildAdhocArgs("claude-opus-4")
 		assert.Equal(t, []string{"run", "-m", "claude-opus-4", "--agent", "build", "--title", "adhoc [claude-opus-4]"}, args)
 	})
 
 	t.Run("modelWithVariant", func(t *testing.T) {
-		args := buildAdhocArgs("claude-opus-4:fast")
+		args := b.BuildAdhocArgs("claude-opus-4:fast")
 		assert.Contains(t, args, "run")
 		assert.Contains(t, args, "-m")
 		assert.Contains(t, args, "--agent")
@@ -661,13 +663,13 @@ func TestBuildAdhocArgs(t *testing.T) {
 	})
 
 	t.Run("withVariantAddsFlag", func(t *testing.T) {
-		args := buildAdhocArgs("anthropic/claude-sonnet-4-6 (thinking)")
+		args := b.BuildAdhocArgs("anthropic/claude-sonnet-4-6 (thinking)")
 		assert.Contains(t, args, "--variant")
 		assert.Contains(t, args, "thinking")
 	})
 
 	t.Run("withoutVariantNoFlag", func(t *testing.T) {
-		args := buildAdhocArgs("anthropic/claude-sonnet-4-6")
+		args := b.BuildAdhocArgs("anthropic/claude-sonnet-4-6")
 		for _, arg := range args {
 			assert.NotEqual(t, "--variant", arg)
 		}
@@ -3084,13 +3086,15 @@ func TestHandleAPIStateWithCaching(t *testing.T) {
 }
 
 func TestBuildAdhocArgsWithVariantAddsFlag(t *testing.T) {
-	args := buildAdhocArgs("anthropic/claude-sonnet-4-6 (thinking)")
+	b := &opencodeBackend{}
+	args := b.BuildAdhocArgs("anthropic/claude-sonnet-4-6 (thinking)")
 	assert.Contains(t, args, "--variant")
 	assert.Contains(t, args, "thinking")
 }
 
 func TestBuildAdhocArgsWithoutVariantNoFlag(t *testing.T) {
-	args := buildAdhocArgs("anthropic/claude-sonnet-4-6")
+	b := &opencodeBackend{}
+	args := b.BuildAdhocArgs("anthropic/claude-sonnet-4-6")
 	for _, arg := range args {
 		assert.NotEqual(t, "--variant", arg)
 	}

--- a/cmd/sgai/service_adhoc.go
+++ b/cmd/sgai/service_adhoc.go
@@ -11,6 +11,15 @@ import (
 	"time"
 )
 
+// resolveAdhocBackend loads the project config for the workspace and returns the appropriate backend.
+func (s *Server) resolveAdhocBackend(workspacePath string) Backend {
+	config, err := loadProjectConfig(workspacePath)
+	if err != nil {
+		return &opencodeBackend{}
+	}
+	return resolveBackend(config)
+}
+
 type adhocStatusResult struct {
 	Running bool
 	Output  string
@@ -52,11 +61,12 @@ func (s *Server) adhocStartService(workspacePath, prompt, model string) adhocSta
 	st.selectedModel = strings.TrimSpace(model)
 	st.promptText = strings.TrimSpace(prompt)
 
-	args := buildAdhocArgs(st.selectedModel)
-	cmd := exec.Command("opencode", args...)
+	backend := s.resolveAdhocBackend(workspacePath)
+	args := backend.BuildAdhocArgs(st.selectedModel)
+	cmd := exec.Command(backend.BinaryName(), args...)
 	cmd.Dir = workspacePath
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-	cmd.Env = append(os.Environ(), "OPENCODE_CONFIG_DIR="+filepath.Join(workspacePath, ".sgai"))
+	cmd.Env = backend.BuildEnv(AgentEnvParams{Dir: workspacePath})
 	cmd.Stdin = strings.NewReader(st.promptText)
 	writer := &lockedWriter{mu: &st.mu, buf: &st.output}
 	prefix := fmt.Sprintf("[%s][adhoc:0000]", filepath.Base(workspacePath))
@@ -64,7 +74,7 @@ func (s *Server) adhocStartService(workspacePath, prompt, model string) adhocSta
 	stderrPW := &prefixWriter{prefix: prefix + " ", w: os.Stderr, startTime: time.Now()}
 	cmd.Stdout = io.MultiWriter(stdoutPW, writer)
 	cmd.Stderr = io.MultiWriter(stderrPW, writer)
-	commandLine := "$ opencode " + strings.Join(args, " ")
+	commandLine := "$ " + backend.BinaryName() + " " + strings.Join(args, " ")
 	promptLine := "prompt: " + st.promptText
 	_, _ = fmt.Fprintln(stderrPW, commandLine)
 	_, _ = fmt.Fprintln(stderrPW, promptLine)

--- a/cmd/sgai/workflow_runner.go
+++ b/cmd/sgai/workflow_runner.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -28,6 +29,7 @@ type workflowRunner struct {
 	retroLogs        retroLogWriters
 	iterationCounter int
 	previousAgent    string
+	backend          Backend
 }
 
 type retroLogWriters struct {
@@ -157,6 +159,7 @@ func (r *workflowRunner) executeAgent(ctx context.Context, currentAgent string) 
 		logWriter:        r.logWriter,
 		stdoutLog:        r.retroLogs.stdout,
 		stderrLog:        r.retroLogs.stderr,
+		backend:          r.backend,
 	}
 	return runMultiModelAgent(ctx, cfg, r.wfState, r.metadata, &r.iterationCounter)
 }
@@ -182,7 +185,7 @@ func (r *workflowRunner) runContinuous(ctx context.Context, continuousPrompt str
 			return
 		}
 
-		runContinuousModePrompt(ctx, r.dir, continuousPrompt, r.mcpURL, r.coord)
+		runContinuousModePrompt(ctx, r.dir, continuousPrompt, r.mcpURL, r.coord, r.backend)
 
 		if ctx.Err() != nil {
 			return
@@ -246,6 +249,15 @@ func buildWorkflowRunner(dir string, mcpURL string, logWriter io.Writer, session
 		log.Fatalln("failed to load sgai.json:", errConfig)
 	}
 
+	backend, errBackend := resolveBackendStrict(projectConfig)
+	if errBackend != nil {
+		log.Fatalln(errBackend)
+	}
+
+	if _, err := exec.LookPath(backend.BinaryName()); err != nil {
+		log.Fatalf("%s is required but not found in PATH", backend.BinaryName())
+	}
+
 	if errValidate := validateProjectConfig(projectConfig); errValidate != nil {
 		log.Fatalln(errValidate)
 	}
@@ -272,7 +284,7 @@ func buildWorkflowRunner(dir string, mcpURL string, logWriter io.Writer, session
 	ensureImplicitAgentModel(flowDag, &metadata, "project-critic-council")
 	ensureImplicitAgentModel(flowDag, &metadata, "retrospective")
 
-	if errModels := validateModels(metadata.Models); errModels != nil {
+	if errModels := backend.ValidateModels(metadata.Models); errModels != nil {
 		log.Fatalln(errModels)
 	}
 
@@ -361,6 +373,7 @@ func buildWorkflowRunner(dir string, mcpURL string, logWriter io.Writer, session
 		mcpURL:         mcpURL,
 		logWriter:      logWriter,
 		retroLogs:      retroLogs,
+		backend:        backend,
 	}
 	return runner, cleanup, true
 }

--- a/cmd/sgai/workflow_runner.go
+++ b/cmd/sgai/workflow_runner.go
@@ -268,7 +268,7 @@ func buildWorkflowRunner(dir string, mcpURL string, logWriter io.Writer, session
 		log.Fatalln("failed to initialize workspace directory:", errInit)
 	}
 
-	if errMCP := applyCustomMCPs(dir, projectConfig); errMCP != nil {
+	if errMCP := applyCustomMCPs(dir, projectConfig, backend); errMCP != nil {
 		log.Fatalln("failed to apply custom MCPs:", errMCP)
 	}
 


### PR DESCRIPTION
## Summary
- Add a `Backend` interface abstracting opencode vs Claude Code CLI backends, with two implementations (`opencodeBackend`, `claudeCodeBackend`)
- Wire the backend through all agent execution paths (`multiModelConfig`, `workflowRunner`, `jsonPrettyWriter`, adhoc, continuous mode)
- Add `"backend"` field to `sgai.json` config (`"opencode"` default, `"claude-code"` option)
- Handle Claude Code specifics: stream-json event parsing, `--append-system-prompt` for agent identity, `--permission-mode bypassPermissions`, `--mcp-config` injection, provider prefix stripping

## New Files
| File | Purpose |
|------|---------|
| `backend.go` | `Backend` interface + `AgentRunParams`/`AgentEnvParams` types |
| `backend_opencode.go` | opencode implementation (extracted from main.go) |
| `backend_claudecode.go` | Claude Code implementation + stream-json parser |
| `backend_claudecode_mcp.go` | MCP config generation for `--mcp-config` |
| `backend_test.go` | Integration tests for backend selection |
| `backend_opencode_test.go` | opencode backend unit tests |
| `backend_claudecode_test.go` | Claude Code backend unit tests |
| `backend_claudecode_mcp_test.go` | MCP config generation tests |

## Modified Files
| File | Change |
|------|--------|
| `config.go` | Add `Backend` field, `resolveBackend()`, guard `applyCustomMCPs` |
| `main.go` | Thread backend through `multiModelConfig`, `jsonPrettyWriter`, remove standalone functions |
| `workflow_runner.go` | Thread backend through runner, resolve at startup |
| `serve_api.go` | Use backend for adhoc execution |
| `service_adhoc.go` | Use backend for adhoc execution |
| `continuous.go` | Use backend for continuous mode |

## Usage
```json
{
  "backend": "claude-code",
  "defaultModel": "anthropic/claude-opus-4-6 (max)"
}
```
Defaults to `"opencode"` when omitted.

## Test plan
- [x] All existing tests pass (no regressions)
- [x] opencode backend tests (9 tests)
- [x] Claude Code backend tests (21 tests)
- [x] MCP config generation tests (7 tests)
- [x] Config/backend selection tests (7 tests)
- [x] Integration tests verifying both backends (15 tests)
- [x] Full suite: `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)