### PR TITLE
cmd/sgai: fix opencode export step-finish parsing

### DIFF
--- a/cmd/sgai/adhoc_usage_test.go
+++ b/cmd/sgai/adhoc_usage_test.go
@@ -79,7 +79,7 @@ func TestReconcileAdhocUsageWritesGlobalUsageForOriginWorkspace(t *testing.T) {
 	exportSessionBytes = func(dir, sessionID string) ([]byte, error) {
 		assert.Equal(t, workspacePath, dir)
 		assert.Equal(t, "adhoc-full-chain-session", sessionID)
-		return []byte(fmt.Sprintf(`{"type":"step_finish","sessionID":"adhoc-full-chain-session","timestamp":%d,"model":"openai/gpt-5.5","part":{"cost":0.042,"tokens":{"input":1000,"output":200,"reasoning":50,"cache":{"read":20,"write":10}}}}`, timestamp.UnixMilli())), nil
+		return []byte(fmt.Sprintf(`{"type":"step-finish","sessionID":"adhoc-full-chain-session","timestamp":%d,"model":"openai/gpt-5.5","cost":0.042,"tokens":{"input":1000,"output":200,"reasoning":50,"cache":{"read":20,"write":10}}}`, timestamp.UnixMilli())), nil
 	}
 	fetchModelsDevCatalog = func() ([]byte, error) {
 		return nil, errors.New("pricing unavailable in test")
@@ -133,7 +133,7 @@ func TestReconcileAdhocUsageAttributesForkWorkspaceToRootWorkspace(t *testing.T)
 	exportSessionBytes = func(dir, sessionID string) ([]byte, error) {
 		assert.Equal(t, forkWorkspacePath, dir)
 		assert.Equal(t, "adhoc-fork-session", sessionID)
-		return []byte(fmt.Sprintf(`{"type":"step_finish","sessionID":"adhoc-fork-session","timestamp":%d,"model":"openai/gpt-5.5","part":{"cost":0.084,"tokens":{"input":2000,"output":400}}}`, timestamp.UnixMilli())), nil
+		return []byte(fmt.Sprintf(`{"type":"step-finish","sessionID":"adhoc-fork-session","timestamp":%d,"model":"openai/gpt-5.5","cost":0.084,"tokens":{"input":2000,"output":400}}`, timestamp.UnixMilli())), nil
 	}
 	fetchModelsDevCatalog = func() ([]byte, error) {
 		return nil, errors.New("pricing unavailable in test")

--- a/cmd/sgai/metering.go
+++ b/cmd/sgai/metering.go
@@ -231,25 +231,30 @@ func collectExportedSteps(value any, defaultSessionID, fallbackModel string, ste
 			collectExportedSteps(item, defaultSessionID, fallbackModel, steps)
 		}
 	case map[string]any:
-		if stringValue(typed["type"]) == "step_finish" {
-			data, err := json.Marshal(typed)
-			if err == nil {
-				var event streamEvent
-				if err := json.Unmarshal(data, &event); err == nil {
-					sessionID := event.SessionID
-					if sessionID == "" {
-						sessionID = defaultSessionID
-					}
-					model := event.Model
-					if model == "" {
-						model = event.Part.Model
-					}
-					if model == "" {
-						model = fallbackModel
-					}
-					*steps = append(*steps, exportedStep{SessionID: sessionID, Part: event.Part, Timestamp: event.Timestamp, Model: model})
+		partType := stringValue(typed["type"])
+		if partType == "step-finish" {
+			sessionID := stringValue(typed["sessionID"])
+			if sessionID == "" {
+				sessionID = defaultSessionID
+			}
+			stepPart := part{
+				Cost: float64Value(typed["cost"]),
+			}
+			if tokens, ok := typed["tokens"].(map[string]any); ok {
+				stepPart.Tokens.Input = intValue(tokens["input"])
+				stepPart.Tokens.Output = intValue(tokens["output"])
+				stepPart.Tokens.Reasoning = intValue(tokens["reasoning"])
+				if cache, ok := tokens["cache"].(map[string]any); ok {
+					stepPart.Tokens.Cache.Read = intValue(cache["read"])
+					stepPart.Tokens.Cache.Write = intValue(cache["write"])
 				}
 			}
+			timestamp := int64Value(typed["timestamp"])
+			model := stringValue(typed["model"])
+			if model == "" {
+				model = fallbackModel
+			}
+			*steps = append(*steps, exportedStep{SessionID: sessionID, Part: stepPart, Timestamp: timestamp, Model: model})
 		}
 		for _, item := range typed {
 			collectExportedSteps(item, defaultSessionID, fallbackModel, steps)
@@ -600,4 +605,17 @@ func floatField(values map[string]any, key string) (float64, bool) {
 func stringValue(value any) string {
 	text, _ := value.(string)
 	return text
+}
+
+func float64Value(value any) float64 {
+	f, _ := value.(float64)
+	return f
+}
+
+func intValue(value any) int {
+	return int(float64Value(value))
+}
+
+func int64Value(value any) int64 {
+	return int64(float64Value(value))
 }

--- a/cmd/sgai/metering_test.go
+++ b/cmd/sgai/metering_test.go
@@ -37,7 +37,7 @@ fi
 
 func TestParseExportedSessionCollectsStepFinish(t *testing.T) {
 	data := []byte(`[
-		{"type":"step_finish","sessionID":"session-1","timestamp":1700000000000,"part":{"cost":0.02,"model":"openai/gpt-5.5","tokens":{"input":1000,"output":200,"reasoning":50,"cache":{"read":300,"write":20}}}}
+		{"type":"step-finish","sessionID":"session-1","timestamp":1700000000000,"model":"openai/gpt-5.5","cost":0.02,"tokens":{"input":1000,"output":200,"reasoning":50,"cache":{"read":300,"write":20}}}
 	]`)
 
 	steps, children, err := parseExportedSession(data, "session-1", "openai/gpt-5.5")


### PR DESCRIPTION
Fixes a schema mismatch (step_start/finish -> step-start/finish; location of some fields at top level rather than nested in "part" obect). (Existing parse confuses schema of live stream with that of opencode export.)