### PR TITLE
cmd/sgai: make retrospectives opt-in

### DIFF
--- a/cmd/sgai/compose.go
+++ b/cmd/sgai/compose.go
@@ -13,6 +13,7 @@ type composerState struct {
 	Description    string              `json:"description"`
 	CompletionGate string              `json:"completionGate"`
 	SafetyAnalysis bool                `json:"safetyAnalysis"`
+	Retrospective  bool                `json:"retrospective"`
 	Agents         []composerAgentConf `json:"agents"`
 	Flow           string              `json:"flow"`
 	Tasks          string              `json:"tasks"`
@@ -64,6 +65,7 @@ func loadComposerStateFromDisk(dir string) composerState {
 		Description:    extractDescriptionFromBody(bodyContent),
 		CompletionGate: metadata.CompletionGateScript,
 		SafetyAnalysis: bodyHasSafetyAnalysis(bodyContent) || legacySafetyAnalysis,
+		Retrospective:  retrospectiveEnabled(metadata),
 		Flow:           activeComposerFlow(metadata.Flow),
 		Tasks:          extractTasksFromBody(bodyContent),
 	}
@@ -208,6 +210,10 @@ func buildGOALContent(st composerState) string {
 		buf.WriteString("completionGateScript: ")
 		buf.WriteString(st.CompletionGate)
 		buf.WriteString("\n")
+	}
+
+	if st.Retrospective {
+		buf.WriteString("retrospective: true\n")
 	}
 
 	buf.WriteString("---\n\n")

--- a/cmd/sgai/compose_test.go
+++ b/cmd/sgai/compose_test.go
@@ -152,6 +152,7 @@ Description here.
 			validate: func(t *testing.T, state composerState) {
 				assert.Equal(t, "My Project\n\nDescription here.", state.Description)
 				assert.Equal(t, "make test", state.CompletionGate)
+				assert.False(t, state.Retrospective)
 				assert.Contains(t, state.Flow, "agent1")
 				assert.Contains(t, state.Tasks, "Task 1")
 				assert.Len(t, state.Agents, 2)
@@ -261,6 +262,21 @@ flow: |
 				assert.Len(t, state.Agents, 0)
 			},
 		},
+		{
+			name: "loadFromGOALWithRetrospectiveEnabled",
+			setupFunc: func(t *testing.T, dir string) {
+				goalContent := `---
+retrospective: true
+---
+# My Project
+`
+				goalPath := filepath.Join(dir, "GOAL.md")
+				require.NoError(t, os.WriteFile(goalPath, []byte(goalContent), 0644))
+			},
+			validate: func(t *testing.T, state composerState) {
+				assert.True(t, state.Retrospective)
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -343,6 +359,20 @@ func TestBuildGOALContent(t *testing.T) {
 				assert.NotContains(t, content, "stpa-analyst")
 				assert.NotContains(t, content, "models:")
 				assert.NotContains(t, content, "flow:")
+			},
+		},
+		{
+			name:  "buildGOALOmitsRetrospectiveByDefault",
+			state: composerState{Description: "My Project"},
+			validate: func(t *testing.T, content string) {
+				assert.NotContains(t, content, "retrospective:")
+			},
+		},
+		{
+			name:  "buildGOALIncludesRetrospectiveWhenEnabled",
+			state: composerState{Description: "My Project", Retrospective: true},
+			validate: func(t *testing.T, content string) {
+				assert.Contains(t, content, "retrospective: true")
 			},
 		},
 		{

--- a/cmd/sgai/compose_wizard.go
+++ b/cmd/sgai/compose_wizard.go
@@ -156,6 +156,7 @@ type wizardState struct {
 	Description    string
 	TechStack      []string
 	SafetyAnalysis bool
+	Retrospective  bool
 	CompletionGate string
 }
 
@@ -191,6 +192,7 @@ func syncWizardState(wizard wizardState, st composerState) wizardState {
 	if !wizard.SafetyAnalysis {
 		wizard.SafetyAnalysis = st.SafetyAnalysis
 	}
+	wizard.Retrospective = st.Retrospective
 	return wizard
 }
 

--- a/cmd/sgai/dag.go
+++ b/cmd/sgai/dag.go
@@ -201,6 +201,60 @@ func (d *dag) injectRetrospectiveEdge() {
 	slices.Sort(coordNode.Successors)
 }
 
+func (d *dag) removeRetrospective() {
+	retrospectiveNode, exists := d.Nodes["retrospective"]
+	if !exists {
+		return
+	}
+	for _, predecessor := range retrospectiveNode.Predecessors {
+		if predecessor == "retrospective" {
+			continue
+		}
+		predecessorNode := d.Nodes[predecessor]
+		if predecessorNode == nil {
+			continue
+		}
+		for _, successor := range retrospectiveNode.Successors {
+			if successor == "retrospective" || successor == predecessor {
+				continue
+			}
+			successorNode := d.Nodes[successor]
+			if successorNode == nil {
+				continue
+			}
+			if !slices.Contains(predecessorNode.Successors, successor) {
+				predecessorNode.Successors = append(predecessorNode.Successors, successor)
+			}
+			if !slices.Contains(successorNode.Predecessors, predecessor) {
+				successorNode.Predecessors = append(successorNode.Predecessors, predecessor)
+			}
+		}
+		slices.Sort(predecessorNode.Successors)
+	}
+	delete(d.Nodes, "retrospective")
+	for _, node := range d.Nodes {
+		node.Predecessors = slices.DeleteFunc(node.Predecessors, func(agent string) bool {
+			return agent == "retrospective"
+		})
+		node.Successors = slices.DeleteFunc(node.Successors, func(agent string) bool {
+			return agent == "retrospective"
+		})
+	}
+	d.recomputeEntryNodes()
+	d.injectCoordinatorEdges()
+}
+
+func (d *dag) recomputeEntryNodes() {
+	d.EntryNodes = d.EntryNodes[:0]
+	for name, node := range d.Nodes {
+		if len(node.Predecessors) == 0 {
+			d.EntryNodes = append(d.EntryNodes, name)
+		}
+	}
+	slices.Sort(d.EntryNodes)
+	d.parsedEntryNodes = slices.Clone(d.EntryNodes)
+}
+
 func (d *dag) detectCycles() error {
 	visited := make(map[string]bool)
 	recStack := make(map[string]bool)

--- a/cmd/sgai/dag_test.go
+++ b/cmd/sgai/dag_test.go
@@ -313,6 +313,49 @@ func TestDagInjectCoordinatorEdges(t *testing.T) {
 	}
 }
 
+func TestDagRemoveRetrospective(t *testing.T) {
+	t.Run("bypassesRetrospectiveBetweenAgents", func(t *testing.T) {
+		d := &dag{
+			Nodes: map[string]*dagNode{
+				"coordinator":   {Name: "coordinator", Successors: []string{"worker"}},
+				"worker":        {Name: "worker", Predecessors: []string{"coordinator"}, Successors: []string{"retrospective"}},
+				"retrospective": {Name: "retrospective", Predecessors: []string{"worker"}, Successors: []string{"deployer"}},
+				"deployer":      {Name: "deployer", Predecessors: []string{"retrospective"}},
+			},
+			EntryNodes:       []string{"coordinator"},
+			parsedEntryNodes: []string{"coordinator"},
+		}
+
+		d.removeRetrospective()
+
+		assert.NotContains(t, d.Nodes, "retrospective")
+		assert.Equal(t, []string{"deployer"}, d.Nodes["worker"].Successors)
+		assert.Equal(t, []string{"worker"}, d.Nodes["deployer"].Predecessors)
+		assert.Equal(t, []string{"coordinator"}, d.EntryNodes)
+		assert.Equal(t, []string{"coordinator"}, d.parsedEntryNodes)
+	})
+
+	t.Run("recomputesNewEntryNodes", func(t *testing.T) {
+		d := &dag{
+			Nodes: map[string]*dagNode{
+				"coordinator":   {Name: "coordinator", Successors: []string{"retrospective"}},
+				"retrospective": {Name: "retrospective", Predecessors: []string{"coordinator"}, Successors: []string{"worker"}},
+				"worker":        {Name: "worker", Predecessors: []string{"retrospective"}},
+			},
+			EntryNodes:       []string{"coordinator"},
+			parsedEntryNodes: []string{"coordinator"},
+		}
+
+		d.removeRetrospective()
+
+		assert.NotContains(t, d.Nodes, "retrospective")
+		assert.Equal(t, []string{"worker"}, d.Nodes["coordinator"].Successors)
+		assert.Equal(t, []string{"coordinator"}, d.Nodes["worker"].Predecessors)
+		assert.Equal(t, []string{"coordinator"}, d.EntryNodes)
+		assert.Equal(t, []string{"coordinator"}, d.parsedEntryNodes)
+	})
+}
+
 func TestDagDetectCycles(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/cmd/sgai/main.go
+++ b/cmd/sgai/main.go
@@ -1203,6 +1203,10 @@ func generateRetrospectiveDirName() string {
 }
 
 func openRetrospectiveLogs(retrospectiveDir string) (io.WriteCloser, io.WriteCloser, error) {
+	if retrospectiveDir == "" {
+		return nil, nil, nil
+	}
+
 	stdoutLogPath := filepath.Join(retrospectiveDir, "stdout.log")
 	stderrLogPath := filepath.Join(retrospectiveDir, "stderr.log")
 
@@ -1845,9 +1849,9 @@ func isExistingDirectory(path string) bool {
 	return fi.IsDir()
 }
 
-func isFalsish(s string) bool {
+func isTruthy(s string) bool {
 	switch strings.ToLower(strings.TrimSpace(s)) {
-	case "no", "false", "0", "off":
+	case "yes", "true", "1", "on":
 		return true
 	default:
 		return false
@@ -1855,5 +1859,5 @@ func isFalsish(s string) bool {
 }
 
 func retrospectiveEnabled(metadata GoalMetadata) bool {
-	return !isFalsish(metadata.Retrospective)
+	return isTruthy(metadata.Retrospective)
 }

--- a/cmd/sgai/main_test.go
+++ b/cmd/sgai/main_test.go
@@ -442,7 +442,7 @@ func TestHandleCompleteStatus(t *testing.T) {
 		newState := state.Workflow{Status: state.StatusComplete, VisitCounts: map[string]int{}}
 		wfState := state.Workflow{}
 
-		result := handleCompleteStatus(t.Context(), cfg, newState, wfState, GoalMetadata{})
+		result := handleCompleteStatus(t.Context(), cfg, newState, wfState, GoalMetadata{Retrospective: "true"})
 		assert.Equal(t, state.StatusAgentDone, result.Status)
 	})
 }
@@ -606,19 +606,50 @@ func TestFormatDurationVariants(t *testing.T) {
 	assert.Equal(t, "135m 0s", formatDuration(2*time.Hour+15*time.Minute))
 }
 
-func TestIsFalsishVariants(t *testing.T) {
-	assert.True(t, isFalsish("false"))
-	assert.True(t, isFalsish("no"))
-	assert.True(t, isFalsish("0"))
-	assert.True(t, isFalsish("FALSE"))
-	assert.False(t, isFalsish("true"))
-	assert.False(t, isFalsish("yes"))
+func TestRetrospectiveEnabledVariants(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{"absent", "", false},
+		{"empty", "   ", false},
+		{"false", "false", false},
+		{"no", "no", false},
+		{"off", "off", false},
+		{"zero", "0", false},
+		{"true", "true", true},
+		{"yes", "yes", true},
+		{"on", "on", true},
+		{"one", "1", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, retrospectiveEnabled(GoalMetadata{Retrospective: tt.in}))
+		})
+	}
 }
 
-func TestRetrospectiveEnabledVariants(t *testing.T) {
-	assert.True(t, retrospectiveEnabled(GoalMetadata{}))
-	assert.False(t, retrospectiveEnabled(GoalMetadata{Retrospective: "false"}))
-	assert.True(t, retrospectiveEnabled(GoalMetadata{Retrospective: "true"}))
+func TestBlockCompletionOnRetrospectiveDefaultDisabled(t *testing.T) {
+	dir := t.TempDir()
+	coord, errCoord := state.NewCoordinatorWith(filepath.Join(dir, ".sgai", "state.json"), state.Workflow{})
+	require.NoError(t, errCoord)
+	cfg := multiModelConfig{
+		dir:        dir,
+		agent:      "coordinator",
+		flowDag:    buildTestDag(map[string][]string{"coordinator": {"retrospective"}}, []string{"coordinator"}),
+		coord:      coord,
+		paddedsgai: "test",
+	}
+	wfState := state.Workflow{
+		Status:      state.StatusComplete,
+		VisitCounts: map[string]int{"coordinator": 1},
+	}
+
+	blocked := blockCompletionOnRetrospective(cfg, wfState, GoalMetadata{})
+
+	assert.Nil(t, blocked)
 }
 
 func TestFormatElapsedOutput(t *testing.T) {
@@ -1006,6 +1037,30 @@ retrospective: "true"
 				assert.Equal(t, "true", m.Retrospective)
 			},
 		},
+		{
+			name: "withUnquotedRetrospectiveTrue",
+			content: `---
+flow: "test"
+retrospective: true
+---
+# Goal`,
+			wantErr: false,
+			validate: func(t *testing.T, m GoalMetadata) {
+				assert.True(t, retrospectiveEnabled(m))
+			},
+		},
+		{
+			name: "withEmptyRetrospective",
+			content: `---
+flow: "test"
+retrospective:
+---
+# Goal`,
+			wantErr: false,
+			validate: func(t *testing.T, m GoalMetadata) {
+				assert.False(t, retrospectiveEnabled(m))
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -1047,7 +1102,7 @@ func TestRetrospectiveEnabled(t *testing.T) {
 		{
 			name:     "emptyString",
 			metadata: GoalMetadata{Retrospective: ""},
-			expected: true,
+			expected: false,
 		},
 		{
 			name:     "yesString",
@@ -2748,72 +2803,6 @@ func TestFormatToolCall(t *testing.T) {
 			} else {
 				assert.Equal(t, tt.expected, result)
 			}
-		})
-	}
-}
-
-func TestIsFalsish(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    string
-		expected bool
-	}{
-		{
-			name:     "no",
-			input:    "no",
-			expected: true,
-		},
-		{
-			name:     "false",
-			input:    "false",
-			expected: true,
-		},
-		{
-			name:     "zero",
-			input:    "0",
-			expected: true,
-		},
-		{
-			name:     "off",
-			input:    "off",
-			expected: true,
-		},
-		{
-			name:     "yes",
-			input:    "yes",
-			expected: false,
-		},
-		{
-			name:     "true",
-			input:    "true",
-			expected: false,
-		},
-		{
-			name:     "one",
-			input:    "1",
-			expected: false,
-		},
-		{
-			name:     "empty",
-			input:    "",
-			expected: false,
-		},
-		{
-			name:     "uppercaseFalse",
-			input:    "FALSE",
-			expected: true,
-		},
-		{
-			name:     "spacedFalse",
-			input:    " false ",
-			expected: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := isFalsish(tt.input)
-			assert.Equal(t, tt.expected, result)
 		})
 	}
 }

--- a/cmd/sgai/prompt_registry.go
+++ b/cmd/sgai/prompt_registry.go
@@ -62,15 +62,12 @@ You are running in Building mode. The brainstorming and work-gate phases are com
 - Skip the BRAINSTORMING step entirely - it is already done
 - Skip the WORK-GATE step entirely - it is already approved
 - Do NOT use ask_user_question or ask_user_work_gate during the building phase
-- The retrospective phase is STILL ACTIVE — you must run it when all work is complete
-- During the retrospective, the system will re-enable human interaction tools automatically
+- If GOAL.md enables retrospective with retrospective: true, the system will route to the retrospective agent before completion
 `
 
-const flowSectionBuildingModeCoordinator = `- Your master plan: read GOAL.md → delegate to agents → verify with project-critic → run retrospective → complete
+const flowSectionBuildingModeCoordinator = `- Your master plan: read GOAL.md → delegate to agents → verify with project-critic → complete
 - When delegated work is done, invoke the project-critic wrapper subagent to verify all GOAL.md checkboxes are genuinely complete
-- After project-critic approves, send a message to the retrospective agent to start analysis
-- IMPORTANT: The retrospective step is MANDATORY. You MUST send a message to the retrospective agent and wait for RETRO_COMPLETE before marking complete
-- Do NOT mark status:complete until the retrospective has finished
+- If GOAL.md enables retrospective with retrospective: true, wait for the system's retrospective routing before final completion
 `
 
 const flowSectionRetrospectiveMode = `# RETROSPECTIVE MODE ACTIVE
@@ -78,7 +75,7 @@ You are running in Retrospective mode. The building phase is complete.
 - Human interaction tools (ask_user_question) are re-enabled
 - If you are the retrospective agent: analyze session artifacts and send RETRO_QUESTION messages to coordinator
 - If you are the coordinator: you MUST relay RETRO_QUESTION messages to the human using ask_user_question, then send the human's answer back to the retrospective agent
-- Do NOT skip the retrospective - it is a mandatory step
+- This phase runs only when GOAL.md explicitly opts in with retrospective: true
 `
 
 const flowSectionRetrospectiveModeCoordinator = `- You are in the RETRO_QUESTION relay phase

--- a/cmd/sgai/prompt_registry_test.go
+++ b/cmd/sgai/prompt_registry_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/sandgardenhq/sgai/pkg/state"
@@ -63,6 +65,50 @@ func TestModeSectionForMode(t *testing.T) {
 			} else {
 				assert.Empty(t, coordPlan)
 			}
+		})
+	}
+}
+
+func TestCoordinatorPromptsSayRetrospectiveIsOptIn(t *testing.T) {
+	paths := []string{
+		filepath.Join("skel", ".sgai", "agent", "coordinator.md"),
+	}
+
+	for _, path := range paths {
+		t.Run(path, func(t *testing.T) {
+			content, errRead := os.ReadFile(path)
+			assert.NoError(t, errRead)
+
+			prompt := string(content)
+			assert.NotContains(t, prompt, "default: enabled when absent or truish")
+			assert.Contains(t, prompt, "default: disabled when absent or empty")
+		})
+	}
+}
+
+func TestBuildingModePromptDoesNotSayRetrospectiveIsMandatory(t *testing.T) {
+	_, coordPlan := modeSectionForMode(state.ModeBuilding)
+
+	assert.NotContains(t, coordPlan, "retrospective step is MANDATORY")
+	assert.NotContains(t, coordPlan, "Do NOT mark status:complete until the retrospective has finished")
+}
+
+func TestModePromptsDoNotPresentRetrospectiveAsMandatory(t *testing.T) {
+	tests := []struct {
+		name string
+		mode string
+	}{
+		{name: "building", mode: state.ModeBuilding},
+		{name: "retrospective", mode: state.ModeRetrospective},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			modeSection, coordPlan := modeSectionForMode(tt.mode)
+			prompt := modeSection + "\n" + coordPlan
+
+			assert.NotContains(t, prompt, "mandatory")
+			assert.NotContains(t, prompt, "Do NOT skip the retrospective")
 		})
 	}
 }

--- a/cmd/sgai/serve_api.go
+++ b/cmd/sgai/serve_api.go
@@ -1476,6 +1476,7 @@ type apiWizardState struct {
 	Description    string   `json:"description,omitempty"`
 	TechStack      []string `json:"techStack"`
 	SafetyAnalysis bool     `json:"safetyAnalysis"`
+	Retrospective  bool     `json:"retrospective"`
 	CompletionGate string   `json:"completionGate,omitempty"`
 }
 

--- a/cmd/sgai/serve_api_test.go
+++ b/cmd/sgai/serve_api_test.go
@@ -3594,12 +3594,13 @@ func TestHandleAPIComposeStateFull(t *testing.T) {
 	cs := srv.getComposerSession(wsDir)
 	cs.mu.Lock()
 	cs.state.Description = "test"
+	cs.state.Retrospective = true
 	cs.state.Agents = []composerAgentConf{
 		{Name: "coordinator", Selected: true, Model: "openai/gpt-5.5"},
 	}
 	cs.state.Flow = `digraph G { "coordinator" -> "builder" }`
 	cs.state.CompletionGate = "make test"
-	cs.wizard = wizardState{TechStack: []string{"go", "react"}}
+	cs.wizard = wizardState{TechStack: []string{"go", "react"}, Retrospective: true}
 	cs.mu.Unlock()
 
 	w := serveHTTP(srv, "GET", "/api/v1/compose?workspace=compose-full", "")
@@ -3608,7 +3609,32 @@ func TestHandleAPIComposeStateFull(t *testing.T) {
 	var resp apiComposeStateResponse
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 	assert.Equal(t, "test", resp.State.Description)
+	assert.True(t, resp.State.Retrospective)
+	assert.True(t, resp.Wizard.Retrospective)
 	assert.NotEmpty(t, resp.TechStackItems)
+}
+
+func TestHandleAPIComposeDraftPreviewAndSaveRetrospective(t *testing.T) {
+	srv, rootDir := setupTestServer(t)
+	wsDir := setupTestWorkspace(t, rootDir, "compose-retro")
+	goalPath := filepath.Join(wsDir, "GOAL.md")
+	require.NoError(t, os.WriteFile(goalPath, []byte("# Goal"), 0o644))
+
+	draftBody := `{"state":{"description":"Retro project","retrospective":true},"wizard":{"currentStep":4,"techStack":[],"retrospective":true}}`
+	wDraft := serveHTTP(srv, "POST", "/api/v1/compose/draft?workspace=compose-retro", draftBody)
+	assert.Equal(t, http.StatusOK, wDraft.Code)
+
+	wPreview := serveHTTP(srv, "GET", "/api/v1/compose/preview?workspace=compose-retro", "")
+	assert.Equal(t, http.StatusOK, wPreview.Code)
+	var preview apiComposePreviewResponse
+	require.NoError(t, json.Unmarshal(wPreview.Body.Bytes(), &preview))
+	assert.Contains(t, preview.Content, "retrospective: true")
+
+	wSave := serveHTTP(srv, "POST", "/api/v1/compose?workspace=compose-retro", "")
+	assert.Equal(t, http.StatusCreated, wSave.Code)
+	saved, errRead := os.ReadFile(goalPath)
+	require.NoError(t, errRead)
+	assert.Contains(t, string(saved), "retrospective: true")
 }
 
 func TestHandleAPIComposeStateFullContent(t *testing.T) {

--- a/cmd/sgai/service_compose_test.go
+++ b/cmd/sgai/service_compose_test.go
@@ -123,11 +123,13 @@ func TestComposeDraftService(t *testing.T) {
 	wsDir := setupTestWorkspace(t, rootDir, "test-ws")
 
 	result := server.composeDraftService(wsDir, composerState{
-		Description: "Test description",
-		Tasks:       "Test tasks",
+		Description:   "Test description",
+		Tasks:         "Test tasks",
+		Retrospective: true,
 	}, wizardState{})
 	assert.True(t, result.Saved)
 
 	stateResult := server.composeStateService(wsDir)
 	assert.Equal(t, "Test description", stateResult.State.Description)
+	assert.True(t, stateResult.State.Retrospective)
 }

--- a/cmd/sgai/skel/.sgai/agent/coordinator.md
+++ b/cmd/sgai/skel/.sgai/agent/coordinator.md
@@ -344,8 +344,8 @@ sgai_update_workflow_state({status: "agent-done"})
 - Step Name: RUN-RETROSPECTIVE
   BEFORE transitioning to the retrospective phase, the coordinator must verify that all pending inter-agent messages have been processed. Unread messages represent incomplete work (e.g., re-review requests, status updates) that would be orphaned at session end. Call `sgai_check_inbox()` and process any remaining messages before proceeding.
   BEFORE marking the workflow as complete, check if retrospective should run:
-  1. Check GOAL.md frontmatter for `retrospective:` key (default: enabled when absent or truish)
-  2. If disabled (falsish value like "no", "false", "off", "0"), skip to MARK-COMPLETE
+  1. Check GOAL.md frontmatter for `retrospective:` key (default: disabled when absent or empty)
+  2. If disabled (absent, empty, or falsish value like "no", "false", "off", "0"), skip to MARK-COMPLETE
   3. If enabled AND the session is running in interactive mode:
      - Send a message to the retrospective agent asking it to start its analysis:
        ```

--- a/cmd/sgai/webapp/src/components/ui/__tests__/Switch.test.tsx
+++ b/cmd/sgai/webapp/src/components/ui/__tests__/Switch.test.tsx
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Switch } from "../switch";
+
+describe("Switch", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("exposes Radix switch state attributes while toggling", async () => {
+    const user = userEvent.setup();
+    let checked = false;
+
+    const { rerender } = render(
+      <Switch
+        aria-label="Enable option"
+        checked={checked}
+        onCheckedChange={(nextChecked) => {
+          checked = nextChecked;
+        }}
+      />,
+    );
+
+    const toggle = screen.getByRole("switch", { name: "Enable option" });
+    expect(toggle.getAttribute("data-state")).toBe("unchecked");
+
+    await user.click(toggle);
+    rerender(
+      <Switch
+        aria-label="Enable option"
+        checked={checked}
+        onCheckedChange={(nextChecked) => {
+          checked = nextChecked;
+        }}
+      />,
+    );
+
+    expect(toggle.getAttribute("data-state")).toBe("checked");
+  });
+});

--- a/cmd/sgai/webapp/src/components/ui/switch.tsx
+++ b/cmd/sgai/webapp/src/components/ui/switch.tsx
@@ -1,38 +1,27 @@
 import * as React from "react"
+import { Switch as SwitchPrimitive } from "radix-ui"
 
 import { cn } from "@/lib/utils"
 
-interface SwitchProps extends Omit<React.ComponentProps<"button">, "onChange"> {
-  checked?: boolean
-  onCheckedChange?: (checked: boolean) => void
-}
-
-function Switch({ className, checked = false, onCheckedChange, disabled, ...props }: SwitchProps) {
+function Switch({ className, ...props }: React.ComponentProps<typeof SwitchPrimitive.Root>) {
   return (
-    <button
+    <SwitchPrimitive.Root
       data-slot="switch"
-      type="button"
-      role="switch"
-      aria-checked={checked}
-      disabled={disabled}
-      onClick={() => onCheckedChange?.(!checked)}
       className={cn(
-        "peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent shadow-sm transition-colors",
+        "peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent shadow-sm transition-colors data-[state=checked]:bg-primary data-[state=unchecked]:bg-input",
         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
         "disabled:cursor-not-allowed disabled:opacity-50",
-        checked ? "bg-primary" : "bg-input",
         className
       )}
       {...props}
     >
-      <span
+      <SwitchPrimitive.Thumb
         data-slot="switch-thumb"
         className={cn(
-          "pointer-events-none block size-4 rounded-full bg-background shadow-lg ring-0 transition-transform",
-          checked ? "translate-x-4" : "translate-x-0"
+          "pointer-events-none block size-4 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0"
         )}
       />
-    </button>
+    </SwitchPrimitive.Root>
   )
 }
 

--- a/cmd/sgai/webapp/src/hooks/__tests__/useComposeWizard.test.tsx
+++ b/cmd/sgai/webapp/src/hooks/__tests__/useComposeWizard.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "bun:test";
+import { loadStepFromStorage, saveStepToStorage, type WizardStepData } from "../useComposeWizard";
+import type { ApiComposeDraftRequest } from "@/types";
+
+function createMemoryStorage(initial: Record<string, string> = {}) {
+  const values = new Map(Object.entries(initial));
+  return {
+    getItem: (key: string) => values.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      values.set(key, value);
+    },
+    read: (key: string) => values.get(key),
+  };
+}
+
+describe("useComposeWizard retrospective state helpers", () => {
+  it("loads step 4 retrospective from session storage", () => {
+    const storage = createMemoryStorage({
+      "compose-wizard-step-4": JSON.stringify({
+        completionGate: "make test",
+        retrospective: true,
+      }),
+    });
+
+    const result = loadStepFromStorage(4, storage);
+
+    expect(result.error).toBeNull();
+    expect(result.data).toEqual({
+      completionGate: "make test",
+      retrospective: true,
+    });
+  });
+
+  it("saves step 4 retrospective to session storage", () => {
+    const storage = createMemoryStorage();
+
+    const error = saveStepToStorage(4, {
+      completionGate: "make test",
+      retrospective: true,
+    }, storage);
+
+    expect(error).toBeNull();
+    expect(JSON.parse(storage.read("compose-wizard-step-4") ?? "{}")).toEqual({
+      completionGate: "make test",
+      retrospective: true,
+    });
+  });
+
+  it("requires compose draft payloads to carry retrospective on state and wizard", () => {
+    const wizardData: WizardStepData = {
+      description: "Build a thing",
+      techStack: ["react"],
+      safetyAnalysis: false,
+      completionGate: "",
+      retrospective: true,
+    };
+
+    const draft: ApiComposeDraftRequest = {
+      state: {
+        description: wizardData.description,
+        completionGate: wizardData.completionGate,
+        retrospective: wizardData.retrospective,
+        agents: [],
+        flow: "",
+        tasks: "",
+      },
+      wizard: {
+        currentStep: 4,
+        description: wizardData.description,
+        techStack: wizardData.techStack,
+        safetyAnalysis: wizardData.safetyAnalysis,
+        completionGate: wizardData.completionGate,
+        retrospective: wizardData.retrospective,
+      },
+    };
+
+    expect(draft.state.retrospective).toBe(true);
+    expect(draft.wizard.retrospective).toBe(true);
+  });
+});

--- a/cmd/sgai/webapp/src/hooks/useComposeWizard.ts
+++ b/cmd/sgai/webapp/src/hooks/useComposeWizard.ts
@@ -13,11 +13,12 @@ const STORAGE_KEY_PREFIX = "compose-wizard-step-";
 const AUTO_SAVE_INTERVAL_MS = 30_000;
 const WIZARD_STEPS = [1, 2, 3, 4] as const;
 
-interface WizardStepData {
+export interface WizardStepData {
   description: string;
   techStack: string[];
   safetyAnalysis: boolean;
   completionGate: string;
+  retrospective: boolean;
 }
 
 interface StorageLoadResult {
@@ -54,15 +55,19 @@ function validateStoredStepData(
         ? { safetyAnalysis: candidate.safetyAnalysis }
         : null;
     case 4:
-      return typeof candidate.completionGate === "string"
-        ? { completionGate: candidate.completionGate }
+      return typeof candidate.completionGate === "string" &&
+        (candidate.retrospective === undefined || typeof candidate.retrospective === "boolean")
+        ? {
+            completionGate: candidate.completionGate,
+            retrospective: candidate.retrospective ?? false,
+          }
         : null;
     default:
       return null;
   }
 }
 
-function loadStepFromStorage(
+export function loadStepFromStorage(
   step: number,
   storage: Pick<Storage, "getItem"> = sessionStorage,
 ): StorageLoadResult {
@@ -103,7 +108,7 @@ function loadStepFromStorage(
   return { data: validated, error: null };
 }
 
-function saveStepToStorage(
+export function saveStepToStorage(
   step: number,
   data: Partial<WizardStepData>,
   storage: Pick<Storage, "setItem"> = sessionStorage,
@@ -138,6 +143,7 @@ function buildWizardStateFromData(data: WizardStepData, step: number): ApiWizard
     techStack: data.techStack,
     safetyAnalysis: data.safetyAnalysis,
     completionGate: data.completionGate,
+    retrospective: data.retrospective,
   };
 }
 
@@ -248,6 +254,7 @@ function buildComposerStateFromData(
   return {
     description: data.description,
     completionGate: data.completionGate,
+    retrospective: data.retrospective,
     agents: sanitizeComposerAgents(hasUserAgents ? agents : (serverState?.agents ?? [])),
     flow: sanitizeComposerFlow(hasUserAgents ? flow : (serverState?.flow ?? "")),
     tasks: serverState?.tasks ?? "",
@@ -310,6 +317,7 @@ function serializeWizardData(data: WizardStepData): string {
     techStack: data.techStack,
     safetyAnalysis: data.safetyAnalysis,
     completionGate: data.completionGate,
+    retrospective: data.retrospective,
   });
 }
 
@@ -318,6 +326,7 @@ const DEFAULT_WIZARD_DATA: WizardStepData = {
   techStack: [],
   safetyAnalysis: false,
   completionGate: "",
+  retrospective: false,
 };
 
 interface ComposeWizardState {
@@ -383,6 +392,7 @@ export function useComposeWizard({
           techStack: stateResp.wizard.techStack ?? [],
           safetyAnalysis: stateResp.wizard.safetyAnalysis ?? false,
           completionGate: stateResp.wizard.completionGate ?? stateResp.state.completionGate ?? "",
+          retrospective: stateResp.wizard.retrospective ?? stateResp.state.retrospective ?? false,
         };
 
         // Override with any sessionStorage persisted data per step (R-14)
@@ -408,6 +418,9 @@ export function useComposeWizard({
             if (step === 4) {
               if (storedStep.completionGate !== undefined) {
                 merged.completionGate = storedStep.completionGate;
+              }
+              if (storedStep.retrospective !== undefined) {
+                merged.retrospective = storedStep.retrospective;
               }
             }
           }
@@ -466,6 +479,7 @@ export function useComposeWizard({
       case 4:
         storageError = saveStepToStorage(4, {
           completionGate: wizardData.completionGate,
+          retrospective: wizardData.retrospective,
         });
         break;
     }

--- a/cmd/sgai/webapp/src/pages/ComposeTemplate.tsx
+++ b/cmd/sgai/webapp/src/pages/ComposeTemplate.tsx
@@ -83,6 +83,7 @@ function buildDraftRequest(template: ApiComposeTemplateEntry) {
     state: {
       description: "",
       completionGate: "",
+      retrospective: false,
       agents: template.agents,
       flow: template.flow,
       tasks: "",
@@ -94,6 +95,7 @@ function buildDraftRequest(template: ApiComposeTemplateEntry) {
       techStack: [],
       safetyAnalysis: false,
       completionGate: "",
+      retrospective: false,
     },
   };
 }

--- a/cmd/sgai/webapp/src/pages/WizardFinish.tsx
+++ b/cmd/sgai/webapp/src/pages/WizardFinish.tsx
@@ -17,6 +17,7 @@ import {
   Users,
   ShieldCheck,
   Terminal,
+  History,
   CheckCircle2,
   AlertTriangle,
   Loader2,
@@ -65,6 +66,10 @@ export function WizardFinish() {
     if (selectedTechIDs.has(item.id)) {
       selectedTechNames.push(item.name);
     }
+  }
+
+  if (!workspace) {
+    return <MissingWorkspaceNotice />;
   }
 
   if (!workspace) {
@@ -194,6 +199,18 @@ export function WizardFinish() {
               </CardContent>
             </Card>
           ) : null}
+
+          <Card className="py-3">
+            <CardContent className="flex items-start gap-3 px-4 py-0">
+              <History className="size-5 text-muted-foreground mt-0.5 flex-shrink-0" />
+              <div className="min-w-0 flex-1">
+                <div className="text-xs text-muted-foreground mb-1">Retrospective</div>
+                <div className="font-semibold text-sm">
+                  {wizardData.retrospective ? "Enabled" : "Disabled"}
+                </div>
+              </div>
+            </CardContent>
+          </Card>
 
           {/* Draft saved indicator */}
           {draftSavedAt ? (

--- a/cmd/sgai/webapp/src/pages/WizardStep1.tsx
+++ b/cmd/sgai/webapp/src/pages/WizardStep1.tsx
@@ -43,6 +43,10 @@ export function WizardStep1() {
     return <MissingWorkspaceNotice />;
   }
 
+  if (!workspace) {
+    return <MissingWorkspaceNotice />;
+  }
+
   if (isLoading) {
     return (
       <div className="space-y-4 p-4">

--- a/cmd/sgai/webapp/src/pages/WizardStep2.tsx
+++ b/cmd/sgai/webapp/src/pages/WizardStep2.tsx
@@ -51,6 +51,10 @@ export function WizardStep2() {
     return <MissingWorkspaceNotice />;
   }
 
+  if (!workspace) {
+    return <MissingWorkspaceNotice />;
+  }
+
   if (isLoading) {
     return (
       <div className="space-y-4 p-4">

--- a/cmd/sgai/webapp/src/pages/WizardStep3.tsx
+++ b/cmd/sgai/webapp/src/pages/WizardStep3.tsx
@@ -48,6 +48,10 @@ export function WizardStep3() {
     return <MissingWorkspaceNotice />;
   }
 
+  if (!workspace) {
+    return <MissingWorkspaceNotice />;
+  }
+
   if (isLoading) {
     return (
       <div className="space-y-4 p-4">

--- a/cmd/sgai/webapp/src/pages/WizardStep4.tsx
+++ b/cmd/sgai/webapp/src/pages/WizardStep4.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect } from "react";
 import { useSearchParams } from "react-router";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
 import { Skeleton } from "@/components/ui/skeleton";
 import { WizardLayout } from "@/components/WizardLayout";
 import { useComposeWizard } from "@/hooks/useComposeWizard";
@@ -30,6 +31,13 @@ export function WizardStep4() {
     [setWizardData],
   );
 
+  const handleRetrospectiveChange = useCallback(
+    (checked: boolean) => {
+      setWizardData((prev) => ({ ...prev, retrospective: checked }));
+    },
+    [setWizardData],
+  );
+
   // Update preview when settings change
   useEffect(() => {
     if (!workspace || isLoading) return;
@@ -37,7 +45,7 @@ export function WizardStep4() {
       fetchPreview();
     }, 500);
     return () => clearTimeout(timer);
-  }, [workspace, wizardData.completionGate, isLoading, fetchPreview]);
+  }, [workspace, wizardData.completionGate, wizardData.retrospective, isLoading, fetchPreview]);
 
   if (!workspace) {
     return <MissingWorkspaceNotice />;
@@ -82,6 +90,21 @@ export function WizardStep4() {
             <p className="text-xs text-muted-foreground">
               A command that must pass before the workflow is considered complete (optional)
             </p>
+          </div>
+
+          <div className="flex items-start justify-between gap-4 rounded-lg border p-4">
+            <div className="space-y-1">
+              <Label htmlFor="retrospective">Run a retrospective after completion</Label>
+              <p id="retrospective-help" className="text-xs text-muted-foreground">
+                Capture lessons and factory improvements after the build finishes. Optional and off by default.
+              </p>
+            </div>
+            <Switch
+              id="retrospective"
+              checked={wizardData.retrospective}
+              onCheckedChange={handleRetrospectiveChange}
+              aria-describedby="retrospective-help"
+            />
           </div>
         </div>
       </div>

--- a/cmd/sgai/webapp/src/pages/__tests__/WizardStep4.test.tsx
+++ b/cmd/sgai/webapp/src/pages/__tests__/WizardStep4.test.tsx
@@ -1,0 +1,296 @@
+import { describe, it, expect, beforeEach, afterEach, mock, spyOn } from "bun:test";
+import { cleanup, render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Link, MemoryRouter, Route, Routes } from "react-router";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import type { ApiComposeDraftRequest } from "@/types";
+
+let savedDraft: ApiComposeDraftRequest | null = null;
+const saveDraftCalls: ApiComposeDraftRequest[] = [];
+
+const defaultDraft: ApiComposeDraftRequest = {
+  state: {
+    description: "",
+    completionGate: "",
+    retrospective: false,
+    agents: [],
+    flow: "",
+    tasks: "",
+  },
+  wizard: {
+    currentStep: 4,
+    description: "",
+    techStack: [],
+    safetyAnalysis: false,
+    completionGate: "",
+    retrospective: false,
+  },
+};
+
+const mockGet = mock(() => Promise.resolve({
+  workspace: "demo",
+  state: savedDraft?.state ?? defaultDraft.state,
+  wizard: savedDraft?.wizard ?? defaultDraft.wizard,
+  techStackItems: [],
+}));
+
+const mockPreview = mock(() => Promise.resolve({
+  content: savedDraft?.state.retrospective
+    ? "---\nretrospective: true\n---\n# GOAL"
+    : "---\n---\n# GOAL",
+  etag: "etag-1",
+}));
+
+const mockSaveDraft = mock((_workspace: string, draft: ApiComposeDraftRequest) => {
+  savedDraft = draft;
+  saveDraftCalls.push(draft);
+  return Promise.resolve({ saved: true });
+});
+
+const mockSaveGoal = mock(() => Promise.resolve({ saved: true, workspace: "demo" }));
+
+mock.module("@/lib/api", () => ({
+  api: {
+    compose: {
+      get: mockGet,
+      preview: mockPreview,
+      saveDraft: mockSaveDraft,
+      save: mockSaveGoal,
+    },
+  },
+  ApiError: class ApiError extends Error {
+    constructor(public status: number, message: string) {
+      super(message);
+      this.name = "ApiError";
+    }
+  },
+}));
+
+mock.module("@/components/MarkdownEditor", () => ({
+  MarkdownEditor: ({ value, onChange }: { value: string; onChange: (value: string | undefined) => void }) => (
+    <textarea
+      aria-label="Project Description"
+      value={value}
+      onChange={(event) => onChange(event.currentTarget.value)}
+    />
+  ),
+}));
+
+const { WizardStep1 } = await import("../WizardStep1");
+const { WizardStep2 } = await import("../WizardStep2");
+const { WizardStep3 } = await import("../WizardStep3");
+const { WizardStep4 } = await import("../WizardStep4");
+const { WizardFinish } = await import("../WizardFinish");
+
+const hookOrderErrorPattern = /change in the order of Hooks|Rendered more hooks|Rendered fewer hooks/i;
+
+function renderStep4() {
+  return render(
+    <MemoryRouter initialEntries={["/compose/step/4?workspace=demo"]}>
+      <Routes>
+        <Route path="/compose/step/4" element={<WizardStep4 />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+function renderStep4WithRouteToggle() {
+  return render(
+    <MemoryRouter initialEntries={["/compose/step/4"]}>
+      <Link to="/compose/step/4?workspace=demo">Open workspace settings</Link>
+      <Routes>
+        <Route path="/compose/step/4" element={<WizardStep4 />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+function renderWizardPageWithRouteToggle(path: string, element: React.ReactNode, linkLabel: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <TooltipProvider>
+        <Link to={`${path}?workspace=demo`}>{linkLabel}</Link>
+        <Routes>
+          <Route path={path} element={element} />
+        </Routes>
+      </TooltipProvider>
+    </MemoryRouter>,
+  );
+}
+
+function renderFinish() {
+  return render(
+    <MemoryRouter initialEntries={["/compose/finish?workspace=demo"]}>
+      <Routes>
+        <Route path="/compose/finish" element={<WizardFinish />} />
+        <Route path="/workspaces/:workspace" element={<div>Workspace page</div>} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+async function waitForSettings() {
+  await screen.findByRole("heading", { name: "Step 4: Settings" });
+}
+
+describe("WizardStep4 retrospective opt-in", () => {
+  beforeEach(() => {
+    document.body.style.pointerEvents = "auto";
+    sessionStorage.clear();
+    savedDraft = null;
+    saveDraftCalls.length = 0;
+    mockGet.mockClear();
+    mockPreview.mockClear();
+    mockSaveDraft.mockClear();
+    mockSaveGoal.mockClear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    sessionStorage.clear();
+  });
+
+  it("renders the retrospective switch off by default with accessible copy", async () => {
+    renderStep4();
+
+    await waitForSettings();
+
+    const retrospectiveSwitch = screen.getByRole("switch", {
+      name: "Run a retrospective after completion",
+    });
+
+    expect(retrospectiveSwitch.getAttribute("aria-checked")).toBe("false");
+    expect(screen.getByText("Capture lessons and factory improvements after the build finishes. Optional and off by default.")).not.toBeNull();
+  });
+
+  it("persists the retrospective switch in session storage across remounts", async () => {
+    const firstRender = renderStep4();
+    await waitForSettings();
+
+    await userEvent.click(screen.getByRole("switch", { name: "Run a retrospective after completion" }));
+
+    await waitFor(() => {
+      expect(JSON.parse(sessionStorage.getItem("compose-wizard-step-4") ?? "{}")).toMatchObject({
+        retrospective: true,
+      });
+    });
+
+    firstRender.unmount();
+    renderStep4();
+    await waitForSettings();
+
+    expect(screen.getByRole("switch", { name: "Run a retrospective after completion" }).getAttribute("aria-checked")).toBe("true");
+  });
+
+  it("refreshes preview and draft payload from the retrospective switch state", async () => {
+    renderStep4();
+    await waitForSettings();
+
+    const previewPanel = screen.getByText("GOAL.md Preview").closest("div")?.parentElement;
+    expect(previewPanel).not.toBeNull();
+    expect(within(previewPanel as HTMLElement).queryByText(/retrospective: true/)).toBeNull();
+
+    await userEvent.click(screen.getByRole("switch", { name: "Run a retrospective after completion" }));
+
+    await waitFor(() => {
+      const latestDraft = saveDraftCalls.at(-1);
+      expect(latestDraft?.state.retrospective).toBe(true);
+      expect(latestDraft?.wizard.retrospective).toBe(true);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/retrospective: true/)).not.toBeNull();
+    });
+
+    await userEvent.click(screen.getByRole("switch", { name: "Run a retrospective after completion" }));
+
+    await waitFor(() => {
+      const latestDraft = saveDraftCalls.at(-1);
+      expect(latestDraft?.state.retrospective).toBe(false);
+      expect(latestDraft?.wizard.retrospective).toBe(false);
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText(/retrospective: true/)).toBeNull();
+    });
+  });
+
+  it("keeps hook ordering stable when workspace query param appears after the missing workspace state", async () => {
+    renderStep4WithRouteToggle();
+
+    expect(screen.getByText("Workspace required")).not.toBeNull();
+
+    await userEvent.click(screen.getByRole("link", { name: "Open workspace settings" }));
+
+    await waitForSettings();
+    expect(screen.getByRole("switch", { name: "Run a retrospective after completion" })).not.toBeNull();
+  });
+
+  it.each([
+    ["WizardStep1", "/compose/step/1", <WizardStep1 key="wizard-step-1" />, "Step 1: Project Description"],
+    ["WizardStep2", "/compose/step/2", <WizardStep2 key="wizard-step-2" />, "Step 2: Tech Stack"],
+    ["WizardStep3", "/compose/step/3", <WizardStep3 key="wizard-step-3" />, "Step 3: Safety Analysis"],
+    ["WizardStep4", "/compose/step/4", <WizardStep4 key="wizard-step-4" />, "Step 4: Settings"],
+    ["WizardFinish", "/compose/finish", <WizardFinish key="wizard-finish" />, "Review & Save"],
+  ])("keeps %s hook ordering stable after workspace query param appears", async (_name, path, element, heading) => {
+    const consoleError = spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      renderWizardPageWithRouteToggle(path, element, `Open ${_name}`);
+
+      expect(screen.getByText("Workspace required")).not.toBeNull();
+
+      await userEvent.click(screen.getByRole("link", { name: `Open ${_name}` }));
+
+      await screen.findByRole("heading", { name: heading });
+
+      const hookOrderMessages: string[] = [];
+      for (const call of consoleError.mock.calls) {
+        for (const value of call) {
+          const message = String(value);
+          if (hookOrderErrorPattern.test(message)) {
+            hookOrderMessages.push(message);
+          }
+        }
+      }
+      expect(hookOrderMessages).toEqual([]);
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  it("saves the final GOAL.md with the current retrospective opt-in state", async () => {
+    savedDraft = {
+      state: {
+        description: "Build the thing",
+        completionGate: "make test",
+        retrospective: true,
+        agents: [],
+        flow: "",
+        tasks: "",
+      },
+      wizard: {
+        currentStep: 4,
+        description: "Build the thing",
+        techStack: [],
+        safetyAnalysis: false,
+        completionGate: "make test",
+        retrospective: true,
+      },
+    };
+
+    renderFinish();
+
+    await screen.findByRole("heading", { name: "Review & Save" });
+    expect(screen.getByText("Enabled")).not.toBeNull();
+
+    await userEvent.click(screen.getByRole("button", { name: "Save GOAL.md" }));
+
+    await waitFor(() => {
+      expect(mockSaveGoal).toHaveBeenCalledWith("demo", "etag-1");
+    });
+    const latestDraft = saveDraftCalls.at(-1);
+    expect(latestDraft?.state.retrospective).toBe(true);
+    expect(latestDraft?.wizard.retrospective).toBe(true);
+  });
+});

--- a/cmd/sgai/webapp/src/types/index.ts
+++ b/cmd/sgai/webapp/src/types/index.ts
@@ -320,6 +320,7 @@ export interface ApiComposerAgentConf {
 export interface ApiComposerState {
   description: string;
   completionGate: string;
+  retrospective: boolean;
   agents: ApiComposerAgentConf[];
   flow: string;
   tasks: string;
@@ -332,6 +333,7 @@ export interface ApiWizardState {
   techStack: string[];
   safetyAnalysis: boolean;
   completionGate?: string;
+  retrospective: boolean;
 }
 
 export interface ApiTechStackItem {

--- a/cmd/sgai/workflow_runner.go
+++ b/cmd/sgai/workflow_runner.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -274,8 +275,11 @@ func buildWorkflowRunner(dir string, mcpURL string, logWriter io.Writer, session
 		log.Fatalln("failed to parse flow:", errFlow)
 	}
 
-	if retrospectiveEnabled(metadata) {
+	retrospectiveOn := retrospectiveEnabled(metadata)
+	if retrospectiveOn {
 		flowDag.injectRetrospectiveEdge()
+	} else {
+		flowDag.removeRetrospective()
 	}
 
 	ensureImplicitRetrospectiveModel(flowDag, &metadata)
@@ -289,7 +293,7 @@ func buildWorkflowRunner(dir string, mcpURL string, logWriter io.Writer, session
 	if coord == nil {
 		var errCoord error
 		coord, errCoord = state.NewCoordinator(stateJSONPath)
-		if errCoord != nil && !os.IsNotExist(errCoord) {
+		if errCoord != nil && !errors.Is(errCoord, os.ErrNotExist) {
 			log.Fatalln("failed to read state.json:", errCoord)
 		}
 		if errCoord != nil {
@@ -315,7 +319,10 @@ func buildWorkflowRunner(dir string, mcpURL string, logWriter io.Writer, session
 
 	resuming := canResumeWorkflow(wfState, newChecksum)
 
-	retroDir := resolveRetrospectiveDir(resuming, dir, retrospectivesBaseDir, pmPath, stateJSONPath, goalPath)
+	retroDir := ""
+	if retrospectiveOn {
+		retroDir = resolveRetrospectiveDir(resuming, dir, retrospectivesBaseDir, pmPath, stateJSONPath, goalPath)
+	}
 
 	retroStdoutLog, retroStderrLog, errRetroLogs := openRetrospectiveLogs(retroDir)
 	if errRetroLogs != nil {
@@ -323,11 +330,15 @@ func buildWorkflowRunner(dir string, mcpURL string, logWriter io.Writer, session
 	}
 
 	cleanup := func() {
-		if errClose := retroStdoutLog.Close(); errClose != nil {
-			log.Println("failed to close stdout log:", errClose)
+		if retroStdoutLog != nil {
+			if errClose := retroStdoutLog.Close(); errClose != nil {
+				log.Println("failed to close stdout log:", errClose)
+			}
 		}
-		if errClose := retroStderrLog.Close(); errClose != nil {
-			log.Println("failed to close stderr log:", errClose)
+		if retroStderrLog != nil {
+			if errClose := retroStderrLog.Close(); errClose != nil {
+				log.Println("failed to close stderr log:", errClose)
+			}
 		}
 		if retroDir != "" {
 			if errCopy := copyFinalStateToRetrospective(dir, retroDir); errCopy != nil {
@@ -355,6 +366,20 @@ func buildWorkflowRunner(dir string, mcpURL string, logWriter io.Writer, session
 		wfState = coord.State()
 	}
 
+	if !retrospectiveOn {
+		sanitizedState, changed := sanitizeDisabledRetrospectiveState(wfState)
+		if changed {
+			if errUpdate := coord.UpdateState(func(wf *state.Workflow) {
+				*wf = sanitizedState
+			}); errUpdate != nil {
+				log.Println("failed to sanitize disabled retrospective state:", errUpdate)
+				cleanup()
+				return nil, func() {}, false
+			}
+			wfState = coord.State()
+		}
+	}
+
 	retroLogs := retroLogWriters{stdout: retroStdoutLog, stderr: retroStderrLog}
 	runner := &workflowRunner{
 		dir:            dir,
@@ -371,6 +396,47 @@ func buildWorkflowRunner(dir string, mcpURL string, logWriter io.Writer, session
 		retroLogs:      retroLogs,
 	}
 	return runner, cleanup, true
+}
+
+func sanitizeDisabledRetrospectiveState(wfState state.Workflow) (state.Workflow, bool) {
+	changed := false
+	if wfState.CurrentAgent == "retrospective" {
+		wfState.CurrentAgent = "coordinator"
+		changed = true
+	}
+	if wfState.InteractionMode == state.ModeRetrospective {
+		wfState.InteractionMode = state.ModeBuilding
+		changed = true
+	}
+	if _, exists := wfState.VisitCounts["retrospective"]; exists {
+		delete(wfState.VisitCounts, "retrospective")
+		changed = true
+	}
+	if extractAgentFromModelID(wfState.CurrentModel) == "retrospective" {
+		wfState.CurrentModel = ""
+		changed = true
+	}
+	for modelID := range wfState.ModelStatuses {
+		if extractAgentFromModelID(modelID) == "retrospective" {
+			delete(wfState.ModelStatuses, modelID)
+			changed = true
+		}
+	}
+	messages := slices.DeleteFunc(wfState.Messages, func(msg state.Message) bool {
+		return !msg.Read && (extractAgentFromModelID(msg.ToAgent) == "retrospective" || extractAgentFromModelID(msg.FromAgent) == "retrospective")
+	})
+	if len(messages) != len(wfState.Messages) {
+		wfState.Messages = messages
+		changed = true
+	}
+	agentSequence := slices.DeleteFunc(wfState.AgentSequence, func(entry state.AgentSequenceEntry) bool {
+		return entry.Agent == "retrospective"
+	})
+	if len(agentSequence) != len(wfState.AgentSequence) {
+		wfState.AgentSequence = agentSequence
+		changed = true
+	}
+	return wfState, changed
 }
 
 func buildAllAgents(dagAgents []string) []string {

--- a/cmd/sgai/workflow_runner_test.go
+++ b/cmd/sgai/workflow_runner_test.go
@@ -265,6 +265,179 @@ func TestResolveRetrospectiveDirNewSession(t *testing.T) {
 	assert.True(t, os.IsNotExist(errStatState))
 }
 
+func TestBuildWorkflowRunnerDefaultRetrospectiveDisabledCreatesNoArtifacts(t *testing.T) {
+	dir := t.TempDir()
+	goalContent := `---
+flow: |
+  "worker"
+models: {}
+---
+# Test Goal
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "GOAL.md"), []byte(goalContent), 0o644))
+
+	runner, cleanup, ok := buildWorkflowRunner(dir, "", nil, nil)
+	require.True(t, ok)
+	defer cleanup()
+
+	assert.Empty(t, runner.retroDir)
+	assert.NotContains(t, runner.flowDag.Nodes, "retrospective")
+	assert.Nil(t, runner.retroLogs.stdout)
+	assert.Nil(t, runner.retroLogs.stderr)
+	assert.NoDirExists(t, filepath.Join(dir, ".sgai", "retrospectives"))
+	assert.NoFileExists(t, filepath.Join(dir, ".sgai", "PROJECT_MANAGEMENT.md"))
+}
+
+func TestBuildWorkflowRunnerDisabledRetrospectivePrunesExplicitFlowNode(t *testing.T) {
+	dir := t.TempDir()
+	goalContent := `---
+flow: |
+  "worker" -> "retrospective"
+models: {}
+---
+# Test Goal
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "GOAL.md"), []byte(goalContent), 0o644))
+
+	runner, cleanup, ok := buildWorkflowRunner(dir, "", nil, nil)
+	require.True(t, ok)
+	defer cleanup()
+
+	assert.Empty(t, runner.retroDir)
+	assert.NotContains(t, runner.flowDag.Nodes, "retrospective")
+	assert.NotContains(t, runner.flowDag.getSuccessors("worker"), "retrospective")
+	assert.NotContains(t, runner.flowDag.getSuccessors("coordinator"), "retrospective")
+	assert.NoDirExists(t, filepath.Join(dir, ".sgai", "retrospectives"))
+}
+
+func TestBuildWorkflowRunnerRetrospectiveEnabledCreatesArtifacts(t *testing.T) {
+	dir := t.TempDir()
+	goalContent := `---
+retrospective: true
+flow: |
+  "worker"
+models: {}
+---
+# Test Goal
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "GOAL.md"), []byte(goalContent), 0o644))
+
+	runner, cleanup, ok := buildWorkflowRunner(dir, "", nil, nil)
+	require.True(t, ok)
+	defer cleanup()
+
+	assert.NotEmpty(t, runner.retroDir)
+	assert.Contains(t, runner.flowDag.Nodes, "retrospective")
+	assert.NotNil(t, runner.retroLogs.stdout)
+	assert.NotNil(t, runner.retroLogs.stderr)
+	assert.DirExists(t, runner.retroDir)
+	assert.FileExists(t, filepath.Join(runner.retroDir, "GOAL.md"))
+}
+
+func TestBuildWorkflowRunnerIgnoresLegacyDisableRetrospectiveConfig(t *testing.T) {
+	dir := t.TempDir()
+	goalContent := `---
+retrospective: true
+flow: |
+  "worker"
+models: {}
+---
+# Test Goal
+`
+	requiredFiles := map[string]string{
+		"GOAL.md":   goalContent,
+		"sgai.json": `{"disable_retrospective": true}`,
+	}
+	for name, content := range requiredFiles {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644))
+	}
+
+	runner, cleanup, ok := buildWorkflowRunner(dir, "", nil, nil)
+	require.True(t, ok)
+	defer cleanup()
+
+	assert.NotEmpty(t, runner.retroDir)
+	assert.Contains(t, runner.flowDag.Nodes, "retrospective")
+	assert.DirExists(t, runner.retroDir)
+}
+
+func TestBuildWorkflowRunnerDisabledRetrospectiveSanitizesResumedState(t *testing.T) {
+	dir := t.TempDir()
+	goalContent := `---
+retrospective: false
+flow: |
+  "worker" -> "retrospective"
+models: {}
+---
+# Test Goal
+`
+	goalPath := filepath.Join(dir, "GOAL.md")
+	require.NoError(t, os.WriteFile(goalPath, []byte(goalContent), 0o644))
+
+	checksum, errChecksum := computeGoalChecksum(goalPath)
+	require.NoError(t, errChecksum)
+
+	statePath := filepath.Join(dir, ".sgai", "state.json")
+	_, errCoord := state.NewCoordinatorWith(statePath, state.Workflow{
+		Status:          state.StatusWorking,
+		GoalChecksum:    checksum,
+		CurrentAgent:    "retrospective",
+		InteractionMode: state.ModeRetrospective,
+		VisitCounts:     map[string]int{"coordinator": 1, "retrospective": 1},
+		CurrentModel:    "retrospective:openai/gpt-5.5",
+		ModelStatuses: map[string]string{
+			"retrospective:openai/gpt-5.5": "model-working",
+			"coordinator:openai/gpt-5.5":   "model-done",
+		},
+		Messages: []state.Message{
+			{ID: 1, FromAgent: "coordinator", ToAgent: "retrospective", Body: "run retrospective", Read: false},
+			{ID: 2, FromAgent: "retrospective", ToAgent: "worker", Body: "stale outgoing", Read: false},
+			{ID: 3, FromAgent: "worker", ToAgent: "worker", Body: "keep me", Read: false},
+		},
+	})
+	require.NoError(t, errCoord)
+
+	runner, cleanup, ok := buildWorkflowRunner(dir, "", nil, nil)
+	require.True(t, ok)
+	defer cleanup()
+
+	assert.Empty(t, runner.retroDir)
+	assert.NotContains(t, runner.flowDag.Nodes, "retrospective")
+	assert.NotEqual(t, "retrospective", runner.wfState.CurrentAgent)
+	assert.NotEqual(t, state.ModeRetrospective, runner.wfState.InteractionMode)
+	assert.NotContains(t, runner.wfState.VisitCounts, "retrospective")
+	assert.Empty(t, runner.wfState.CurrentModel)
+	assert.NotContains(t, runner.wfState.ModelStatuses, "retrospective:openai/gpt-5.5")
+	assertNoUnreadRetrospectiveMessages(t, runner.wfState.Messages)
+	assert.Equal(t, []state.Message{{ID: 3, FromAgent: "worker", ToAgent: "worker", Body: "keep me", Read: false}}, runner.wfState.Messages)
+	assert.Equal(t, "worker", findFirstPendingMessageAgent(runner.wfState))
+	assert.NoDirExists(t, filepath.Join(dir, ".sgai", "retrospectives"))
+	assert.NoFileExists(t, filepath.Join(dir, ".sgai", "PROJECT_MANAGEMENT.md"))
+
+	persistedCoord, errPersisted := state.NewCoordinator(statePath)
+	require.NoError(t, errPersisted)
+	persisted := persistedCoord.State()
+	assert.NotEqual(t, "retrospective", persisted.CurrentAgent)
+	assert.NotEqual(t, state.ModeRetrospective, persisted.InteractionMode)
+	assert.NotContains(t, persisted.VisitCounts, "retrospective")
+	assert.Empty(t, persisted.CurrentModel)
+	assert.NotContains(t, persisted.ModelStatuses, "retrospective:openai/gpt-5.5")
+	assertNoUnreadRetrospectiveMessages(t, persisted.Messages)
+	assert.Equal(t, []state.Message{{ID: 3, FromAgent: "worker", ToAgent: "worker", Body: "keep me", Read: false}}, persisted.Messages)
+	assert.Equal(t, "worker", findFirstPendingMessageAgent(persisted))
+}
+
+func assertNoUnreadRetrospectiveMessages(t *testing.T, messages []state.Message) {
+	t.Helper()
+	for _, msg := range messages {
+		if msg.Read {
+			continue
+		}
+		assert.NotEqual(t, "retrospective", extractAgentFromModelID(msg.FromAgent), "message ID %d FromAgent", msg.ID)
+		assert.NotEqual(t, "retrospective", extractAgentFromModelID(msg.ToAgent), "message ID %d ToAgent", msg.ID)
+	}
+}
+
 func TestHandleWorkingLoop(t *testing.T) {
 	cfg := multiModelConfig{paddedsgai: "test", agent: "builder"}
 	sessionID := "session-123"

--- a/docs/reference/project-configuration.md
+++ b/docs/reference/project-configuration.md
@@ -27,12 +27,6 @@ Notes:
 
 - `defaultModel` is validated using the base model name. If the value includes a variant in parentheses (for example, `provider/model (variant)`), only the base model is validated.
 
-### `disable_retrospective`
-
-Type: boolean
-
-If `true`, `sgai` does not create or resume a retrospective directory for the workflow run.
-
 ### `editor`
 
 Type: string


### PR DESCRIPTION
This change makes workflow retrospectives opt-in instead of enabled by default.

It adds a compose wizard switch that persists the retrospective choice through draft, preview, and save flows; only creates retrospective workflow artifacts when the GOAL frontmatter explicitly enables retrospectives; and removes the retired disable_retrospective configuration documentation.